### PR TITLE
chore(pre-align): align heading structure (11 docs) with ko

### DIFF
--- a/en/api-guide-v1-0.md
+++ b/en/api-guide-v1-0.md
@@ -1,8 +1,14 @@
+<!-- pre-align:aligned sig=f22611a38cd5 -->
+
 ## Cloud Functions API v1.0 Guide
 
 **Compute > Cloud Functions > API Guide > API v1.0 Guide**
 
+<a id="cloud-functions-api-v10-common-information"></a>
+
 ## Cloud Functions API v1.0 Common Information
+
+<a id="api-endpoint"></a>
 
 ### API Endpoint
 
@@ -12,11 +18,15 @@ The endpoints by region for calling the Cloud Functions API are as follows:
 | --- |-----------------------------------------------------|
 | Korea (Pangyo) Region | https://kr1-cloud-functions.api.nhncloudservice.com |
 
+<a id="authentication-and-authorization"></a>
+
 ### Authentication and Authorization
 
 Cloud Functions uses User Access Key tokens for authentication and authorization when making API calls.
 The User Access Key token is a temporary, Bearer-type access token issued from a User Access Key.
 For more information on issuing and using User Access Key tokens, refer to the [User Access Key Token](/nhncloud/en/public-api/user-access-key-token).
+
+<a id="response-common-information"></a>
 
 ### Response Common Information
 
@@ -66,15 +76,21 @@ Every API response follows the common format as below:
 
 ---
 
+<a id="list-environments"></a>
+
 ## List Environments
 
 Retrieves a list of available runtime environments.
+
+<a id="request"></a>
 
 ### Request
 
 ```
 GET /v1.0/env/list
 ```
+
+<a id="request-parameter"></a>
 
 ### Request Parameter
 
@@ -83,9 +99,13 @@ GET /v1.0/env/list
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 
+<a id="request-body"></a>
+
 ### Request Body
 
 This API does not require a request body.
+
+<a id="response"></a>
 
 ### Response
 
@@ -128,15 +148,21 @@ This API does not require a request body.
 
 ---
 
+<a id="list-functions"></a>
+
 ## List Functions
 
 Retrieves a list of functions.
+
+<a id="list-functions-request"></a>
 
 ### Request
 
 ```
 GET /v1.0/functions
 ```
+
+<a id="list-functions-request-parameter"></a>
 
 ### Request Parameter
 
@@ -147,9 +173,13 @@ GET /v1.0/functions
 | page | Query | Integer | N | Current page (default: 0) |
 | pageSize | Query | Integer | N | Number of items to display per page (default: 5,000) |
 
+<a id="list-functions-request-body"></a>
+
 ### Request Body
 
 This API does not require a request body.
+
+<a id="list-functions-response"></a>
 
 ### Response
 
@@ -200,15 +230,21 @@ This API does not require a request body.
 
 ---
 
+<a id="get-function"></a>
+
 ## Get Function
 
 Retrieves detailed information and build logs for a function.
+
+<a id="get-function-request"></a>
 
 ### Request
 
 ```
 GET /v1.0/functions/{functionName}
 ```
+
+<a id="get-function-request-parameter"></a>
 
 ### Request Parameter
 
@@ -218,9 +254,13 @@ GET /v1.0/functions/{functionName}
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name |
 
+<a id="get-function-request-body"></a>
+
 ### Request Body
 
 This API does not require a request body.
+
+<a id="get-function-response"></a>
 
 ### Response
 
@@ -280,6 +320,8 @@ This API does not require a request body.
 
 ---
 
+<a id="create-function"></a>
+
 ## Create Function
 
 Creates a new function. Upload the source file as multipart/form-data.
@@ -287,11 +329,15 @@ The runtime must be entered in the `{environment}-{version}` format (e.g., NodeJ
 
 Required parameters vary depending on the executorType. When using poolManager, requestPerPod is required. When using newDeployment, minInstance and maxInstance are required.
 
+<a id="create-function-request"></a>
+
 ### Request
 
 ```
 POST /v1.0/functions
 ```
+
+<a id="create-function-request-parameter"></a>
 
 ### Request Parameter
 
@@ -299,6 +345,8 @@ POST /v1.0/functions
 | --- | --- | --- | --- | --- |
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
+
+<a id="create-function-request-body"></a>
 
 ### Request Body
 
@@ -318,6 +366,8 @@ Content-Type: multipart/form-data
 | maxInstance | Integer | Conditional | Maximum number of instances (required when using newDeployment, 1–100) |
 | lncsAppkey | String | N | LnCS Appkey |
 | sourceFile | Binary | Y | Source code file (ZIP) |
+
+<a id="create-function-response"></a>
 
 ### Response
 
@@ -339,17 +389,23 @@ Content-Type: multipart/form-data
 
 ---
 
+<a id="modify-function"></a>
+
 ## Modify Function
 
 Modifies a function. The source file can be uploaded as multipart/form-data.
 
 The source file (sourceFile) is optional. If no source file is included, the existing source code is retained.
 
+<a id="modify-function-request"></a>
+
 ### Request
 
 ```
 PUT /v1.0/functions/{functionName}
 ```
+
+<a id="modify-function-request-parameter"></a>
 
 ### Request Parameter
 
@@ -358,6 +414,8 @@ PUT /v1.0/functions/{functionName}
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Name of the function to modify |
+
+<a id="modify-function-request-body"></a>
 
 ### Request Body
 
@@ -376,6 +434,8 @@ Content-Type: multipart/form-data
 | maxInstance | Integer | Conditional | Maximum number of instances (required when using newDeployment, 1–100) |
 | lncsAppkey | String | N | LnCS Appkey |
 | sourceFile | Binary | N | Source code file (ZIP) |
+
+<a id="modify-function-response"></a>
 
 ### Response
 
@@ -397,9 +457,13 @@ Content-Type: multipart/form-data
 
 ---
 
+<a id="delete-functions"></a>
+
 ## Delete Functions
 
 Deletes functions in bulk.
+
+<a id="delete-functions-request"></a>
 
 ### Request
 
@@ -407,12 +471,16 @@ Deletes functions in bulk.
 DELETE /v1.0/functions
 ```
 
+<a id="delete-functions-request-parameter"></a>
+
 ### Request Parameter
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
+
+<a id="delete-functions-request-body"></a>
 
 ### Request Body
 
@@ -430,6 +498,8 @@ DELETE /v1.0/functions
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | names | Array | Y | Function name list to delete |
+
+<a id="delete-functions-response"></a>
 
 ### Response
 
@@ -451,15 +521,21 @@ DELETE /v1.0/functions
 
 ---
 
+<a id="execute-function-get"></a>
+
 ## Execute Function (GET)
 
 Executes a function using the GET method.
+
+<a id="execute-function-get-request"></a>
 
 ### Request
 
 ```
 GET /v1.0/functions/{functionName}/invoke
 ```
+
+<a id="execute-function-get-request-parameter"></a>
 
 ### Request Parameter
 
@@ -469,9 +545,13 @@ GET /v1.0/functions/{functionName}/invoke
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name to execute |
 
+<a id="execute-function-get-request-body"></a>
+
 ### Request Body
 
 This API does not require a request body.
+
+<a id="execute-function-get-response"></a>
 
 ### Response
 
@@ -497,15 +577,21 @@ This API does not require a request body.
 
 ---
 
+<a id="execute-function-post"></a>
+
 ## Execute Function (POST)
 
 Executes a function using the POST method. A request body can be included.
+
+<a id="execute-function-post-request"></a>
 
 ### Request
 
 ```
 POST /v1.0/functions/{functionName}/invoke
 ```
+
+<a id="execute-function-post-request-parameter"></a>
 
 ### Request Parameter
 
@@ -514,6 +600,8 @@ POST /v1.0/functions/{functionName}/invoke
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name to execute |
+
+<a id="execute-function-post-request-body"></a>
 
 ### Request Body
 
@@ -531,6 +619,8 @@ POST /v1.0/functions/{functionName}/invoke
 | Name | Type | Required | Description |
 | --- |------| --- | --- |
 | body | JSON | N | Body to send to the function |
+
+<a id="execute-function-post-response"></a>
 
 ### Response
 
@@ -556,15 +646,21 @@ POST /v1.0/functions/{functionName}/invoke
 
 ---
 
+<a id="list-versions"></a>
+
 ## List Versions
 
 Retrieves a list of versions (packages) for a function.
+
+<a id="list-versions-request"></a>
 
 ### Request
 
 ```
 GET /v1.0/functions/{functionName}/versions
 ```
+
+<a id="list-versions-request-parameter"></a>
 
 ### Request Parameter
 
@@ -574,9 +670,13 @@ GET /v1.0/functions/{functionName}/versions
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name |
 
+<a id="list-versions-request-body"></a>
+
 ### Request Body
 
 This API does not require a request body.
+
+<a id="list-versions-response"></a>
 
 ### Response
 
@@ -625,15 +725,21 @@ This API does not require a request body.
 
 ---
 
+<a id="switch-version"></a>
+
 ## Switch Version
 
 Changes the currently active version of a function.
+
+<a id="switch-version-request"></a>
 
 ### Request
 
 ```
 PUT /v1.0/functions/{functionName}/versions
 ```
+
+<a id="switch-version-request-parameter"></a>
 
 ### Request Parameter
 
@@ -642,6 +748,8 @@ PUT /v1.0/functions/{functionName}/versions
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name |
+
+<a id="switch-version-request-body"></a>
 
 ### Request Body
 
@@ -660,6 +768,8 @@ PUT /v1.0/functions/{functionName}/versions
 | --- | --- | --- | --- |
 | versionId | Integer | Y | Version ID to convert |
 
+<a id="switch-version-response"></a>
+
 ### Response
 
 <details>
@@ -680,17 +790,23 @@ PUT /v1.0/functions/{functionName}/versions
 
 ---
 
+<a id="delete-versions"></a>
+
 ## Delete Versions
 
 Deletes versions of a function in bulk.
 
 The currently active version cannot be deleted.
 
+<a id="delete-versions-request"></a>
+
 ### Request
 
 ```
 DELETE /v1.0/functions/{functionName}/versions
 ```
+
+<a id="delete-versions-request-parameter"></a>
 
 ### Request Parameter
 
@@ -699,6 +815,8 @@ DELETE /v1.0/functions/{functionName}/versions
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name |
+
+<a id="delete-versions-request-body"></a>
 
 ### Request Body
 
@@ -717,6 +835,8 @@ DELETE /v1.0/functions/{functionName}/versions
 | --- | --- | --- | --- |
 | versionIds | Array | Y | Version ID list to delete |
 
+<a id="delete-versions-response"></a>
+
 ### Response
 
 <details>
@@ -737,15 +857,21 @@ DELETE /v1.0/functions/{functionName}/versions
 
 ---
 
+<a id="list-triggers"></a>
+
 ## List Triggers
 
 Retrieves a list of triggers for a function.
+
+<a id="list-triggers-request"></a>
 
 ### Request
 
 ```
 GET /v1.0/triggers/{functionName}
 ```
+
+<a id="list-triggers-request-parameter"></a>
 
 ### Request Parameter
 
@@ -755,9 +881,13 @@ GET /v1.0/triggers/{functionName}
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name |
 
+<a id="list-triggers-request-body"></a>
+
 ### Request Body
 
 This API does not require a request body.
+
+<a id="list-triggers-response"></a>
 
 ### Response
 
@@ -800,15 +930,21 @@ This API does not require a request body.
 
 ---
 
+<a id="create-time-trigger"></a>
+
 ## Create Time Trigger
 
 Creates a time trigger for a function.
+
+<a id="create-time-trigger-request"></a>
 
 ### Request
 
 ```
 POST /v1.0/triggers/{functionName}/time
 ```
+
+<a id="create-time-trigger-request-parameter"></a>
 
 ### Request Parameter
 
@@ -817,6 +953,8 @@ POST /v1.0/triggers/{functionName}/time
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name |
+
+<a id="create-time-trigger-request-body"></a>
 
 ### Request Body
 
@@ -834,6 +972,8 @@ POST /v1.0/triggers/{functionName}/time
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | cron | String | Y | cron expression |
+
+<a id="create-time-trigger-response"></a>
 
 ### Response
 
@@ -855,15 +995,21 @@ POST /v1.0/triggers/{functionName}/time
 
 ---
 
+<a id="modify-time-trigger"></a>
+
 ## Modify Time Trigger
 
 Modifies the cron expression of a time trigger.
+
+<a id="modify-time-trigger-request"></a>
 
 ### Request
 
 ```
 PUT /v1.0/triggers/{functionName}/time
 ```
+
+<a id="modify-time-trigger-request-parameter"></a>
 
 ### Request Parameter
 
@@ -872,6 +1018,8 @@ PUT /v1.0/triggers/{functionName}/time
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name |
+
+<a id="modify-time-trigger-request-body"></a>
 
 ### Request Body
 
@@ -891,6 +1039,8 @@ PUT /v1.0/triggers/{functionName}/time
 | --- | --- | --- | --- |
 | name | String | Y | Trigger name |
 | cron | String | Y | cron expression |
+
+<a id="modify-time-trigger-response"></a>
 
 ### Response
 
@@ -912,15 +1062,21 @@ PUT /v1.0/triggers/{functionName}/time
 
 ---
 
+<a id="delete-time-triggers"></a>
+
 ## Delete Time Triggers
 
 Deletes time triggers in bulk.
+
+<a id="delete-time-triggers-request"></a>
 
 ### Request
 
 ```
 DELETE /v1.0/triggers/{functionName}/time
 ```
+
+<a id="delete-time-triggers-request-parameter"></a>
 
 ### Request Parameter
 
@@ -929,6 +1085,8 @@ DELETE /v1.0/triggers/{functionName}/time
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name |
+
+<a id="delete-time-triggers-request-body"></a>
 
 ### Request Body
 
@@ -946,6 +1104,8 @@ DELETE /v1.0/triggers/{functionName}/time
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | names | Array | Y | List of trigger names to delete |
+
+<a id="delete-time-triggers-response"></a>
 
 ### Response
 

--- a/en/code-template-dotnet-guide.md
+++ b/en/code-template-dotnet-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=3c324618eb1e -->
+
 ## Compute > Cloud Functions > Code Template Guide > .NET
 
 This document details how to develop functions by using .NET from NHN Cloud's Cloud Functions service.
+
+<a id="template-information"></a>
 
 ## Template information
 | Item              | Value                  |
@@ -9,7 +13,11 @@ This document details how to develop functions by using .NET from NHN Cloud's Cl
 | **File name**         | func.cs |
 | **Entry point** | func             |
 
+<a id="basic-template"></a>
+
 ## Basic template
+
+<a id="hello-world-example"></a>
 
 ### Hello World example
 A basic form of function. Use `NhnContext` of `Nhn.DotNetCore.Api` namespace to access the logger and request information.
@@ -49,6 +57,8 @@ public class NhnFunction
     }
 }
 ```
+
+<a id="context-object"></a>
 
 ### Context object
 With the `NhnContext` object, you can access the logger, request, and response.
@@ -95,12 +105,18 @@ public class NhnFunction
 }
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## Download and use template file
+
+<a id="template-download"></a>
 
 ### Template download
 You can download the .NET template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [dotnet.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/dotnet/dotnet.zip)
+
+<a id="template-file-structure"></a>
 
 ### Template file structure
 The structure of the downloaded template file is as follows:
@@ -112,7 +128,11 @@ dotnet.zip
 └── nuget.txt     # Dependency management file
 ```
 
+<a id="local-development-process"></a>
+
 ### Local development process
+
+<a id="unzip"></a>
 
 #### 1. Unzip
 ```bash
@@ -122,6 +142,8 @@ unzip dotnet.zip -d my-function
 # Move to task directory
 cd my-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. Modify function codes
 Modify `func.cs` file with the logic you want.
@@ -178,6 +200,8 @@ public class NhnFunction
 }
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file. You must compress it so that `func.cs` and `nuget.txt` are included at the top level.
 
@@ -185,11 +209,17 @@ Compress the modified source code into ZIP file. You must compress it so that `f
 zip my-function.zip func.cs nuget.txt
 ```
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Upload from Cloud Functions console
 - When creating or modifying a function, select the **User Local Environment** method.
 - Click **Select File** to upload the `my-function.zip` file you created.
 
+<a id="process-by-http-method"></a>
+
 ## Process by HTTP method
+
+<a id="process-get-request"></a>
 
 ### Process GET request
 ```csharp
@@ -219,6 +249,8 @@ public class NhnFunction
     }
 }
 ```
+
+<a id="process-post-request"></a>
 
 ### Process POST request
 ```csharp
@@ -272,6 +304,8 @@ public class NhnFunction
 }
 ```
 
+<a id="manage-package-nugettxt"></a>
+
 ## Manage package (`nuget.txt`)
 
 Use the `nuget.txt` file to manage dependencies (NuGet packages). Write the required packages one per line.
@@ -280,6 +314,8 @@ Use the `nuget.txt` file to manage dependencies (NuGet packages). Write the requ
 # nuget.txt
 Microsoft.Extensions.Configuration:8.0.0
 ```
+
+<a id="example-of-configuration-management"></a>
 
 ### Example of configuration management
 ```csharp
@@ -362,6 +398,8 @@ public class NhnFunction
 }
 ```
 
+<a id="configure-entry-point"></a>
+
 ## Configure Entry Point
 
 Entry Point is **file name**. (excluding extention)
@@ -370,6 +408,8 @@ Entry Point is **file name**. (excluding extention)
 - Entry Point: `func`
 
 **Important**: The class name must be `NhnFunction`, and the method acting as a function must have the signature `public string Execute(NhnContext context)`.
+
+<a id="caution"></a>
 
 ### Caution
 - **Package version**: You can specify the package version in `nuget.txt`. (example: `Newtonsoft.Json:9.0.1`)

--- a/en/code-template-go-guide.md
+++ b/en/code-template-go-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=9b45d499c0b7 -->
+
 ## Compute > Cloud Functions > Code Template Guide > Go
 
 This document details how to develop functions by using Go from NHN Cloud's Cloud Functions service.
+
+<a id="template-information"></a>
 
 ## Template information
 | Item              | Value                                        |
@@ -9,7 +13,11 @@ This document details how to develop functions by using Go from NHN Cloud's Clou
 | **File name**    | functions.go                               |
 | **Entry Point** | Handler                                  |
 
+<a id="basic-template"></a>
+
 ## Basic template
+
+<a id="hello-world-example"></a>
 
 ### Hello World example
 A basic form of function.
@@ -37,6 +45,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 ```
+
+<a id="context-object"></a>
 
 ### Context object
 In Go functions, HTTP requests and responses are processed via `http.ResponseWriter` and `*http.Request`.
@@ -74,12 +84,18 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## Download and use template file
+
+<a id="template-download"></a>
 
 ### Template download
 You can download the Go template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [go.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/go/go.zip)
+
+<a id="template-file-structure"></a>
 
 ### Template file structure
 The structure of the downloaded template file is as follows:
@@ -89,6 +105,8 @@ go.zip
 ├── functions.go     # Main function file
 └── go.mod          # Dependency management file
 ```
+
+<a id="functionsgo"></a>
 
 #### functions.go
 Include basic fake data generation functions.
@@ -116,6 +134,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+<a id="gomod"></a>
+
 #### go.mod
 ```go
 module example.com/ncf
@@ -125,7 +145,11 @@ go 1.22
 require github.com/brianvoe/gofakeit/v6 v6.28.0
 ```
 
+<a id="local-development-process"></a>
+
 ### Local development process
+
+<a id="unzip"></a>
 
 #### 1. Unzip
 ```bash
@@ -135,6 +159,8 @@ unzip go.zip -d my-function
 # Move to task directory
 cd my-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. Modify function codes
 Modify `functions.go` file with the logic you want.
@@ -185,6 +211,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file.
 
@@ -202,10 +230,16 @@ zip my-function.zip functions.go go.mod
 zip -r my-function.zip . -x "*.git*" "go.sum" "test.go"
 ```
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Upload from Cloud Functions console
 > Used when uploading files from the user's local environment when creating or modifying a function. (refer to Console Guide)
 
+<a id="cautions-for-upload"></a>
+
 ### Cautions for upload
+
+<a id="zip-file-structure"></a>
 
 #### ZIP file structure
 - The `.go` file and `go.mod` must be located directly in the root of the ZIP file.
@@ -227,9 +261,13 @@ my-function.zip
     └── go.mod
 ```
 
+<a id="file-size-limit"></a>
+
 #### File size limit
 - ZIP file size is limited to 100MiB.
 - `go.sum` file should not be included.
+
+<a id="files-to-exclude"></a>
 
 #### Files to exclude
 ```bash
@@ -243,7 +281,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
+<a id="process-by-http-method"></a>
+
 ## Process by HTTP method
+
+<a id="process-get-request"></a>
 
 ### Process GET request
 ```go
@@ -282,6 +324,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(response)
 }
 ```
+
+<a id="process-post-request"></a>
 
 ### Process POST request
 ```go
@@ -354,7 +398,11 @@ func getOrDefault(value, defaultValue string) string {
 }
 ```
 
+<a id="manage-packages"></a>
+
 ## Manage packages
+
+<a id="write-gomod"></a>
 
 ### Write go.mod
 Write `go.mod` to manage dependencies.
@@ -369,6 +417,8 @@ require (
     github.com/gorilla/mux v1.8.1
 )
 ```
+
+<a id="example-of-external-api-call"></a>
 
 ### Example of external API call
 ```go
@@ -422,6 +472,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(response)
 }
 ```
+
+<a id="data-processing-example"></a>
 
 ### Data processing example
 ```go
@@ -516,13 +568,19 @@ func normalizeName(name string) string {
 }
 ```
 
+<a id="configure-entry-point"></a>
+
 ## Configure Entry Point
+
+<a id="single-function"></a>
 
 ### Single function
 Use the function name as the Entry Point.
 
 Function name: `Handler`
 Entry Point: `Handler`
+
+<a id="multiple-functions"></a>
 
 ### Multiple functions
 You can define multiple functions in a single file.
@@ -564,7 +622,11 @@ Entry Point configuration:
 - `CreateUser`
 - `UpdateUser`
 
+<a id="caution"></a>
+
 ## Caution
+
+<a id="go-version"></a>
 
 ### Go version
 | Version | End of Support | End of Service |
@@ -573,6 +635,8 @@ Entry Point configuration:
 | 1.24 | - | - |
 | 1.23 | 2026-02-21 | 2026-08-21 |
 | 1.22 | 2026-01-28 | 2026-07-28 |
+
+<a id="go-version-support-policy"></a>
 
 #### Go Version Support Policy
 Cloud Functions follows Go's official release policy. Go releases new major versions twice a year (January and July), and each version is supported only up to the latest two major versions.

--- a/en/code-template-java-guide.md
+++ b/en/code-template-java-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=65e9891c8f54 -->
+
 ## Compute > Cloud Functions > Code Template Guide > Java
 
 This document details how to develop functions by using Java from NHN Cloud's Cloud Functions service.
+
+<a id="template-information"></a>
 
 ## Template information
 | Item               | Value                  |
@@ -9,7 +13,11 @@ This document details how to develop functions by using Java from NHN Cloud's Cl
 | **File name**          | HelloWorld.java    |
 | **Entry Point** | example.HelloWorld |
 
+<a id="basic-template"></a>
+
 ## Basic template
+
+<a id="hello-world-example"></a>
 
 ### Hello World example
 A basic form of function.
@@ -28,6 +36,8 @@ public class HelloWorld {
 
 }
 ```
+
+<a id="context-object-requestentity"></a>
 
 ### Context object (RequestEntity)
 In a Java function, you can access HTTP request information through `RequestEntity`.
@@ -62,12 +72,18 @@ public class HelloWorld {
 }
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## Download and use template file
+
+<a id="template-download"></a>
 
 ### Template download
 You can download the Java template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [java.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/java/java.zip)
+
+<a id="template-file-structure"></a>
 
 ### Template file structure
 The structure of the downloaded template file is as follows:
@@ -82,7 +98,11 @@ java.zip
                 └── HelloWorld.java
 ```
 
+<a id="local-development-process"></a>
+
 ### Local development process
+
+<a id="unzip"></a>
 
 #### 1. Unzip
 ```bash
@@ -92,6 +112,8 @@ unzip java.zip -d my-java-function
 # Move to task directory
 cd my-java-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. Modify function codes
 Modify `src/main/java/example/HelloWorld.java` file with the logic you want.
@@ -144,6 +166,8 @@ public class HelloWorld {
 }
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file. You must compress it so that `pom.xml` and `src` are included at the top level.
 
@@ -161,9 +185,13 @@ zip -r my-function.zip pom.xml src
 zip -r my-function.zip . -x "*.git*" "target/*" "*.log"
 ```
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Upload from Cloud Functions console
 - When creating or modifying a function, select the **User Local Environment** method.
 - Click **Select File** to upload the `my-function.zip` file you created.
+
+<a id="cautions-for-upload"></a>
 
 ### Cautions for upload
 - **Upload File**: Upload **ZIP file** which includes source code and `pom.xml`.
@@ -171,7 +199,11 @@ zip -r my-function.zip . -x "*.git*" "target/*" "*.log"
 - **File to Exclude**: Do not include unnecessary files such as the `target` directory, `.git` directory, etc.
 - **File Size**: ZIP file size is limited to 100 MiB.
 
+<a id="process-by-http-method"></a>
+
 ## Process by HTTP method
+
+<a id="process-get-request"></a>
 
 ### Process GET request
 ```java
@@ -208,6 +240,8 @@ public class GetHandler {
     }
 }
 ```
+
+<a id="process-post-request"></a>
 
 ### Process POST request
 ```java
@@ -250,6 +284,8 @@ public class PostHandler {
 }
 ```
 
+<a id="manage-package-pomxml"></a>
+
 ## Manage package (`pom.xml`)
 
 Use the `pom.xml` file to manage dependencies. When you add required libraries to the `dependencies` section, Cloud Functions automatically downloads the dependencies and includes them in the build when you upload your function.
@@ -272,6 +308,8 @@ Use the `pom.xml` file to manage dependencies. When you add required libraries t
     </dependency>
 </dependencies>
 ```
+
+<a id="example-of-using-external-libraries"></a>
 
 ### Example of using external libraries
 ```java
@@ -307,7 +345,11 @@ public class StringUtilsHandler {
 }
 ```
 
+<a id="entry-point-configuration"></a>
+
 ## Entry Point configuration
+
+<a id="single-class"></a>
 
 ### Single class
 Use `packagename.classname` as an Entry Point.
@@ -316,6 +358,8 @@ Use `packagename.classname` as an Entry Point.
 - Class name: `HelloWorld`
 - Entry Point: `example.HelloWorld`
 - **Important**: Methods that act as functions must have the signature `public ResponseEntity<?> call(RequestEntity<?> req)`.
+
+<a id="caution"></a>
 
 ### Caution
 - **Project structure**: You must maintain the `src/main/java` directory structure.

--- a/en/code-template-node-guide.md
+++ b/en/code-template-node-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=ce91cd7cb2f1 -->
+
 ## Compute > Cloud Functions > Code Template Guide > Node.js
 
 This document details how to develop functions by using Node.js from NHN Cloud's Cloud Functions service.
+
+<a id="template-information"></a>
 
 ## Template information
 | Item           | Value                  |
@@ -9,7 +13,11 @@ This document details how to develop functions by using Node.js from NHN Cloud's
 | **File name**         | hello.js        |
 | **Entry Point** | hello           |
 
+<a id="basic-template"></a>
+
 ## Basic template
+<a id="hello-world-example"></a>
+
 ### Hello World example
 A basic form of function.
 
@@ -21,6 +29,8 @@ module.exports = async (context) => {
     };
 }
 ```
+
+<a id="context-object"></a>
 
 ### Context object
 'context' object sent to functions include:
@@ -42,12 +52,18 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## Download and use template file
+
+<a id="template-download"></a>
 
 ### Template download
 You can download the Node.js template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [nodejs.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/nodejs/nodejs.zip)
+
+<a id="template-file-structure"></a>
 
 ### Template file structure
 The structure of the downloaded template file is as follows:
@@ -57,6 +73,8 @@ nodejs.zip
 ├── hello.js          # Main function file
 └── package.json      # Dependency management file
 ```
+
+<a id="hellojs"></a>
 
 #### hello.js
 Basic Hello World function is included.
@@ -69,12 +87,18 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="packagejson"></a>
+
 #### package.json
 ```json
 {}
 ```
 
+<a id="local-development-process"></a>
+
 ### Local development process
+
+<a id="unzip"></a>
 
 #### 1. Unzip
 ```bash
@@ -84,6 +108,8 @@ unzip nodejs.zip -d my-function
 # Move to task directory
 cd my-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. Modify function codes
 Modify `hello.js` file with the logic you want.
@@ -127,6 +153,8 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file.
 
@@ -144,10 +172,16 @@ zip my-function.zip hello.js package.json
 zip -r my-function.zip . -x "*.git*" "node_modules/*" "test.js"
 ```
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Upload from Cloud Functions console
 > Used when uploading files from the user's local environment when creating or modifying a function. (refer to Console Guide)
 
+<a id="cautions-for-upload"></a>
+
 ### Cautions for upload
+
+<a id="zip-file-structure"></a>
 
 #### ZIP file structure
 - The `.js` file and `package.json` must be located directly in the root of the ZIP file.
@@ -169,9 +203,13 @@ my-function.zip
     └── package.json
 ```
 
+<a id="file-size-limit"></a>
+
 #### File size limit
 - ZIP file size is limited to 100MiB.
 - `node_modules` file should not be included. (for dependencies, manageed as `package.json`)
+
+<a id="files-to-exclude"></a>
 
 #### Files to exclude
 ```bash
@@ -185,7 +223,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
+<a id="process-by-http-method"></a>
+
 ## Process by HTTP method
+
+<a id="process-get-request"></a>
 
 ### Process GET request
 ```javascript
@@ -212,6 +254,8 @@ module.exports = async (context) => {
     };
 }
 ```
+
+<a id="process-post-request"></a>
 
 ### Process POST request
 ```javascript
@@ -258,7 +302,11 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="manage-packages"></a>
+
 ## Manage packages
+
+<a id="write-packagejson"></a>
 
 ### Write package.json
 Write `package.json` to manage dependencies.
@@ -277,6 +325,8 @@ Write `package.json` to manage dependencies.
   }
 }
 ```
+
+<a id="example-of-external-api-call"></a>
 
 ### Example of external API call
 ```javascript
@@ -327,6 +377,8 @@ module.exports = async (context) => {
     }
 }
 ```
+
+<a id="data-processing-example"></a>
 
 ### Data processing example
 ```javascript
@@ -382,13 +434,19 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="configure-entry-point"></a>
+
 ## Configure Entry Point
+
+<a id="single-function"></a>
 
 ### Single function
 Use the function name as the Entry Point.
 
 File name: `hello.js`
 Entry Point: `hello`
+
+<a id="multiple-functions"></a>
 
 ### Multiple functions
 You can define multiple functions in a single file.
@@ -425,6 +483,8 @@ Entry Point Configuration:
 - `users.createUser`
 - `users.updateUser`
 
+<a id="entry-point-restriction"></a>
+
 ### Entry Point restriction
 - **Subdirectory specification unavailable**: Files in subdirectories of the root directory cannot be specified as Entry Points.
 
@@ -443,7 +503,11 @@ modules/auth.js → modules.auth ❌
 
 All function files must be located at the root level of the ZIP file.
 
+<a id="caution"></a>
+
 ## Caution
+
+<a id="commonjs-vs-es-modules"></a>
 
 ### CommonJS vs ES Modules
 Cloud Functions currently only supports CommonJS method.
@@ -463,6 +527,8 @@ export default async (context) => {  // ❌ Not supported
     // Function logic
 };
 ```
+
+<a id="considerations-for-memory-and-execution-time"></a>
 
 ### Considerations for Memory and execution time
 - Functions must operate within limited memory and execution time.

--- a/en/code-template-python-guide.md
+++ b/en/code-template-python-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=577d9bcb43c9 -->
+
 ## Compute > Cloud Functions > Code Template Guide > Python
 
 This document details how to develop functions by using Python from NHN Cloud's Cloud Functions service.
+
+<a id="template-information"></a>
 
 ## Template information
 | Item              | Value                  |
@@ -9,7 +13,11 @@ This document details how to develop functions by using Python from NHN Cloud's 
 | **File name**         | user.py            |
 | **Entry Point** | user.main        |
 
+<a id="basic-template"></a>
+
 ## Basic template
+
+<a id="hello-world-example"></a>
 
 ### Hello World example
 A basic form of function.
@@ -28,6 +36,8 @@ document = """
 def main():
     return yaml.dump(yaml.safe_load(document))
 ```
+
+<a id="context-object"></a>
 
 ### Context object
 Python functions can access HTTP request information through Flask's request object.
@@ -57,12 +67,18 @@ def main():
     }
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## Download and use template file
+
+<a id="template-download"></a>
 
 ### Template download
 You can download the Python template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [python.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/python/python.zip)
+
+<a id="template-file-structure"></a>
 
 ### Template file structure
 The structure of the downloaded template file is as follows:
@@ -72,6 +88,8 @@ python.zip
 ├── user.py          # Main function file
 └── requirements.txt # Dependency management file
 ```
+
+<a id="userpy"></a>
 
 #### user.py
 Include basic YAML processing functions.
@@ -90,12 +108,18 @@ def main():
     return yaml.dump(yaml.safe_load(document))
 ```
 
+<a id="requirementstxt"></a>
+
 #### requirements.txt
 ```txt
 pyyaml
 ```
 
+<a id="local-development-process"></a>
+
 ### Local development process
+
+<a id="unzip"></a>
 
 #### 1. Unzip
 ```bash
@@ -105,6 +129,8 @@ unzip python.zip -d my-function
 # Move to task directory
 cd my-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. Modify function codes
 Modify `user.py` file with the logic you want.
@@ -147,6 +173,8 @@ def main():
         }, ensure_ascii=False)
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file.
 
@@ -164,10 +192,16 @@ zip my-function.zip user.py requirements.txt
 zip -r my-function.zip . -x "*.git*" "__pycache__/*" "*.pyc" "test.py"
 ```
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Upload from Cloud Functions console
 > Used when uploading files from the user's local environment when creating or modifying a function. (refer to Console Guide)
 
+<a id="cautions-for-upload"></a>
+
 ### Cautions for upload
+
+<a id="zip-file-structure"></a>
 
 #### ZIP file structure
 - The `.py` file and `requirements.txt` must be located directly in the root of the ZIP file.
@@ -189,9 +223,13 @@ my-function.zip
     └── requirements.txt
 ```
 
+<a id="file-size-limit"></a>
+
 #### File size limit
 - ZIP file size is limited to 100MiB.
 - `__pycache__` file should not be included.
+
+<a id="files-to-exclude"></a>
 
 #### Files to exclude
 ```bash
@@ -206,7 +244,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
+<a id="process-by-http-method"></a>
+
 ## Process by HTTP method
+
+<a id="process-get-request"></a>
 
 ### Process GET request
 ```python
@@ -230,6 +272,8 @@ def main():
 
     return json.dumps(result, ensure_ascii=False)
 ```
+
+<a id="process-post-request"></a>
 
 ### Process POST request
 ```python
@@ -274,7 +318,11 @@ def main():
         }, ensure_ascii=False), 400
 ```
 
+<a id="manage-packages"></a>
+
 ## Manage packages
+
+<a id="write-requirementstxt"></a>
 
 ### Write requirements.txt
 Write `requirements.txt` to manage dependencies.
@@ -284,6 +332,8 @@ pyyaml
 requests>=2.28.0
 python-dateutil>=2.8.0
 ```
+
+<a id="example-of-external-api-call"></a>
 
 ### Example of external API call
 ```python
@@ -326,6 +376,8 @@ def main():
             'details': str(e)
         }, ensure_ascii=False), 500
 ```
+
+<a id="data-processing-example"></a>
 
 ### Data processing example
 ```python
@@ -381,7 +433,11 @@ def normalize_name(name):
     return name.strip().title()
 ```
 
+<a id="configure-entry-point"></a>
+
 ## Configure Entry Point
+
+<a id="single-function"></a>
 
 ### Single function
 Use `filename.functionname` as the Entry Point.
@@ -389,6 +445,8 @@ Use `filename.functionname` as the Entry Point.
 File name: `user.py`
 Function name: `main`
 Entry Point: `user.main`
+
+<a id="multiple-functions"></a>
 
 ### Multiple functions
 You can define multiple functions in a single file.
@@ -416,7 +474,11 @@ Entry Point Configuration:
 - `handlers.create_user`
 - `handlers.update_user`
 
+<a id="caution"></a>
+
 ## Caution
+
+<a id="unsupported-packages"></a>
 
 ### Unsupported packages
 Complex packages with the following features are not currently supported:
@@ -431,6 +493,8 @@ Complex packages with the following features are not currently supported:
 - `pyyaml` (YAML processing)
 - `python-dateutil` (date/time processing)
 - `pillow` (image processing - basic feature)
+
+<a id="considerations-for-memory-and-execution-time"></a>
 
 ### Considerations for Memory and execution time
 - Functions must operate within limited memory and execution time.

--- a/en/code-template-ruby-guide.md
+++ b/en/code-template-ruby-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=1d5361d8d187 -->
+
 ## Compute > Cloud Functions > Code Template Guide   > Ruby
 
 This document details how to develop functions by using Ruby from NHN Cloud's Cloud Functions service.
+
+<a id="template-information"></a>
 
 ## Template information
 | Item         | Value        |
@@ -9,7 +13,11 @@ This document details how to develop functions by using Ruby from NHN Cloud's Cl
 | **File name**         | parse.rb |
 | **Entry Point** | handler |
 
+<a id="basic-template"></a>
+
 ## Basic template
+
+<a id="hello-world-example"></a>
 
 ### Hello World example
 A basic form of function.
@@ -29,6 +37,8 @@ def handler(context)
   Rack::Response.new([msg, "\n"]).finish
 end
 ```
+
+<a id="context-object"></a>
 
 ### Context object
 You can access logger and request information through the `context` object passed to the function.
@@ -64,12 +74,18 @@ def handler(context)
 end
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## Download and use template file
+
+<a id="template-download"></a>
 
 ### Template download
 You can download the Ruby template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [ruby.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/ruby/ruby.zip)
+
+<a id="template-file-structure"></a>
 
 ### Template file structure
 The structure of the downloaded template file is as follows:
@@ -80,7 +96,11 @@ ruby.zip
 └── Gemfile
 ```
 
+<a id="local-development-process"></a>
+
 ### Local development process
+
+<a id="unzip"></a>
 
 #### 1. Unzip
 ```bash
@@ -90,6 +110,8 @@ unzip ruby.zip -d my-function
 # Move to task directory
 cd my-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. Modify function codes
 Modify `parse.rb` file with the logic you want.
@@ -135,6 +157,8 @@ def handler(context)
 end
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file. You must compress it so that `parse.rb` and `Gemfile` are included at the top level.
 
@@ -143,9 +167,13 @@ zip my-function.zip parse.rb Gemfile Gemfile.lock
 ```
 **Note**: The `Gemfile.lock` file is automatically created during the deployment phase, but if you want to check or lock the exact versions of your dependencies in advance, you can create one yourself by running `bundle install` locally and then compress it together. If a `Gemfile.lock` file is included, the build will use the versions specified in it.
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Upload from Cloud Functions console
 - When creating or modifying a function, select the **User Local Environment** method.
 - Click **Select File** to upload the `my-function.zip` file you created.
+
+<a id="cautions-for-upload"></a>
 
 ### Cautions for upload
 - **Upload File**: Upload **ZIP file** which includes `*.rb`, `Gemfile`.
@@ -153,7 +181,11 @@ zip my-function.zip parse.rb Gemfile Gemfile.lock
 - **ZIP Files Structure**: Files must be located directly in the root of the ZIP file.
 - **File Size**: ZIP file size is limited to 100 MiB.
 
+<a id="process-post-request"></a>
+
 ## Process POST request
+
+<a id="process-get-request"></a>
 
 ### Process GET request
 ```ruby
@@ -178,6 +210,8 @@ def handler(context)
   Rack::Response.new([response_data], 200, { 'Content-Type' => 'application/json' }).finish
 end
 ```
+
+<a id="process-post-request-2"></a>
 
 ### Process POST request
 ```ruby
@@ -214,6 +248,8 @@ def handler(context)
 end
 ```
 
+<a id="manage-package-gemfile"></a>
+
 ## Manage package (`Gemfile`)
 
 Use `Gemfile` to manage dependencies (gems). Add the required gems and run `bundle install` to generate `Gemfile.lock`.
@@ -227,6 +263,8 @@ source "https://rubygems.org"
 gem "nokogiri", "~> 1.18" # XML/HTML parser
 gem "httparty", "~> 0.23" # HTTP client
 ```
+
+<a id="example-of-external-api-call"></a>
 
 ### Example of external API call
 ```ruby
@@ -268,6 +306,8 @@ def handler(context)
 end
 ```
 
+<a id="configure-entry-point"></a>
+
 ## Configure Entry Point
 
 Entry Point uses the function name.
@@ -275,6 +315,8 @@ Entry Point uses the function name.
 - File name: `parse.rb`
 - Function name: `handler`
 - Entry Point: `handler`
+
+<a id="caution"></a>
 
 ### Caution
 - **Bundler version**: We recommend using Bundler 2.6.2 or later when generating `Gemfile.lock`.

--- a/en/console-guide.md
+++ b/en/console-guide.md
@@ -1,14 +1,22 @@
+<!-- pre-align:aligned sig=fda183656939 -->
+
 ## Compute > Cloud Functions > Console User Guide
 This document describes how to create and manage functions in Cloud Functions console.
 
+<a id="manage-functions"></a>
+
 ## Manage functions
 You can create, edit, delete, and copy functions.
+
+<a id="create-functions"></a>
 
 ### Create functions
 Configure the function, write your code, and build it. Then, click **Create** to deploy the function using the latest built package.
 
 ![console-guide-07](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-01.png)
 ![console-guide-08](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-02.png)
+
+<a id="function-settings"></a>
 
 #### Function settings
 <table class="it">
@@ -87,6 +95,8 @@ Configure the function, write your code, and build it. Then, click **Create** to
 <br>
 
 
+<a id="code-writing"></a>
+
 #### Code writing
 
 ![console-guide-09](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-03.png)
@@ -150,18 +160,28 @@ Configure the function, write your code, and build it. Then, click **Create** to
 
 > **[Note]** <br> Packages generated via Build button are linked to the function version during creation or updates. You must perform at least one build before creating a function
 
+<a id="modify-functions"></a>
+
 ### Modify functions
 To modify the function settings and code of an existing function, click **Modify** button to modify the function.
+<a id="non-modifiable-item"></a>
+
 #### Non-modifiable item
 - Name, runtime environment
     - You can edit everything except the item.
+<a id="source-code"></a>
+
 #### Source code
 - If you're using the code editor, the existing code is loaded.
 - If you created a function by uploading a ZIP file from the local environment, when you switch to the code editor, it loads the default template code without showing the ZIP file.
 
+<a id="delete-a-function"></a>
+
 ### Delete a function
 ![console-guide-14](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-06.png)
 Select an existing function to delete it. You can delete multiple functions at once.
+
+<a id="copy-a-function"></a>
 
 ### Copy a function
 ![console-guide-13](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-07.png)
@@ -169,26 +189,38 @@ Copy a function that is identical to an existing function. The name cannot be du
 - Triggers are not copied. (HTTP triggers are provided by default).
 - Only the currently applied version will be copied.
 
+<a id="about-functions"></a>
+
 ## About functions
+<a id="list-of-functions"></a>
+
 ### List of functions
 ![console-guide-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-08.png)
 - You can see a list of functions that users have created.
 - Build status shows the build status of the current version.
+<a id="basic-information-of-functions"></a>
+
 ### Basic information of functions
 ![console-guide-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-09.png)
 - You can see basic information about the function.
 - Click Log & Crash Search in the Log Management section to view your logs in the Log & Crash Search service.
+
+<a id="function-versioning"></a>
 
 ### Function versioning
 ![console-guide-15](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2026-01-27/console-guide-en-15.png)
 - You can manage function versions.
 - You can view version history and rollback to any previous version.
 
+<a id="versioning-overview"></a>
+
 #### Versioning overview
 Build your code by clicking **Build** in the function creation or modification screen to generate a package.
 - When you create or update a function, the latest built package is integrated into the function version.
 - Each version is managed independently, allowing you to apply a tested version directly to your function.
 - At least one build is required to enable function creation.
+
+<a id="version-information"></a>
 
 #### Version information
 <table class="it">
@@ -219,6 +251,8 @@ Build your code by clicking **Build** in the function creation or modification s
     </tr>
 </table>
 
+<a id="deploy-versions"></a>
+
 #### Deploy versions
 - Select a version from the list and click **Deploy Version** to update the function to the version.
 - The currently applied version cannot be selected for deployment.
@@ -227,6 +261,8 @@ Build your code by clicking **Build** in the function creation or modification s
 
 > **[Note]**
 > <br>A confirmation popup will appear upon deployment. Once the deployment is successful, the version list will refresh automatically.
+
+<a id="delete-versions"></a>
 
 #### Delete versions
 - To delete a version, select it from the list and click **Delete Version**.
@@ -237,11 +273,15 @@ Build your code by clicking **Build** in the function creation or modification s
 > **[Note]**
 > <br>A confirmation popup will appear when deleting a version. Please note that deleted versions cannot be recovered.
 
+<a id="constraints"></a>
+
 #### Constraints
 - Canceling function creation or modification will prevent the built package from being integrated into a function version.
 - Deleting a function will permanently remove all integrated versions.
 - When copying a function, only the currently active version is copied. The full version history will not be copied.
 - While multiple runtimes are available during function creation, you can only build using the initially selected runtime when modifying the function.
+
+<a id="manage-function-triggers"></a>
 
 ### Manage function triggers
 You can manage triggers that can perform functions.
@@ -254,14 +294,20 @@ You can manage triggers that can perform functions.
     - Example: `https://{userdomain}/{function name}`
     - Method : GET, POST
 
+<a id="createedit-triggers"></a>
+
 #### Create/edit triggers
 - Timer
     - Value: Enter the cycle as a Cron string.
     - API Gateway
     - You can add HTTP Endpoint by using the API Gateway service.
 
+<a id="delete-triggers"></a>
+
 #### Delete triggers
 - You can select multiple triggers to delete. You can't delete the HTTP trigger, which is the default trigger.
+
+<a id="monitor-functions"></a>
 
 ### Monitor functions
 ![console-guide-06](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-11.png)

--- a/en/overview.md
+++ b/en/overview.md
@@ -1,5 +1,9 @@
+<!-- pre-align:aligned sig=92acb111e0a0 -->
+
 ## Compute > Cloud Functions > Overview
 Users can write codes by function unit. Functions defined on a specific event are automatically executed, processing the required tasks. Without server management or infrastructure configuration, you can focus only on application logic.
+
+<a id="features"></a>
 
 ### Features
 - Cost-effectiveness
@@ -13,15 +17,21 @@ Users can write codes by function unit. Functions defined on a specific event ar
     - Support for multiple languages and runtimes.
     - The event-based architecture is versatile.
 
+<a id="main-features"></a>
+
 ### Main features
 - We offer multiple languages (environments).
 - The **code editor** makes you write simple function unit code.
 - Provide an HTTPS Endpoint as standard to perform the function.
 - Iterate the function at regular cycles.
 
+<a id="two-modes-available"></a>
+
 ### Two modes available
 - Pool Manager
 - New Deployment
+<a id="pool-manager"></a>
+
 #### Pool Manager
 - Instances are created and use resources only when the function is performed.
 - If the function is not performed for a certain period, instances disappear, and the resource usage becomes 0.
@@ -29,12 +39,16 @@ Users can write codes by function unit. Functions defined on a specific event ar
 
 ![overview-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_1_en.png)
 
+<a id="new-deployment"></a>
+
 #### New Deployment
 - Once functions are created, instances are created, keeping a certain amount of resources being used.
 - Instances are kept to reduce response latency.
 - Use it when the number of requests is large to perform the function and a quick response is needed.
 
 ![overview-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_2_en.png)
+
+<a id="supported-languages"></a>
 
 ### Supported languages
 | Language     | Version                | End of Support   | End of Service   |
@@ -55,6 +69,8 @@ Users can write codes by function unit. Functions defined on a specific event ar
 |        | 2.6.1 (end of service)     | 2024-01-30 | 2025-01-30 |
 | .NET   | 8                 | 2026-11-10 | 2027-11-10 |
 |        | 7 (end of service)         | 2024-05-14 | 2025-05-14 |
+
+<a id="trigger"></a>
 
 ### Trigger
 - HTTP Trigger

--- a/en/release-notes.md
+++ b/en/release-notes.md
@@ -1,22 +1,38 @@
+<!-- pre-align:aligned sig=06519d7ca905 -->
+
 ## Compute > Cloud Functions > Release Notes
 
+<a id="april-14-2026"></a>
+
 ### April 14, 2026
+
+<a id="added-features"></a>
 
 #### Added Features
 - Added Public API v1.0
   - Added support for using Cloud Functions via API.
 
+<a id="january-27-2026"></a>
+
 ### January 27, 2026
+
+<a id="january-27-2026-added-features"></a>
 
 #### Added Features
 - Added function versioning
   - Manage build packages by version and rollback to previous versions.
 
+<a id="november-25-2025"></a>
+
 ### November 25, 2025
+
+<a id="november-25-2025-added-features"></a>
 
 #### Added Features
 - Added API Gateway trigger
   - Added the feature to create API Gateway triggers by utilizing the API Gateway service in the same project.
+
+<a id="feature-updates"></a>
 
 #### Feature Updates
 - Added the latest runtime environment and deprecated some versions
@@ -26,7 +42,11 @@
   - Deprecated Ruby 2.6.1, added Ruby 3.4.5
   - Deprecated .NET 7, added .NET 8
 
+<a id="july-29-2025"></a>
+
 ### July 29. 2025
+
+<a id="launch-cloud-functions-service"></a>
 
 #### Launch Cloud Functions Service
 - Users can write codes by function unit. Functions defined on a specific event are automatically executed, processing the required tasks. Without server management or infrastructure configuration, you can focus only on application logic.

--- a/en/trigger-guide.md
+++ b/en/trigger-guide.md
@@ -1,10 +1,16 @@
+<!-- pre-align:aligned sig=02be28f736c7 -->
+
 ## Compute > Cloud Functions > Trigger Guide
 
 This document describes the trigger types available in Cloud Functions and how to set them up.
 
+<a id="trigger-overview"></a>
+
 ## Trigger Overview
 
 Trigger is an event source to execute functions. Cloud Functions provide various triggers to allow you to call functions in multiple ways.
+
+<a id="supported-triggers"></a>
 
 ### Supported Triggers
 
@@ -14,9 +20,13 @@ Trigger is an event source to execute functions. Cloud Functions provide various
 | Timer | Execute a function at a specified time or interval | No |
 | API Gateway | Execute a function via API Gateway | No |
 
+<a id="http-trigger"></a>
+
 ## HTTP Trigger
 
 HTTP trigger is built-in when creating a function, and you can execute the function with an HTTP request.
+
+<a id="features"></a>
 
 ### Features
 
@@ -24,19 +34,27 @@ HTTP trigger is built-in when creating a function, and you can execute the funct
 - It cannot be deleted but only enabled or disabled.
 - GET, POST methods are supported.
 
+<a id="url-format-of-http-trigger"></a>
+
 ### URL Format of HTTP Trigger
 
 ```
 https://{userdomain}/{function name}
 ```
 
+<a id="examples"></a>
+
 ### Examples
+
+<a id="request-get"></a>
 
 #### Request GET
 
 ```bash
 curl -X GET "https://{userdomain}/{function name}?param1=value1&param2=value2"
 ```
+
+<a id="request-post"></a>
 
 #### Request POST
 
@@ -45,6 +63,8 @@ curl -X POST "https://{userdomain}/{function name}" \
   -H "Content-Type: application/json" \
   -d '{"key": "value"}'
 ```
+
+<a id="enabledisable-http-trigger"></a>
 
 ### Enable/disable HTTP Trigger
 
@@ -55,9 +75,13 @@ curl -X POST "https://{userdomain}/{function name}" \
 > **[Note]**
 > <br>If you send a request with a disabled HTTP trigger, the function will not execute.
 
+<a id="timer-trigger"></a>
+
 ## Timer Trigger
 
 Timer trigger executes a function automatically at the specified time or cycle. You can set up the cycle by using the Cron expression.
+
+<a id="create-timer-trigger"></a>
 
 ### Create Timer Trigger
 
@@ -69,6 +93,8 @@ Timer trigger executes a function automatically at the specified time or cycle. 
 4. Select the type as **Timer**.
 5. Enter Cron expression in **Value**.
 6. Click **Create**.
+
+<a id="cron-expression-format"></a>
 
 ### Cron Expression Format
 
@@ -85,6 +111,8 @@ Cron expression follows the format as below:
 └─────────── second (0-59)
 ```
 
+<a id="cron-expression-field"></a>
+
 #### Cron Expression Field
 
 | Field | Required | Allowed vale | Allowed special character |
@@ -95,6 +123,8 @@ Cron expression follows the format as below:
 | Day of month | Yes | 1-31 | * / , - ? |
 | Month | Yes | 1-12 or JAN-DEC | * / , - |
 | Day of week | Yes | 0-6 or SUN-SAT | * / , - ? |
+
+<a id="special-characters-details"></a>
 
 #### Special Characters Details
 
@@ -118,6 +148,8 @@ Used to define scope. For example, using `9-17` in the third field (hours) means
 
 You can use * instead of leaving the Day of month or Day of week field blank.
 
+<a id="example-of-cron-expression"></a>
+
 ### Example of Cron Expression
 
 | Cron Expression | Description |
@@ -131,6 +163,8 @@ You can use * instead of leaving the Day of month or Day of week field blank.
 | `0 0 9-18 * * MON-FRI` | Execute every hour from 9:00 AM to 6:00 PM on weekdays (Mon-Fri) |
 | `30 0 12 * * *` | Execute every day at 12:00:30 PM |
 | `0 0 0 1 JAN *` | Execute every January 1st at midnight |
+
+<a id="modify-timer-trigger"></a>
 
 ### Modify Timer Trigger
 
@@ -146,14 +180,20 @@ You can use * instead of leaving the Day of month or Day of week field blank.
 > **[Note]**
 > <br>The Month and Day of week field values ​​are case-insensitive. "SUN", "Sun", "sun" are all recognized equally.
 
+<a id="api-gateway-trigger"></a>
+
 ## API Gateway Trigger
 
 API Gateway triggers can execute functions by leveraging the API Gateway service in the same project. API Gateway enables more detailed API management and control.
+
+<a id="prerequisites"></a>
 
 ### Prerequisites
 
 - The API Gateway service must be enabled in the same project.
   - If it isn't enabled, you can enable it when creating a trigger.
+
+<a id="create-api-gateway-trigger"></a>
 
 ### Create API Gateway Trigger
 
@@ -167,19 +207,27 @@ API Gateway triggers can execute functions by leveraging the API Gateway service
    * Duplicate path is unavailable.
 6. Click **Create**.
 
+<a id="api-gateway-trigger-url-format"></a>
+
 ### API Gateway Trigger URL Format
 
 ```
 https://{stageurl}/{path}
 ```
 
+<a id="api-gateway-trigger-examples"></a>
+
 ### Examples
+
+<a id="api-gateway-trigger-examples-request-get"></a>
 
 #### Request GET
 
 ```bash
 curl -X GET "https://{stageurl}/{path}?param1=value1&param2=value2"
 ```
+
+<a id="api-gateway-trigger-examples-request-post"></a>
 
 #### Request POST
 
@@ -188,6 +236,8 @@ curl -X POST "https://{stageurl}/{path}" \
   -H "Content-Type: application/json" \
   -d '{"key": "value"}'
 ```
+
+<a id="features-of-api-gateway-trigger"></a>
 
 ### Features of API Gateway Trigger
 
@@ -199,6 +249,8 @@ curl -X POST "https://{stageurl}/{path}" \
 - You can manage API settings from the API Gateway console.
 - Integrating functions is available only in a single automatically generated service.
 - The service supports GET and POST methods, same as HTTP triggers.
+
+<a id="modify-api-gateway-trigger"></a>
 
 ### Modify API Gateway Trigger
 
@@ -216,13 +268,19 @@ curl -X POST "https://{stageurl}/{path}" \
 > <br>It results in deleting all plugins applied to the corresponding resource.
 > <br>If you want to change the resource path to which the plugin is applied, we recommend adding a new trigger instead of modifying it.
 
+<a id="use-with-api-gateway"></a>
+
 ### Use with API Gateway
 
 Once you create an API Gateway trigger, you can configure additional settings in the API Gateway console.
 
 For more details, please refer to the [API Gateway Guide](https://docs.nhncloud.com/ko/Application%20Service/API%20Gateway/ko/overview/).
 
+<a id="delete-trigger"></a>
+
 ## Delete Trigger
+
+<a id="how-to-delete-trigger"></a>
 
 ### How to Delete Trigger
 
@@ -234,13 +292,19 @@ For more details, please refer to the [API Gateway Guide](https://docs.nhncloud.
 4. Click **Delete Trigger**.
 5. Click **Delete** from the modal window of **Delete Trigger**.
 
+<a id="cautions"></a>
+
 ### Cautions
 
 - You cannot delete HTTP trigger. HTTP trigger is built-in, only being enabled or disabled.
 - If deleting the trigger, you cannot execute the function through the event.
 - Deleted triggers cannot be recovered.
 
+<a id="restrictions"></a>
+
 ## Restrictions
+
+<a id="restrictions-for-api-gateway-trigger"></a>
 
 ### Restrictions for API Gateway Trigger
 

--- a/ja/api-guide-v1-0.md
+++ b/ja/api-guide-v1-0.md
@@ -1,8 +1,14 @@
+<!-- pre-align:aligned sig=f22611a38cd5 -->
+
 ## Cloud Functions API v1.0 ガイド
 
 **Compute > Cloud Functions > API ガイド > API v1.0 ガイド**
 
+<a id="cloud-functions-api-v10-common-information"></a>
+
 ## Cloud Functions API v1.0 共通情報
+
+<a id="api-endpoint"></a>
 
 ### API エンドポイント
 
@@ -12,11 +18,15 @@ Cloud Functions APIを呼び出すためのリージョン別エンドポイン�
 | --- |-----------------------------------------------------|
 | 韓国(パンギョ)リージョン | https://kr1-cloud-functions.api.nhncloudservice.com |
 
+<a id="authentication-and-authorization"></a>
+
 ### 認証及び権限
 
 Cloud Functionsは、API呼び出し時の認証/認可にUser Access Keyトークンを使用します。
 User Access Keyトークンは、User Access Keyをもとに発行されるBearerタイプの一時的なアクセストークンです。
 User Access Keyトークンの発行手順や使用方法の詳細は、[User Access Keyトークン](/nhncloud/ko/public-api/user-access-key-token)をご参照ください。
+
+<a id="response-common-information"></a>
 
 ### レスポンス共通情報
 
@@ -66,15 +76,21 @@ User Access Keyトークンの発行手順や使用方法の詳細は、[User Ac
 
 ---
 
+<a id="list-environments"></a>
+
 ## 環境一覧
 
 使用可能なランタイム環境一覧を照会します。
+
+<a id="request"></a>
 
 ### リクエスト
 
 ```
 GET /v1.0/env/list
 ```
+
+<a id="request-parameter"></a>
 
 ### リクエストパラメータ
 
@@ -83,9 +99,13 @@ GET /v1.0/env/list
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 
+<a id="request-body"></a>
+
 ### リクエストボディ
 
 このAPIはリクエストボディを必要としません。
+
+<a id="response"></a>
 
 ### レスポンス
 
@@ -128,15 +148,21 @@ GET /v1.0/env/list
 
 ---
 
+<a id="list-functions"></a>
+
 ## 関数一覧
 
 関数一覧を照会します。
+
+<a id="list-functions-request"></a>
 
 ### リクエスト
 
 ```
 GET /v1.0/functions
 ```
+
+<a id="list-functions-request-parameter"></a>
 
 ### リクエストパラメータ
 
@@ -147,9 +173,13 @@ GET /v1.0/functions
 | page | Query | Integer | N | 現在のページ(デフォルト値: 0) |
 | pageSize | Query | Integer | N | 1ページに表示する件数(デフォルト値: 5000) |
 
+<a id="list-functions-request-body"></a>
+
 ### リクエストボディ
 
 このAPIはリクエストボディを必要としません。
+
+<a id="list-functions-response"></a>
 
 ### レスポンス
 
@@ -200,15 +230,21 @@ GET /v1.0/functions
 
 ---
 
+<a id="get-function"></a>
+
 ## 関数詳細照会
 
 関数の詳細情報とビルドログを同時に照会します。
+
+<a id="get-function-request"></a>
 
 ### リクエスト
 
 ```
 GET /v1.0/functions/{functionName}
 ```
+
+<a id="get-function-request-parameter"></a>
 
 ### リクエストパラメータ
 
@@ -218,9 +254,13 @@ GET /v1.0/functions/{functionName}
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 関数名 |
 
+<a id="get-function-request-body"></a>
+
 ### リクエストボディ
 
 このAPIはリクエストボディを必要としません。
+
+<a id="get-function-response"></a>
 
 ### レスポンス
 
@@ -280,6 +320,8 @@ GET /v1.0/functions/{functionName}
 
 ---
 
+<a id="create-function"></a>
+
 ## 関数作成
 
 新しい関数を作成します。multipart/form-dataでソースファイルをアップロードします。
@@ -287,11 +329,15 @@ runtimeは`{environment}-{version}`形式で入力する必要があります(�
 
 executorTypeによって必須パラメータが異なります。poolManagerの場合はrequestPerPodが、newDeploymentの場合はminInstanceとmaxInstanceが必須です。
 
+<a id="create-function-request"></a>
+
 ### リクエスト
 
 ```
 POST /v1.0/functions
 ```
+
+<a id="create-function-request-parameter"></a>
 
 ### リクエストパラメータ
 
@@ -299,6 +345,8 @@ POST /v1.0/functions
 | --- | --- | --- | --- | --- |
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
+
+<a id="create-function-request-body"></a>
 
 ### リクエストボディ
 
@@ -318,6 +366,8 @@ Content-Type: multipart/form-data
 | maxInstance | Integer | Conditional | 最大インスタンス数(newDeploymentの場合は必須、1～100) |
 | lncsAppkey | String | N | LnCS Appkey |
 | sourceFile | Binary | Y | ソースコードファイル(ZIP) |
+
+<a id="create-function-response"></a>
 
 ### レスポンス
 
@@ -339,17 +389,23 @@ Content-Type: multipart/form-data
 
 ---
 
+<a id="modify-function"></a>
+
 ## 関数修正
 
 関数を修正します。multipart/form-dataでソースファイルをアップロードできます。
 
 ソースファイル(sourceFile)は任意項目です。ソースファイルを指定しない場合、既存のソースコードが維持されます。
 
+<a id="modify-function-request"></a>
+
 ### リクエスト
 
 ```
 PUT /v1.0/functions/{functionName}
 ```
+
+<a id="modify-function-request-parameter"></a>
 
 ### リクエストパラメータ
 
@@ -358,6 +414,8 @@ PUT /v1.0/functions/{functionName}
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 修正する関数名 |
+
+<a id="modify-function-request-body"></a>
 
 ### リクエストボディ
 
@@ -376,6 +434,8 @@ Content-Type: multipart/form-data
 | maxInstance | Integer | Conditional | 最大インスタンス数(newDeploymentの場合は必須、1～100) |
 | lncsAppkey | String | N | LnCS Appkey |
 | sourceFile | Binary | N | ソースコードファイル(ZIP) |
+
+<a id="modify-function-response"></a>
 
 ### レスポンス
 
@@ -397,9 +457,13 @@ Content-Type: multipart/form-data
 
 ---
 
+<a id="delete-functions"></a>
+
 ## 関数削除
 
 関数を一括削除します。
+
+<a id="delete-functions-request"></a>
 
 ### リクエスト
 
@@ -407,12 +471,16 @@ Content-Type: multipart/form-data
 DELETE /v1.0/functions
 ```
 
+<a id="delete-functions-request-parameter"></a>
+
 ### リクエストパラメータ
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
+
+<a id="delete-functions-request-body"></a>
 
 ### リクエストボディ
 
@@ -430,6 +498,8 @@ DELETE /v1.0/functions
 | 名前 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- |
 | names | Array | Y | 削除する関数名一覧 |
+
+<a id="delete-functions-response"></a>
 
 ### レスポンス
 
@@ -451,15 +521,21 @@ DELETE /v1.0/functions
 
 ---
 
+<a id="execute-function-get"></a>
+
 ## 関数実行(GET)
 
 GETメソッドで関数を実行します。
+
+<a id="execute-function-get-request"></a>
 
 ### リクエスト
 
 ```
 GET /v1.0/functions/{functionName}/invoke
 ```
+
+<a id="execute-function-get-request-parameter"></a>
 
 ### リクエストパラメータ
 
@@ -469,9 +545,13 @@ GET /v1.0/functions/{functionName}/invoke
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 実行する関数名 |
 
+<a id="execute-function-get-request-body"></a>
+
 ### リクエストボディ
 
 このAPIはリクエストボディを必要としません。
+
+<a id="execute-function-get-response"></a>
 
 ### レスポンス
 
@@ -497,15 +577,21 @@ GET /v1.0/functions/{functionName}/invoke
 
 ---
 
+<a id="execute-function-post"></a>
+
 ## 関数実行(POST)
 
 POSTメソッドで関数を実行します。bodyを送信できます。
+
+<a id="execute-function-post-request"></a>
 
 ### リクエスト
 
 ```
 POST /v1.0/functions/{functionName}/invoke
 ```
+
+<a id="execute-function-post-request-parameter"></a>
 
 ### リクエストパラメータ
 
@@ -514,6 +600,8 @@ POST /v1.0/functions/{functionName}/invoke
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 実行する関数名 |
+
+<a id="execute-function-post-request-body"></a>
 
 ### リクエストボディ
 
@@ -531,6 +619,8 @@ POST /v1.0/functions/{functionName}/invoke
 | 名前 | タイプ  | 必須 | 説明 |
 | --- |------| --- | --- |
 | body | JSON | N | 関数に渡すbody |
+
+<a id="execute-function-post-response"></a>
 
 ### レスポンス
 
@@ -556,15 +646,21 @@ POST /v1.0/functions/{functionName}/invoke
 
 ---
 
+<a id="list-versions"></a>
+
 ## バージョン一覧
 
 関数のバージョン(パッケージ)一覧を照会します。
+
+<a id="list-versions-request"></a>
 
 ### リクエスト
 
 ```
 GET /v1.0/functions/{functionName}/versions
 ```
+
+<a id="list-versions-request-parameter"></a>
 
 ### リクエストパラメータ
 
@@ -574,9 +670,13 @@ GET /v1.0/functions/{functionName}/versions
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 関数名 |
 
+<a id="list-versions-request-body"></a>
+
 ### リクエストボディ
 
 このAPIはリクエストボディを必要としません。
+
+<a id="list-versions-response"></a>
 
 ### レスポンス
 
@@ -625,15 +725,21 @@ GET /v1.0/functions/{functionName}/versions
 
 ---
 
+<a id="switch-version"></a>
+
 ## バージョン切り替え
 
 関数の現在のアクティブバージョンを変更します。
+
+<a id="switch-version-request"></a>
 
 ### リクエスト
 
 ```
 PUT /v1.0/functions/{functionName}/versions
 ```
+
+<a id="switch-version-request-parameter"></a>
 
 ### リクエストパラメータ
 
@@ -642,6 +748,8 @@ PUT /v1.0/functions/{functionName}/versions
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 関数名 |
+
+<a id="switch-version-request-body"></a>
 
 ### リクエストボディ
 
@@ -660,6 +768,8 @@ PUT /v1.0/functions/{functionName}/versions
 | --- | --- | --- | --- |
 | versionId | Integer | Y | 切り替えるバージョンID |
 
+<a id="switch-version-response"></a>
+
 ### レスポンス
 
 <details>
@@ -680,17 +790,23 @@ PUT /v1.0/functions/{functionName}/versions
 
 ---
 
+<a id="delete-versions"></a>
+
 ## バージョン削除
 
 関数のバージョンを一括削除します。
 
 現在のアクティブバージョンは削除できません。
 
+<a id="delete-versions-request"></a>
+
 ### リクエスト
 
 ```
 DELETE /v1.0/functions/{functionName}/versions
 ```
+
+<a id="delete-versions-request-parameter"></a>
 
 ### リクエストパラメータ
 
@@ -699,6 +815,8 @@ DELETE /v1.0/functions/{functionName}/versions
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 関数名 |
+
+<a id="delete-versions-request-body"></a>
 
 ### リクエストボディ
 
@@ -717,6 +835,8 @@ DELETE /v1.0/functions/{functionName}/versions
 | --- | --- | --- | --- |
 | versionIds | Array | Y | 削除するバージョンID一覧 |
 
+<a id="delete-versions-response"></a>
+
 ### レスポンス
 
 <details>
@@ -737,15 +857,21 @@ DELETE /v1.0/functions/{functionName}/versions
 
 ---
 
+<a id="list-triggers"></a>
+
 ## トリガー一覧
 
 関数のトリガー一覧を照会します。
+
+<a id="list-triggers-request"></a>
 
 ### リクエスト
 
 ```
 GET /v1.0/triggers/{functionName}
 ```
+
+<a id="list-triggers-request-parameter"></a>
 
 ### リクエストパラメータ
 
@@ -755,9 +881,13 @@ GET /v1.0/triggers/{functionName}
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 関数名 |
 
+<a id="list-triggers-request-body"></a>
+
 ### リクエストボディ
 
 このAPIはリクエストボディを必要としません。
+
+<a id="list-triggers-response"></a>
 
 ### レスポンス
 
@@ -800,15 +930,21 @@ GET /v1.0/triggers/{functionName}
 
 ---
 
+<a id="create-time-trigger"></a>
+
 ## タイムトリガー作成
 
 関数にタイムトリガーを作成します。
+
+<a id="create-time-trigger-request"></a>
 
 ### リクエスト
 
 ```
 POST /v1.0/triggers/{functionName}/time
 ```
+
+<a id="create-time-trigger-request-parameter"></a>
 
 ### リクエストパラメータ
 
@@ -817,6 +953,8 @@ POST /v1.0/triggers/{functionName}/time
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 関数名 |
+
+<a id="create-time-trigger-request-body"></a>
 
 ### リクエストボディ
 
@@ -834,6 +972,8 @@ POST /v1.0/triggers/{functionName}/time
 | 名前 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- |
 | cron | String | Y | cron式 |
+
+<a id="create-time-trigger-response"></a>
 
 ### レスポンス
 
@@ -855,15 +995,21 @@ POST /v1.0/triggers/{functionName}/time
 
 ---
 
+<a id="modify-time-trigger"></a>
+
 ## タイムトリガー修正
 
 タイムトリガーのcron式を修正します。
+
+<a id="modify-time-trigger-request"></a>
 
 ### リクエスト
 
 ```
 PUT /v1.0/triggers/{functionName}/time
 ```
+
+<a id="modify-time-trigger-request-parameter"></a>
 
 ### リクエストパラメータ
 
@@ -872,6 +1018,8 @@ PUT /v1.0/triggers/{functionName}/time
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 関数名 |
+
+<a id="modify-time-trigger-request-body"></a>
 
 ### リクエストボディ
 
@@ -891,6 +1039,8 @@ PUT /v1.0/triggers/{functionName}/time
 | --- | --- | --- | --- |
 | name | String | Y | トリガー名 |
 | cron | String | Y | cron式 |
+
+<a id="modify-time-trigger-response"></a>
 
 ### レスポンス
 
@@ -912,15 +1062,21 @@ PUT /v1.0/triggers/{functionName}/time
 
 ---
 
+<a id="delete-time-triggers"></a>
+
 ## タイムトリガー削除
 
 タイムトリガーを一括削除します。
+
+<a id="delete-time-triggers-request"></a>
 
 ### リクエスト
 
 ```
 DELETE /v1.0/triggers/{functionName}/time
 ```
+
+<a id="delete-time-triggers-request-parameter"></a>
 
 ### リクエストパラメータ
 
@@ -929,6 +1085,8 @@ DELETE /v1.0/triggers/{functionName}/time
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 関数名 |
+
+<a id="delete-time-triggers-request-body"></a>
 
 ### リクエストボディ
 
@@ -946,6 +1104,8 @@ DELETE /v1.0/triggers/{functionName}/time
 | 名前 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- |
 | names | Array | Y | 削除するトリガー名一覧 |
+
+<a id="delete-time-triggers-response"></a>
 
 ### レスポンス
 

--- a/ja/code-template-dotnet-guide.md
+++ b/ja/code-template-dotnet-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=3c324618eb1e -->
+
 ## Compute > Cloud Functions > コードテンプレートガイド > .NET
 
 このドキュメントでは、NHN CloudのCloud Functionsサービスで.NETを使用して関数を開発する方法を詳しく説明します。
+
+<a id="template-information"></a>
 
 ## テンプレート情報
 | 項目       | 値                |
@@ -9,7 +13,11 @@
 | **ファイル名**    | func.cs            |
 | **Entry Point** | func             |
 
+<a id="basic-template"></a>
+
 ## 基本テンプレート
+
+<a id="hello-world-example"></a>
 
 ### Hello Worldの例
 最も基本的な関数の形式です。`Nhn.DotNetCore.Api`名前空間の`NhnContext`を使用して、ロガーやリクエスト情報にアクセスします。
@@ -49,6 +57,8 @@ public class NhnFunction
     }
 }
 ```
+
+<a id="context-object"></a>
 
 ### Contextオブジェクト
 `NhnContext`オブジェクトを通じて、ロガー、リクエスト(Request)、レスポンス(Response)オブジェクトにアクセスできます。
@@ -95,12 +105,18 @@ public class NhnFunction
 }
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## テンプレートファイルのダウンロードと活用
+
+<a id="template-download"></a>
 
 ### テンプレートのダウンロード
 Cloud Functionsが提供する.NETテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [dotnet.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/dotnet/dotnet.zip)
+
+<a id="template-file-structure"></a>
 
 ### テンプレートのファイル構造
 ダウンロードしたテンプレートファイルの構造は次のとおりです。
@@ -112,7 +128,11 @@ dotnet.zip
 └── nuget.txt     # 依存関係管理ファイル
 ```
 
+<a id="local-development-process"></a>
+
 ### ローカルでの開発プロセス
+
+<a id="unzip"></a>
 
 #### 1. 解凍
 ```bash
@@ -122,6 +142,8 @@ unzip dotnet.zip -d my-function
 # 作業ディレクトリへ移動
 cd my-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. 関数コードの修正
 `func.cs`ファイルを、目的のロジックに合わせて修正します。
@@ -178,6 +200,8 @@ public class NhnFunction
 }
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. ZIPファイルへ圧縮
 修正したソースコードを、再度ZIPファイルへ圧縮します。`func.cs`と`nuget.txt`がルートディレクトリに含まれるように圧縮する必要があります。
 
@@ -185,11 +209,17 @@ public class NhnFunction
 zip my-function.zip func.cs nuget.txt
 ```
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Cloud Functionsコンソールでのアップロード
 - 関数を作成または修正する際に、**ユーザーローカル環境**方式を選択します。
 - **ファイルを選択**をクリックし、作成した`my-function.zip`ファイルをアップロードします。
 
+<a id="process-by-http-method"></a>
+
 ## HTTPメソッド別の処理
+
+<a id="process-get-request"></a>
 
 ### GETリクエストの処理
 ```csharp
@@ -219,6 +249,8 @@ public class NhnFunction
     }
 }
 ```
+
+<a id="process-post-request"></a>
 
 ### POSTリクエストの処理
 ```csharp
@@ -272,6 +304,8 @@ public class NhnFunction
 }
 ```
 
+<a id="manage-package-nugettxt"></a>
+
 ## パッケージ管理(`nuget.txt`)
 
 依存関係(NuGetパッケージ)の管理には、`nuget.txt`ファイルを使用します。必要なパッケージを1行に1つずつ記述してください。
@@ -280,6 +314,8 @@ public class NhnFunction
 # nuget.txt
 Microsoft.Extensions.Configuration:8.0.0
 ```
+
+<a id="example-of-configuration-management"></a>
 
 ### 設定管理の例
 ```csharp
@@ -362,6 +398,8 @@ public class NhnFunction
 }
 ```
 
+<a id="configure-entry-point"></a>
+
 ## エントリーポイントの設定
 
 エントリーポイントは**ファイル名**です。(拡張子を除く)
@@ -370,6 +408,8 @@ public class NhnFunction
 - Entry Point: `func`
 
 **重要**:クラス名は`NhnFunction`である必要があり、関数として機能するメソッドは`public string Execute(NhnContext context)`というシグネチャを持つ必要があります。
+
+<a id="caution"></a>
 
 ### 注意事項
 - **パッケージバージョン**: `nuget.txt`でパッケージのバージョンを明記できます。(例: `Newtonsoft.Json:9.0.1`)

--- a/ja/code-template-go-guide.md
+++ b/ja/code-template-go-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=9b45d499c0b7 -->
+
 ## Compute > Cloud Functions > コードテンプレートガイド > Go
 
 このドキュメントでは、NHN CloudのCloud FunctionsサービスでGoを使用して関数を開発する方法を詳しく説明します。
+
+<a id="template-information"></a>
 
 ## テンプレート情報
 | 項目             | 値                                       |
@@ -9,7 +13,11 @@
 | **ファイル名**         | functions.go                             |
 | **Entry Point** | Handler                                  |
 
+<a id="basic-template"></a>
+
 ## 基本テンプレート
+
+<a id="hello-world-example"></a>
 
 ### Hello Worldの例
 最も基本的な関数の形式です。
@@ -37,6 +45,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 ```
+
+<a id="context-object"></a>
 
 ### Contextオブジェクト
 Goの関数では、`http.ResponseWriter`と`*http.Request`を通じてHTTPのリクエストとレスポンスを処理します。
@@ -74,12 +84,18 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## テンプレートファイルのダウンロードと活用
+
+<a id="template-download"></a>
 
 ### テンプレートのダウンロード
 Cloud Functionsが提供するGoテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [go.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/go/go.zip)
+
+<a id="template-file-structure"></a>
 
 ### テンプレートのファイル構造
 ダウンロードしたテンプレートファイルの構造は次のとおりです。
@@ -89,6 +105,8 @@ go.zip
 ├── functions.go     # メイン関数ファイル
 └── go.mod          # 依存関係管理ファイル
 ```
+
+<a id="functionsgo"></a>
 
 #### functions.go
 基本的なfakeデータ生成関数が含まれています。
@@ -116,6 +134,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+<a id="gomod"></a>
+
 #### go.mod
 ```go
 module example.com/ncf
@@ -125,7 +145,11 @@ go 1.22
 require github.com/brianvoe/gofakeit/v6 v6.28.0
 ```
 
+<a id="local-development-process"></a>
+
 ### ローカルでの開発プロセス
+
+<a id="unzip"></a>
 
 #### 1. 解凍
 ```bash
@@ -135,6 +159,8 @@ unzip go.zip -d my-function
 # 作業ディレクトリへ移動
 cd my-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. 関数コードの修正
 `functions.go`ファイルを、目的のロジックに合わせて修正します。
@@ -185,6 +211,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. ZIPファイルへ圧縮
 修正したコードを、再度ZIPファイルへ圧縮します。
 
@@ -202,10 +230,16 @@ zip my-function.zip functions.go go.mod
 zip -r my-function.zip . -x "*.git*" "go.sum" "test.go"
 ```
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Cloud Functionsコンソールでのアップロード
 > 関数を作成または修正する際に、ユーザーのローカル環境にあるファイルをアップロードする場合に使用します。(コンソール利用ガイド参照)
 
+<a id="cautions-for-upload"></a>
+
 ### アップロード時の注意事項
+
+<a id="zip-file-structure"></a>
 
 #### ZIPファイルの構造
 - ZIPファイルのルートに、直接`.go`ファイルと`go.mod`を配置する必要があります。
@@ -227,9 +261,13 @@ my-function.zip
     └── go.mod
 ```
 
+<a id="file-size-limit"></a>
+
 #### ファイルサイズの制限
 - ZIPファイルのサイズは100MiB以下に制限されます。
 - `go.sum`ファイルは含めないでください。
+
+<a id="files-to-exclude"></a>
 
 #### 除外するファイル
 ```bash
@@ -243,7 +281,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
+<a id="process-by-http-method"></a>
+
 ## HTTPメソッド別の処理
+
+<a id="process-get-request"></a>
 
 ### GETリクエストの処理
 ```go
@@ -282,6 +324,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(response)
 }
 ```
+
+<a id="process-post-request"></a>
 
 ### POSTリクエストの処理
 ```go
@@ -354,7 +398,11 @@ func getOrDefault(value, defaultValue string) string {
 }
 ```
 
+<a id="manage-packages"></a>
+
 ## パッケージ管理
+
+<a id="write-gomod"></a>
 
 ### go.modの作成
 依存関係の管理には、`go.mod`ファイルを作成します。
@@ -369,6 +417,8 @@ require (
     github.com/gorilla/mux v1.8.1
 )
 ```
+
+<a id="example-of-external-api-call"></a>
 
 ### 外部API呼び出しの例
 ```go
@@ -422,6 +472,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(response)
 }
 ```
+
+<a id="data-processing-example"></a>
 
 ### データ処理の例
 ```go
@@ -516,13 +568,19 @@ func normalizeName(name string) string {
 }
 ```
 
+<a id="configure-entry-point"></a>
+
 ## エントリーポイントの設定
+
+<a id="single-function"></a>
 
 ### 単一関数
 関数名をエントリーポイントとして使用します。
 
 関数名: `Handler`
 Entry Point: `Handler`
+
+<a id="multiple-functions"></a>
 
 ### 複数関数
 1つのファイルで複数の関数を定義できます。
@@ -564,7 +622,11 @@ func UpdateUser(w http.ResponseWriter, r *http.Request) {
 - `CreateUser`
 - `UpdateUser`
 
+<a id="caution"></a>
+
 ## 注意事項
+
+<a id="go-version"></a>
 
 ### Goのバージョン
 | バージョン | サポート終了日 | 利用終了日 |
@@ -573,6 +635,8 @@ func UpdateUser(w http.ResponseWriter, r *http.Request) {
 | 1.24 | - | - |
 | 1.23 | 2026-02-21 | 2026-08-21 |
 | 1.22 | 2026-01-28 | 2026-07-28 |
+
+<a id="go-version-support-policy"></a>
 
 #### Goバージョンサポートポリシー
 Cloud Functionsは、Goの公式リリース方針に従います。Goは年2回(1月、7月)新しいメジャーバージョンをリリースしており、各バージョンは最新の2つのメジャーバージョンまでサポートされます。

--- a/ja/code-template-java-guide.md
+++ b/ja/code-template-java-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=65e9891c8f54 -->
+
 ## Compute > Cloud Functions > コードテンプレートガイド > Java
 
 このドキュメントでは、NHN CloudのCloud FunctionsサービスでJavaを使用して関数を開発する方法を詳しく説明します。
+
+<a id="template-information"></a>
 
 ## テンプレート情報
 | 項目       | 値                |
@@ -9,7 +13,11 @@
 | **ファイル名**    | HelloWorld.java    |
 | **Entry Point** | example.HelloWorld |
 
+<a id="basic-template"></a>
+
 ## 基本テンプレート
+
+<a id="hello-world-example"></a>
 
 ### Hello Worldの例
 最も基本的な関数の形式です。
@@ -28,6 +36,8 @@ public class HelloWorld {
 
 }
 ```
+
+<a id="context-object-requestentity"></a>
 
 ### Contextオブジェクト(RequestEntity)
 Javaの関数では、Springの`RequestEntity`を通じてHTTPリクエスト情報にアクセスできます。
@@ -62,12 +72,18 @@ public class HelloWorld {
 }
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## テンプレートファイルのダウンロードと活用
+
+<a id="template-download"></a>
 
 ### テンプレートのダウンロード
 Cloud Functionsが提供するJavaテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [java.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/java/java.zip)
+
+<a id="template-file-structure"></a>
 
 ### テンプレートのファイル構造
 ダウンロードしたテンプレートは、Mavenのプロジェクト構造に従っています。
@@ -82,7 +98,11 @@ java.zip
                 └── HelloWorld.java
 ```
 
+<a id="local-development-process"></a>
+
 ### ローカルでの開発プロセス
+
+<a id="unzip"></a>
 
 #### 1. 解凍
 ```bash
@@ -92,6 +112,8 @@ unzip java.zip -d my-java-function
 # 作業ディレクトリへ移動
 cd my-java-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. 関数コードの修正
 `src/main/java/example/HelloWorld.java`ファイルを、目的のロジックに合わせて修正します。
@@ -144,6 +166,8 @@ public class HelloWorld {
 }
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. ZIPファイルへ圧縮
 修正したソースコードを、再度ZIPファイルへ圧縮します。`pom.xml`ファイルと`src`ディレクトリがルートディレクトリに含まれるように圧縮する必要があります。
 
@@ -161,9 +185,13 @@ zip -r my-function.zip pom.xml src
 zip -r my-function.zip . -x "*.git*" "target/*" "*.log"
 ```
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Cloud Functionsコンソールでのアップロード
 - 関数を作成または修正する際に、**ユーザーローカル環境**方式を選択します。
 - **ファイルを選択**をクリックし、作成した`my-function.zip`ファイルをアップロードします。
+
+<a id="cautions-for-upload"></a>
 
 ### アップロード時の注意事項
 - **アップロードファイル**:ソースコードと`pom.xml`が含まれた**ZIPファイル**をアップロードする必要があります。
@@ -171,7 +199,11 @@ zip -r my-function.zip . -x "*.git*" "target/*" "*.log"
 - **除外するファイル**: `target`ディレクトリや`.git`ディレクトリなど、不要なファイルは含めないでください。
 - **ファイルサイズ**: ZIPファイルのサイズは100MiB以下に制限されます。
 
+<a id="process-by-http-method"></a>
+
 ## HTTPメソッド別の処理
+
+<a id="process-get-request"></a>
 
 ### GETリクエストの処理
 ```java
@@ -208,6 +240,8 @@ public class GetHandler {
     }
 }
 ```
+
+<a id="process-post-request"></a>
 
 ### POSTリクエストの処理
 ```java
@@ -250,6 +284,8 @@ public class PostHandler {
 }
 ```
 
+<a id="manage-package-pomxml"></a>
+
 ## パッケージ管理(`pom.xml`)
 
 依存関係の管理には、`pom.xml`ファイルを修正します。`dependencies`セクションに必要なライブラリを追加すると、関数のアップロード時にCloud Functionsが自動で依存関係をダウンロードし、ビルドに含めます。
@@ -272,6 +308,8 @@ public class PostHandler {
     </dependency>
 </dependencies>
 ```
+
+<a id="example-of-using-external-libraries"></a>
 
 ### 外部ライブラリの活用例
 ```java
@@ -307,7 +345,11 @@ public class StringUtilsHandler {
 }
 ```
 
+<a id="entry-point-configuration"></a>
+
 ## エントリーポイントの設定
+
+<a id="single-class"></a>
 
 ### 単一クラス
 `パッケージ名。クラス名`をエントリーポイントとして使用します。
@@ -316,6 +358,8 @@ public class StringUtilsHandler {
 - クラス名: `HelloWorld`
 - Entry Point: `example.HelloWorld`
 - **重要**:関数として機能するメソッドは、`public ResponseEntity<?> call(RequestEntity<?> req)`というシグネチャを持つ必要があります。
+
+<a id="caution"></a>
 
 ### 注意事項
 - **プロジェクト構造**: `src/main/java`のディレクトリ構造を維持する必要があります。

--- a/ja/code-template-node-guide.md
+++ b/ja/code-template-node-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=ce91cd7cb2f1 -->
+
 ## Compute > Cloud Functions > コードテンプレートガイド > Node.js
 
 このドキュメントでは、NHN CloudのCloud FunctionsサービスでNode.jsを使用して関数を開発する方法を詳しく説明します。
+
+<a id="template-information"></a>
 
 ## テンプレート情報
 | 項目       | 値                |
@@ -9,7 +13,11 @@
 | **ファイル名**    | hello.js           |
 | **Entry Point** | hello            |
 
+<a id="basic-template"></a>
+
 ## 基本テンプレート
+<a id="hello-world-example"></a>
+
 ### Hello Worldの例
 最も基本的な関数の形式です。
 
@@ -21,6 +29,8 @@ module.exports = async (context) => {
     };
 }
 ```
+
+<a id="context-object"></a>
 
 ### Contextオブジェクト
 関数に渡される`context`オブジェクトには、以下の情報が含まれます。
@@ -42,12 +52,18 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## テンプレートファイルのダウンロードと活用
+
+<a id="template-download"></a>
 
 ### テンプレートのダウンロード
 Cloud Functionsが提供するNode.jsテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [nodejs.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/nodejs/nodejs.zip)
+
+<a id="template-file-structure"></a>
 
 ### テンプレートのファイル構造
 ダウンロードしたテンプレートファイルの構造は次のとおりです。
@@ -57,6 +73,8 @@ nodejs.zip
 ├── hello.js          # メイン関数ファイル
 └── package.json      # 依存関係管理ファイル
 ```
+
+<a id="hellojs"></a>
 
 #### hello.js
 基本的なHello World関数が含まれています。
@@ -69,12 +87,18 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="packagejson"></a>
+
 #### package.json
 ```json
 {}
 ```
 
+<a id="local-development-process"></a>
+
 ### ローカルでの開発プロセス
+
+<a id="unzip"></a>
 
 #### 1. 解凍
 ```bash
@@ -84,6 +108,8 @@ unzip nodejs.zip -d my-function
 # 作業ディレクトリへ移動
 cd my-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. 関数コードの修正
 `hello.js`ファイルを、目的のロジックに合わせて修正します。
@@ -127,6 +153,8 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. ZIPファイルへ圧縮
 修正したコードを、再度ZIPファイルへ圧縮します。
 
@@ -144,10 +172,16 @@ zip my-function.zip hello.js package.json
 zip -r my-function.zip . -x "*.git*" "node_modules/*" "test.js"
 ```
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Cloud Functionsコンソールでのアップロード
 > 関数を作成または修正する際に、ユーザーのローカル環境にあるファイルをアップロードする場合に使用します。(コンソール利用ガイド参照)
 
+<a id="cautions-for-upload"></a>
+
 ### アップロード時の注意事項
+
+<a id="zip-file-structure"></a>
 
 #### ZIPファイルの構造
 - ZIPファイルのルートに、直接`.js`ファイルと`package.json`を配置する必要があります。
@@ -169,9 +203,13 @@ my-function.zip
     └── package.json
 ```
 
+<a id="file-size-limit"></a>
+
 #### ファイルサイズの制限
 - ZIPファイルのサイズは100MiB以下に制限されます。
 - `node_modules`フォルダは含めないでください。(依存関係は`package.json`で管理)
+
+<a id="files-to-exclude"></a>
 
 #### 除外するファイル
 ```bash
@@ -185,7 +223,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
+<a id="process-by-http-method"></a>
+
 ## HTTPメソッド別の処理
+
+<a id="process-get-request"></a>
 
 ### GETリクエストの処理
 ```javascript
@@ -212,6 +254,8 @@ module.exports = async (context) => {
     };
 }
 ```
+
+<a id="process-post-request"></a>
 
 ### POSTリクエストの処理
 ```javascript
@@ -258,7 +302,11 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="manage-packages"></a>
+
 ## パッケージ管理
+
+<a id="write-packagejson"></a>
 
 ### package.jsonの作成
 依存関係の管理には、`package.json`ファイルを作成します。
@@ -277,6 +325,8 @@ module.exports = async (context) => {
   }
 }
 ```
+
+<a id="example-of-external-api-call"></a>
 
 ### 外部API呼び出しの例
 ```javascript
@@ -327,6 +377,8 @@ module.exports = async (context) => {
     }
 }
 ```
+
+<a id="data-processing-example"></a>
 
 ### データ処理の例
 ```javascript
@@ -382,13 +434,19 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="configure-entry-point"></a>
+
 ## エントリーポイントの設定
+
+<a id="single-function"></a>
 
 ### 単一関数
 ファイル名をエントリーポイントとして使用します。
 
 ファイル名: `hello.js`
 Entry Point: `hello`
+
+<a id="multiple-functions"></a>
 
 ### 複数関数
 1つのファイルで複数の関数をエクスポートできます。
@@ -425,6 +483,8 @@ module.exports.updateUser = async (context) => {
 - `users.createUser`
 - `users.updateUser`
 
+<a id="entry-point-restriction"></a>
+
 ### エントリーポイントの制限事項
 - **サブディレクトリの指定不可**:ルートディレクトリのサブディレクトリにあるファイルは、エントリーポイントとして指定できません。
 
@@ -443,7 +503,11 @@ modules/auth.js → modules.auth ❌
 
 全ての関数ファイルは、ZIPファイルのルートレベルに配置する必要があります。
 
+<a id="caution"></a>
+
 ## 注意事項
+
+<a id="commonjs-vs-es-modules"></a>
 
 ### CommonJS vs ES Modules
 現在、Cloud FunctionsはCommonJS方式のみをサポートしています。
@@ -463,6 +527,8 @@ export default async (context) => { // ❌サポートしていません
     // 関数ロジック
 };
 ```
+
+<a id="considerations-for-memory-and-execution-time"></a>
 
 ### メモリ及び実行時間に関する考慮事項
 - 関数は、限られたメモリと実行時間内で動作する必要があります。

--- a/ja/code-template-python-guide.md
+++ b/ja/code-template-python-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=577d9bcb43c9 -->
+
 ## Compute > Cloud Functions > コードテンプレートガイド > Python
 
 このドキュメントでは、NHN CloudのCloud FunctionsサービスでPythonを使用して関数を開発する方法を詳しく説明します。
+
+<a id="template-information"></a>
 
 ## テンプレート情報
 | 項目             | 値               |
@@ -9,7 +13,11 @@
 | **ファイル名**         | user.py          |
 | **Entry Point** | user.main        |
 
+<a id="basic-template"></a>
+
 ## 基本テンプレート
+
+<a id="hello-world-example"></a>
 
 ### Hello Worldの例
 最も基本的な関数の形式です。
@@ -28,6 +36,8 @@ document = """
 def main():
     return yaml.dump(yaml.safe_load(document))
 ```
+
+<a id="context-object"></a>
 
 ### Contextオブジェクト
 Pythonの関数では、Flaskのrequestオブジェクトを通じてHTTPリクエスト情報にアクセスできます。
@@ -57,12 +67,18 @@ def main():
     }
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## テンプレートファイルのダウンロードと活用
+
+<a id="template-download"></a>
 
 ### テンプレートのダウンロード
 Cloud Functionsが提供するPythonテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [python.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/python/python.zip)
+
+<a id="template-file-structure"></a>
 
 ### テンプレートのファイル構造
 ダウンロードしたテンプレートファイルの構造は以下の通りです:
@@ -72,6 +88,8 @@ python.zip
 ├── user.py          # メイン関数ファイル
 └── requirements.txt # 依存関係管理ファイル
 ```
+
+<a id="userpy"></a>
 
 #### user.py
 基本的なYAML処理関数が含まれています。
@@ -90,12 +108,18 @@ def main():
     return yaml.dump(yaml.safe_load(document))
 ```
 
+<a id="requirementstxt"></a>
+
 #### requirements.txt
 ```txt
 pyyaml
 ```
 
+<a id="local-development-process"></a>
+
 ### ローカルでの開発プロセス
+
+<a id="unzip"></a>
 
 #### 1. 解凍
 ```bash
@@ -105,6 +129,8 @@ unzip python.zip -d my-function
 # 作業ディレクトリへ移動
 cd my-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. 関数コードの修正
 `user.py`ファイルを、目的のロジックに合わせて修正します。
@@ -147,6 +173,8 @@ def main():
         }, ensure_ascii=False)
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. ZIPファイルへ圧縮
 修正したコードを、再度ZIPファイルへ圧縮します。
 
@@ -164,10 +192,16 @@ zip my-function.zip user.py requirements.txt
 zip -r my-function.zip . -x "*.git*" "__pycache__/*" "*.pyc" "test.py"
 ```
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Cloud Functionsコンソールでのアップロード
 > 関数を作成または修正する際に、ユーザーのローカル環境にあるファイルをアップロードする場合に使用します。(コンソール利用ガイド参照)
 
+<a id="cautions-for-upload"></a>
+
 ### アップロード時の注意事項
+
+<a id="zip-file-structure"></a>
 
 #### ZIPファイルの構造
 - ZIPファイルのルートに、直接`.py`ファイルと`requirements.txt`を配置する必要があります。
@@ -189,9 +223,13 @@ my-function.zip
     └── requirements.txt
 ```
 
+<a id="file-size-limit"></a>
+
 #### ファイルサイズの制限
 - ZIPファイルのサイズは100MiB以下に制限されます。
 - `__pycache__`フォルダは含めないでください。
+
+<a id="files-to-exclude"></a>
 
 #### 除外するファイル
 ```bash
@@ -206,7 +244,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
+<a id="process-by-http-method"></a>
+
 ## HTTPメソッド別の処理
+
+<a id="process-get-request"></a>
 
 ### GETリクエストの処理
 ```python
@@ -230,6 +272,8 @@ def main():
 
     return json.dumps(result, ensure_ascii=False)
 ```
+
+<a id="process-post-request"></a>
 
 ### POSTリクエストの処理
 ```python
@@ -274,7 +318,11 @@ def main():
         }, ensure_ascii=False), 400
 ```
 
+<a id="manage-packages"></a>
+
 ## パッケージ管理
+
+<a id="write-requirementstxt"></a>
 
 ### requirements.txtの作成
 依存関係の管理には、`requirements.txt`ファイルを作成します。
@@ -284,6 +332,8 @@ pyyaml
 requests>=2.28.0
 python-dateutil>=2.8.0
 ```
+
+<a id="example-of-external-api-call"></a>
 
 ### 外部API呼び出しの例
 ```python
@@ -326,6 +376,8 @@ def main():
             'details': str(e)
         }, ensure_ascii=False), 500
 ```
+
+<a id="data-processing-example"></a>
 
 ### データ処理の例
 ```python
@@ -381,7 +433,11 @@ def normalize_name(name):
     return name.strip().title()
 ```
 
+<a id="configure-entry-point"></a>
+
 ## エントリーポイントの設定
+
+<a id="single-function"></a>
 
 ### 単一関数
 `ファイル名.関数名`をエントリーポイントとして使用します。
@@ -389,6 +445,8 @@ def normalize_name(name):
 ファイル名: `user.py`
 関数名: `main`
 Entry Point: `user.main`
+
+<a id="multiple-functions"></a>
 
 ### 複数関数
 1つのファイルで複数の関数を定義できます。
@@ -416,7 +474,11 @@ def update_user():
 - `handlers.create_user`
 - `handlers.update_user`
 
+<a id="caution"></a>
+
 ## 注意事項
+
+<a id="unsupported-packages"></a>
 
 ### サポートしていないパッケージ
 現在、以下の特徴を持つ複雑なパッケージはサポートしていません。
@@ -431,6 +493,8 @@ def update_user():
 - `pyyaml` (YAML処理)
 - `python-dateutil` (日付・時刻処理)
 - `pillow` (画像処理 - 基本機能)
+
+<a id="considerations-for-memory-and-execution-time"></a>
 
 ### メモリ及び実行時間に関する考慮事項
 - 関数は、限られたメモリと実行時間内で動作する必要があります。

--- a/ja/code-template-ruby-guide.md
+++ b/ja/code-template-ruby-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=1d5361d8d187 -->
+
 ## Compute > Cloud Functions > コードテンプレートガイド > Ruby
 
 このドキュメントでは、NHN CloudのCloud FunctionsサービスでRubyを使用して関数を開発する方法を詳しく説明します。
+
+<a id="template-information"></a>
 
 ## テンプレート情報
 | 項目             | 値       |
@@ -9,7 +13,11 @@
 | **ファイル名**         | parse.rb |
 | **Entry Point** | handler  |
 
+<a id="basic-template"></a>
+
 ## 基本テンプレート
+
+<a id="hello-world-example"></a>
 
 ### Hello Worldの例
 最も基本的な関数の形式です。
@@ -29,6 +37,8 @@ def handler(context)
   Rack::Response.new([msg, "\n"]).finish
 end
 ```
+
+<a id="context-object"></a>
 
 ### Contextオブジェクト
 関数に渡される`context`オブジェクトを通じて、ロガーやリクエスト情報にアクセスできます。
@@ -64,12 +74,18 @@ def handler(context)
 end
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## テンプレートファイルのダウンロードと活用
+
+<a id="template-download"></a>
 
 ### テンプレートのダウンロード
 Cloud Functionsが提供するRubyテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [ruby.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/ruby/ruby.zip)
+
+<a id="template-file-structure"></a>
 
 ### テンプレートのファイル構造
 ダウンロードしたテンプレートファイルの構造は次のとおりです。
@@ -80,7 +96,11 @@ ruby.zip
 └── Gemfile
 ```
 
+<a id="local-development-process"></a>
+
 ### ローカルでの開発プロセス
+
+<a id="unzip"></a>
 
 #### 1. 解凍
 ```bash
@@ -90,6 +110,8 @@ unzip ruby.zip -d my-function
 # 作業ディレクトリへ移動
 cd my-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. 関数コードの修正
 `parse.rb`ファイルを、目的のロジックに合わせて修正します。
@@ -135,6 +157,8 @@ def handler(context)
 end
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. ZIPファイルへ圧縮
 修正したソースコードを、再度ZIPファイルへ圧縮します。`parse.rb`と`Gemfile`がルートディレクトリに含まれるように圧縮する必要があります。
 
@@ -143,9 +167,13 @@ zip my-function.zip parse.rb Gemfile Gemfile.lock
 ```
 **参考**: `Gemfile.lock`ファイルはデプロイ段階で自動的に生成されますが、依存関係の正確なバージョンを事前に確認または固定したい場合は、ローカルで`bundle install`を実行して直接生成した後、一緒に圧縮できます。`Gemfile.lock`ファイルが含まれている場合、そのファイルに明記されたバージョンを使用してビルドされます。
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Cloud Functionsコンソールでのアップロード
 - 関数を作成または修正する際に、**ユーザーローカル環境**方式を選択します。
 - **ファイルを選択**をクリックし、作成した`my-function.zip`ファイルをアップロードします。
+
+<a id="cautions-for-upload"></a>
 
 ### アップロード時の注意事項
 - **アップロードファイル**: `*.rb`、`Gemfile`が含まれた**ZIPファイル**をアップロードする必要があります。
@@ -153,7 +181,11 @@ zip my-function.zip parse.rb Gemfile Gemfile.lock
 - **ZIPファイルの構造**: ZIPファイルのルートに各ファイルを配置する必要があります。
 - **ファイルサイズ**: ZIPファイルのサイズは100MiB以下に制限されます。
 
+<a id="process-post-request"></a>
+
 ## HTTPメソッド別の処理
+
+<a id="process-get-request"></a>
 
 ### GETリクエストの処理
 ```ruby
@@ -178,6 +210,8 @@ def handler(context)
   Rack::Response.new([response_data], 200, { 'Content-Type' => 'application/json' }).finish
 end
 ```
+
+<a id="process-post-request-2"></a>
 
 ### POSTリクエストの処理
 ```ruby
@@ -214,6 +248,8 @@ def handler(context)
 end
 ```
 
+<a id="manage-package-gemfile"></a>
+
 ## パッケージ管理(`Gemfile`)
 
 依存関係(Gem)の管理には`Gemfile`を使用します。必要なGemを追加し、`bundle install`を実行して`Gemfile.lock`を生成します。
@@ -227,6 +263,8 @@ source "https://rubygems.org"
 gem "nokogiri", "~> 1.18" # XML/HTMLパーサー
 gem "httparty", "~> 0.23" # HTTPクライアント
 ```
+
+<a id="example-of-external-api-call"></a>
 
 ### 外部API呼び出しの例
 ```ruby
@@ -268,6 +306,8 @@ def handler(context)
 end
 ```
 
+<a id="configure-entry-point"></a>
+
 ## エントリーポイントの設定
 
 エントリーポイントには関数名を使用します。
@@ -275,6 +315,8 @@ end
 - ファイル名: `parse.rb`
 - 関数名: `handler`
 - Entry Point: `handler`
+
+<a id="caution"></a>
 
 ### 注意事項
 - **Bundlerのバージョン**: `Gemfile.lock`を作成する際には、Bundler 2.6.2以上のバージョンの使用を推奨します。

--- a/ja/console-guide.md
+++ b/ja/console-guide.md
@@ -1,14 +1,22 @@
+<!-- pre-align:aligned sig=fda183656939 -->
+
 ## Compute > Cloud Functions > コンソール使用ガイド
 この文書では、NHN Cloud Functionsコンソールで関数を作成し、管理する方法について説明します。
 
+<a id="manage-functions"></a>
+
 ## 関数管理
 関数を作成、修正、削除、コピーできます。
+
+<a id="create-functions"></a>
 
 ### 関数作成
 関数設定を行いコードを作成してビルドした後、**作成**ボタンをクリックすると、最後にビルドしたパッケージで関数が作成されます。
 
 ![console-guide-07](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-01.png)
 ![console-guide-08](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-02.png)
+
+<a id="function-settings"></a>
 
 #### 関数設定
 <table class="it">
@@ -87,6 +95,8 @@
 <br>
 
 
+<a id="code-writing"></a>
+
 #### コード作成
 
 ![console-guide-09](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-03.png)
@@ -150,20 +160,30 @@
 
 > **[参考]** <br>ビルドボタンを通じて作成されたパッケージは、関数の作成/修正時に最後にビルドされたパッケージが関数バージョンとして連携されます。関数作成前に少なくとも1回以上ビルドを実行する必要があります。
 
+<a id="modify-functions"></a>
+
 ### 関数修正
 既存の関数の設定とコードを修正するために、**修正**ボタンを クリックして 関数を修正します。
+
+<a id="non-modifiable-item"></a>
 
 #### 修正不可項目
 - 名前、ランタイム環境
     - 該当項目を除く全ての項目を修正できます。
     
+<a id="source-code"></a>
+
 #### ソースコード
 - コードエディタを使用する場合既存コードが読み込まれます。
 - ユーザーローカル環境のZIPファイルをアップロードして関数を生成した場合、コードエディタに変更するとZIPファイルを表示せず、基本テンプレートコードが読み込まれます。
 
+<a id="delete-a-function"></a>
+
 ### 関数削除
 ![console-guide-14](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-06.png)
 既存の関数を選択して削除します。一度に複数の関数を削除可能です。
+
+<a id="copy-a-function"></a>
 
 ### 関数コピー
 ![console-guide-13](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-07.png)
@@ -171,27 +191,39 @@
 - トリガーはコピーされません。(HTTPトリガーはデフォルトで提供)
 - バージョンは現在適用されているバージョンのみコピーされます。
 
+<a id="about-functions"></a>
+
 ## 関数情報
+<a id="list-of-functions"></a>
+
 ### 関数リスト
 ![console-guide-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-08.png)
 - ユーザーが作成した関数リストを確認できます。
 - ビルドの状態は 現在のバージョンのビルド状態を表示します。
+
+<a id="basic-information-of-functions"></a>
 
 ### 関数基本情報
 ![console-guide-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-09.png)
 - 関数の基本情報を確認できます。
 - ログ管理項目で **Log & Crash Search** ボタンをクリックし、Log & Crash Searchサービスへ移動してログを確認できます。
 
+<a id="function-versioning"></a>
+
 ### 関数バージョン管理
 ![console-guide-15](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2026-01-27/console-guide-jp-15.png)
 - 関数のバージョンを管理できます。
 - 作成された全てのバージョンの履歴を確認し、以前のバージョンにロールバックできます。
+
+<a id="versioning-overview"></a>
 
 #### バージョン管理の概要
 関数作成/修正画面で **ビルド** ボタンをクリックし、コードをビルドするとパッケージが作成されます。
 - 関数の作成/修正時に最後にビルドしたパッケージが関数バージョンとして連携されます。
 - 各バージョンは独立して管理され、テストしたバージョンをそのまま関数に適用できます。
 - 関数作成時、少なくとも1回以上ビルドを実行する必要があります。
+
+<a id="version-information"></a>
 
 #### バージョン情報
 <table class="it">
@@ -222,6 +254,8 @@
     </tr>
 </table>
 
+<a id="deploy-versions"></a>
+
 #### バージョン配布
 - バージョンリストから配布するバージョンを選択し、**バージョン配布**ボタンをクリックすると、該当バージョンで関数が更新されます。
 - 現在適用されているバージョンは選択できません。
@@ -230,6 +264,8 @@
 
 > **[参考]**
 > <br>バージョン配布時に確認ポップアップが表示され、成功するとバージョンリストが自動的に更新されます。
+<a id="delete-versions"></a>
+
 #### バージョン削除
 - バージョンリストから削除するバージョンを選択し、**バージョン削除**ボタンをクリックすると、該当バージョンが削除されます。
 - 現在適用されているバージョンは削除できません。
@@ -238,11 +274,15 @@
 
 > **[参考]**
 > <br>バージョン削除時に確認ポップアップが表示され、削除されたバージョンは復元できません。
+<a id="constraints"></a>
+
 #### 制約事項
 - 関数作成/修正画面でビルドしたパッケージは、関数の作成/修正をキャンセルすると関数バージョンとして連携されません。
 - 関数削除時、該当関数と連携された全てのバージョンも一緒に削除されます。
 - 関数コピー時、元の関数の現在適用されているバージョンのみコピーされ、全てのバージョン履歴はコピーされません。
 - 関数作成時には複数のランタイムでビルドできますが、関数修正時には作成時に選択したランタイムでのみビルドできます。
+
+<a id="manage-function-triggers"></a>
 
 ### 関数トリガー管理
 - 関数を実行できるトリガーを管理できます。
@@ -255,14 +295,20 @@
     - 例: `https://{userdomain}/{関数名}`
     - Method : GET, POST
 
+<a id="createedit-triggers"></a>
+
 #### トリガー作成/修正
 - Timer
     - Value: Cron文字列で周期を入力します。
 - API Gateway
     - API Gatewayサービスを利用してHTTPエンドポイントを追加できます。
         
+<a id="delete-triggers"></a>
+
 #### トリガー削除
 - 複数のトリガーを選択して削除できます。デフォルトのトリガーであるHTTPトリガーは削除できません。
+
+<a id="monitor-functions"></a>
 
 ### 関数モニタリング
 ![console-guide-06](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-11.png)

--- a/ja/overview.md
+++ b/ja/overview.md
@@ -1,5 +1,9 @@
+<!-- pre-align:aligned sig=92acb111e0a0 -->
+
 ## Compute > Cloud Functions > 概要
 ユーザーは関数単位でコードを作成でき、特定のイベントが発生した際に定義された関数が自動で実行され、必要な処理を行います。サーバー管理やインフラ設定を行うことなく、アプリケーションロジックに専念することができます。
+
+<a id="features"></a>
 
 ### 特徴
 - コスト効率性
@@ -13,15 +17,21 @@
     - 様々な言語とランタイムをサポートします。
     - イベントベースのアーキテクチャにより、多様な活用が可能です。
 
+<a id="main-features"></a>
+
 ### 主な機能
 - 様々な言語(環境)を提供します。
 - **コードエディタ**を使用して、簡単な関数単位コードを作成できます。
 - 関数を実行できるHTTPSエンドポイントを標準で提供します。
 - 関数を一定間隔で繰り返し実行できます。
 
+<a id="two-modes-available"></a>
+
 ### 2つのモードを提供
 - Pool Manager
 - New Deployment
+<a id="pool-manager"></a>
+
 #### Pool Manager
 - 関数が実行される際にのみインスタンスが作成され、リソースを使用します。
 - 一定期間関数が実行されない場合、インスタンスは消滅し、リソース使用量は0になります。
@@ -29,12 +39,16 @@
 
 ![overview-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_1_ja.png)
 
+<a id="new-deployment"></a>
+
 #### New Deployment
 - 関数を作成すると、すぐにインスタンスが作成され、一定量のリソースを継続して使用します。
 - 高速な応答のためにインスタンス作成を維持します。
 - 関数実行リクエストが多く、迅速な応答が必要な場合に使用します。
 
 ![overview-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_2_ja.png)
+
+<a id="supported-languages"></a>
 
 ### サポート言語
 
@@ -56,6 +70,8 @@
 |        | 2.6.1(利用停止)     | 2024-01-30 | 2025-01-30 |
 | .NET   | 8                 | 2026-11-10 | 2027-11-10 |
 |        | 7(利用停止)         | 2024-05-14 | 2025-05-14 |
+
+<a id="trigger"></a>
 
 ### Trigger
 - HTTP Trigger

--- a/ja/release-notes.md
+++ b/ja/release-notes.md
@@ -1,22 +1,38 @@
+<!-- pre-align:aligned sig=06519d7ca905 -->
+
 ## Compute > Cloud Functions > リリースノート
 
+<a id="april-14-2026"></a>
+
 ### 2026. 04. 14.
+
+<a id="added-features"></a>
 
 #### 機能追加
 - Public API v1.0追加
   - APIでCloud Functionsを利用できます。
   
+<a id="january-27-2026"></a>
+
 ### 2026. 01. 27.
+
+<a id="january-27-2026-added-features"></a>
 
 #### 機能追加
 - 関数バージョン管理機能の追加
   - ビルドしたパッケージをバージョンとして管理し、以前のバージョンにロールバックできます。
     
+<a id="november-25-2025"></a>
+
 ### 2025. 11. 25.
+
+<a id="november-25-2025-added-features"></a>
 
 #### 機能追加
 - API Gatewayトリガーの追加
   - 同一プロジェクトのAPI Gatewayサービスを活用してAPI Gatewayトリガーを作成できます。
+
+<a id="feature-updates"></a>
 
 #### 機能改善
 - ランタイム環境の最新バージョンの追加及び一部バージョンの使用中止
@@ -26,7 +42,11 @@
   - Ruby 2.6.1の使用中止、Ruby 3.4.5の追加
   - .NET 7の使用中止、.NET 8の追加
     
+<a id="july-29-2025"></a>
+
 ### 2025. 07. 29.
+
+<a id="launch-cloud-functions-service"></a>
 
 #### Cloud Functionsサービスリリース
 - ユーザーは関数単位でコードを作成でき、特定のイベントが発生した際に定義された関数が自動で実行され、必要な処理を行います。サーバー管理やインフラ設定を行うことなく、アプリケーションロジックに専念することができます。

--- a/ja/trigger-guide.md
+++ b/ja/trigger-guide.md
@@ -1,10 +1,16 @@
+<!-- pre-align:aligned sig=02be28f736c7 -->
+
 ## Compute > Cloud Functions > トリガーガイド
 
 このドキュメントでは、Cloud Functionsで提供するトリガーの種類と設定方法について説明します。
 
+<a id="trigger-overview"></a>
+
 ## トリガーの概要
 
 トリガーは関数を実行させるイベントソースです。Cloud Functionsは様々な種類のトリガーを提供しており、複数の方法で関数を呼び出すことができます。
+
+<a id="supported-triggers"></a>
 
 ### サポートするトリガーの種類
 
@@ -14,9 +20,13 @@
 | Timer       | 指定された時間または周期に従って関数を実行 | X      |
 | API Gateway | API Gatewayを通じて関数を実行  | X      |
 
+<a id="http-trigger"></a>
+
 ## HTTPトリガー
 
 HTTPトリガーは関数の作成時にデフォルトで提供され、HTTPリクエストを通じて関数を実行できます。
+
+<a id="features"></a>
 
 ### 特徴
 
@@ -24,19 +34,27 @@ HTTPトリガーは関数の作成時にデフォルトで提供され、HTTPリ
 - 削除することはできず、有効化/無効化のみ可能です。
 - GET, POSTメソッドをサポートします。
 
+<a id="url-format-of-http-trigger"></a>
+
 ### HTTPトリガーURL形式
 
 ```
 https://{userdomain}/{関数名}
 ```
 
+<a id="examples"></a>
+
 ### 使用例
+
+<a id="request-get"></a>
 
 #### GETリクエスト
 
 ```bash
 curl -X GET "https://{userdomain}/{関数名}?param1=value1&param2=value2"
 ```
+
+<a id="request-post"></a>
 
 #### POSTリクエスト
 
@@ -45,6 +63,8 @@ curl -X POST "https://{userdomain}/{関数名}" \
   -H "Content-Type: application/json" \
   -d '{"key": "value"}'
 ```
+
+<a id="enabledisable-http-trigger"></a>
 
 ### HTTPトリガーの有効化/無効化
 
@@ -55,9 +75,13 @@ curl -X POST "https://{userdomain}/{関数名}" \
 > **[参考]**
 > <br>無効化されたHTTPトリガーにリクエストを送信しても、関数は実行されません。
 
+<a id="timer-trigger"></a>
+
 ## Timerトリガー
 
 Timerトリガーは、指定された時間または周期に従って自動的に関数を実行します。Cron式を使用して実行周期を設定できます。
+
+<a id="create-timer-trigger"></a>
 
 ### Timerトリガーの作成
 
@@ -69,6 +93,8 @@ Timerトリガーは、指定された時間または周期に従って自動的
 4. トリガーの種類で**Timer**を選択します。
 5. **Value**にCron式を入力します。
 6. **作成**をクリックします。
+
+<a id="cron-expression-format"></a>
 
 ### Cron式の形式
 
@@ -85,6 +111,8 @@ Cron式は次のような形式に従います。
 └─────────── 秒 (0-59)
 ```
 
+<a id="cron-expression-field"></a>
+
 #### Cron式のフィールド
 
 | フィールド              | 必須  | 許容値             | 許容される記号  |
@@ -95,6 +123,8 @@ Cron式は次のような形式に従います。
 | 日(Day of month) | Yes | 1-31             | * / , - ? |
 | 月(Month)         | Yes | 1-12 または JAN-DEC | * / , -    |
 | 曜日(Day of week) | Yes | 0-6 または SUN-SAT  | * / , - ? |
+
+<a id="special-characters-details"></a>
 
 #### 記号の説明
 
@@ -118,6 +148,8 @@ Cron式は次のような形式に従います。
 
 日(Day of month)または曜日(Day of week)フィールドを空けておくために、`*`の代わりに使用できます。
 
+<a id="example-of-cron-expression"></a>
+
 ### Cron式の例
 
 | Cron式              | 説明                             |
@@ -131,6 +163,8 @@ Cron式は次のような形式に従います。
 | `0 0 9-18 * * MON-FRI` | 平日(月-金)の午前9時から午後6時まで毎時実行 |
 | `30 0 12 * * *`        | 毎日午後12時0分30秒に実行             |
 | `0 0 0 1 JAN *`        | 毎年1月1日の午前0時に実行                  |
+
+<a id="modify-timer-trigger"></a>
 
 ### Timerトリガーの修正
 
@@ -146,14 +180,20 @@ Cron式は次のような形式に従います。
 > **[参考]**
 > <br>月(Month)と曜日(Day of week)フィールドの値は、大文字と小文字を区別しません。"SUN"、"Sun"、"sun"は全て同じものとして認識されます。
 
+<a id="api-gateway-trigger"></a>
+
 ## API Gatewayトリガー
 
 API Gatewayトリガーは、同一プロジェクトのAPI Gatewayサービスを活用して関数を実行できます。API Gatewayを通じて、よりきめ細かいAPI管理と制御が可能になります。
+
+<a id="prerequisites"></a>
 
 ### 事前要件
 
 - 同一プロジェクトでAPI Gatewayサービスが有効になっている必要があります。
   - 有効になっていない場合、トリガー作成時に有効化できます。
+
+<a id="create-api-gateway-trigger"></a>
 
 ### API Gatewayトリガーの作成
 
@@ -167,19 +207,27 @@ API Gatewayトリガーは、同一プロジェクトのAPI Gatewayサービス�
    * 重複するパスは使用できません。
 6. **作成**をクリックします。
 
+<a id="api-gateway-trigger-url-format"></a>
+
 ### API GatewayトリガーURL形式
 
 ```
 https://{stageurl}/{パス}
 ```
 
+<a id="api-gateway-trigger-examples"></a>
+
 ### 使用例
+
+<a id="api-gateway-trigger-examples-request-get"></a>
 
 #### GETリクエスト
 
 ```bash
 curl -X GET "https://{stageurl}/{パス}?param1=value1&param2=value2"
 ```
+
+<a id="api-gateway-trigger-examples-request-post"></a>
 
 #### POSTリクエスト
 
@@ -188,6 +236,8 @@ curl -X POST "https://{stageurl}/{パス}" \
   -H "Content-Type: application/json" \
   -d '{"key": "value"}'
 ```
+
+<a id="features-of-api-gateway-trigger"></a>
 
 ### API Gatewayトリガーの特徴
 
@@ -199,6 +249,8 @@ curl -X POST "https://{stageurl}/{パス}" \
 - API GatewayコンソールでAPI設定を管理できます。
 - 自動的に生成された1つのサービスでのみ関数連携が可能です。
 - HTTPトリガーと同様にGET,POSTメソッドをサポートします。
+
+<a id="modify-api-gateway-trigger"></a>
 
 ### API Gatewayトリガーの修正
 
@@ -216,13 +268,19 @@ curl -X POST "https://{stageurl}/{パス}" \
 > <br>これにより、そのリソースに適用されたプラグインが全て削除されます。
 > <br>プラグインが適用されたリソースパスを変更する場合は、修正の代わりに新しいトリガーを追加することを推奨します。
 
+<a id="use-with-api-gateway"></a>
+
 ### API Gatewayと併用する
 
 API Gatewayトリガーを作成すると、API Gatewayコンソールで追加設定を行えます。
 
 詳細は[API Gatewayガイド](https://docs.nhncloud.com/ko/Application%20Service/API%20Gateway/ko/overview/)を参照してください。
 
+<a id="delete-trigger"></a>
+
 ## トリガーの削除
+
+<a id="how-to-delete-trigger"></a>
 
 ### トリガーの削除方法
 
@@ -234,13 +292,19 @@ API Gatewayトリガーを作成すると、API Gatewayコンソールで追加�
 4. **トリガー削除**をクリックします。
 5. **トリガー削除**モーダルウィンドウで**削除**をクリックします。
 
+<a id="cautions"></a>
+
 ### 注意事項
 
 - HTTPトリガーは削除できません。HTTPトリガーは基本トリガーとして提供され、有効化/無効化のみ可能です。
 - トリガーを削除すると、そのイベントを通じて関数を実行できなくなります。
 - 削除されたトリガーは復元できません。
 
+<a id="restrictions"></a>
+
 ## トリガーの制限事項
+
+<a id="restrictions-for-api-gateway-trigger"></a>
 
 ### API Gatewayトリガーの制限事項
 

--- a/ko/api-guide-v1-0.md
+++ b/ko/api-guide-v1-0.md
@@ -1,8 +1,14 @@
+<!-- pre-align:aligned sig=f22611a38cd5 -->
+
 ## Cloud Functions API v1.0 가이드
 
 **Compute > Cloud Functions > API 가이드 > API v1.0 가이드**
 
+<a id="cloud-functions-api-v10-common-information"></a>
+
 ## Cloud Functions API v1.0 공통 정보
+
+<a id="api-endpoint"></a>
 
 ### API 엔드포인트
 
@@ -12,11 +18,15 @@ Cloud Functions API를 호출하기 위한 리전별 엔드포인트는 다음�
 | --- |-----------------------------------------------------|
 | 한국(판교) 리전 | https://kr1-cloud-functions.api.nhncloudservice.com |
 
+<a id="authentication-and-authorization"></a>
+
 ### 인증 및 권한
 
 Cloud Functions는 API 호출 시 인증/인가를 위해 User Access Key 토큰을 사용합니다.
 User Access Key 토큰은 User Access Key를 기반으로 발급되는 Bearer 타입의 일시적 액세스 토큰입니다.
 User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Access Key 토큰](/nhncloud/ko/public-api/user-access-key-token)을 참고하세요.
+
+<a id="response-common-information"></a>
 
 ### 응답 공통 정보
 
@@ -66,15 +76,21 @@ User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Acc
 
 ---
 
+<a id="list-environments"></a>
+
 ## 환경 목록 조회
 
 사용 가능한 런타임 환경 목록을 조회합니다.
+
+<a id="request"></a>
 
 ### 요청
 
 ```
 GET /v1.0/env/list
 ```
+
+<a id="request-parameter"></a>
 
 ### 요청 파라미터
 
@@ -83,9 +99,13 @@ GET /v1.0/env/list
 | X-NHN-appkey | Header | String | Y | 앱키 |
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 
+<a id="request-body"></a>
+
 ### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
+
+<a id="response"></a>
 
 ### 응답
 
@@ -128,15 +148,21 @@ GET /v1.0/env/list
 
 ---
 
+<a id="list-functions"></a>
+
 ## 함수 목록 조회
 
 함수 목록을 조회합니다.
+
+<a id="list-functions-request"></a>
 
 ### 요청
 
 ```
 GET /v1.0/functions
 ```
+
+<a id="list-functions-request-parameter"></a>
 
 ### 요청 파라미터
 
@@ -147,9 +173,13 @@ GET /v1.0/functions
 | page | Query | Integer | N | 현재 페이지(기본값: 0) |
 | pageSize | Query | Integer | N | 한 페이지에 노출될 개수 |
 
+<a id="list-functions-request-body"></a>
+
 ### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
+
+<a id="list-functions-response"></a>
 
 ### 응답
 
@@ -200,15 +230,21 @@ GET /v1.0/functions
 
 ---
 
+<a id="get-function"></a>
+
 ## 함수 상세 조회
 
 함수의 상세 정보와 빌드 로그를 함께 조회합니다.
+
+<a id="get-function-request"></a>
 
 ### 요청
 
 ```
 GET /v1.0/functions/{functionName}
 ```
+
+<a id="get-function-request-parameter"></a>
 
 ### 요청 파라미터
 
@@ -218,9 +254,13 @@ GET /v1.0/functions/{functionName}
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 함수 이름 |
 
+<a id="get-function-request-body"></a>
+
 ### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
+
+<a id="get-function-response"></a>
 
 ### 응답
 
@@ -280,6 +320,8 @@ GET /v1.0/functions/{functionName}
 
 ---
 
+<a id="create-function"></a>
+
 ## 함수 생성
 
 새 함수를 생성합니다. multipart/form-data로 소스 파일을 업로드합니다.
@@ -287,11 +329,15 @@ runtime은 `{environment}-{version}` 형식으로 입력해야 합니다(예: No
 
 executorType에 따라 필수 파라미터가 달라집니다. poolManager일 때는 requestPerPod가, newDeployment일 때는 minInstance와 maxInstance가 필수입니다.
 
+<a id="create-function-request"></a>
+
 ### 요청
 
 ```
 POST /v1.0/functions
 ```
+
+<a id="create-function-request-parameter"></a>
 
 ### 요청 파라미터
 
@@ -299,6 +345,8 @@ POST /v1.0/functions
 | --- | --- | --- | --- | --- |
 | X-NHN-appkey | Header | String | Y | 앱키 |
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
+
+<a id="create-function-request-body"></a>
 
 ### 요청 본문
 
@@ -318,6 +366,8 @@ Content-Type: multipart/form-data
 | maxInstance | Integer | Conditional | 최대 인스턴스 수(newDeployment일 때 필수, 1~100)                                                             |
 | lncsAppkey | String | N          | LnCS 앱키                                                                                           |
 | sourceFile | Binary | Y          | 소스 코드 파일(ZIP)                                                                                     |
+
+<a id="create-function-response"></a>
 
 ### 응답
 
@@ -339,17 +389,23 @@ Content-Type: multipart/form-data
 
 ---
 
+<a id="modify-function"></a>
+
 ## 함수 수정
 
 함수를 수정합니다. multipart/form-data로 소스 파일을 업로드할 수 있습니다.
 
 소스 파일(sourceFile)은 선택 항목입니다. 소스 파일을 포함하지 않으면 기존 소스 코드가 유지됩니다.
 
+<a id="modify-function-request"></a>
+
 ### 요청
 
 ```
 PUT /v1.0/functions/{functionName}
 ```
+
+<a id="modify-function-request-parameter"></a>
 
 ### 요청 파라미터
 
@@ -358,6 +414,8 @@ PUT /v1.0/functions/{functionName}
 | X-NHN-appkey | Header | String | Y | 앱키 |
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 수정할 함수 이름 |
+
+<a id="modify-function-request-body"></a>
 
 ### 요청 본문
 
@@ -376,6 +434,8 @@ Content-Type: multipart/form-data
 | maxInstance | Integer | Conditional | 최대 인스턴스 수(newDeployment일 때 필수, 1~100)                                                             |
 | lncsAppkey | String | N          | LnCS 앱키                                                                                           |
 | sourceFile | Binary | N          | 소스 코드 파일(ZIP)                                                                                     |
+
+<a id="modify-function-response"></a>
 
 ### 응답
 
@@ -397,9 +457,13 @@ Content-Type: multipart/form-data
 
 ---
 
+<a id="delete-functions"></a>
+
 ## 함수 삭제
 
 함수를 일괄 삭제합니다.
+
+<a id="delete-functions-request"></a>
 
 ### 요청
 
@@ -407,12 +471,16 @@ Content-Type: multipart/form-data
 DELETE /v1.0/functions
 ```
 
+<a id="delete-functions-request-parameter"></a>
+
 ### 요청 파라미터
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
 | X-NHN-appkey | Header | String | Y | 앱키 |
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
+
+<a id="delete-functions-request-body"></a>
 
 ### 요청 본문
 
@@ -430,6 +498,8 @@ DELETE /v1.0/functions
 | 이름 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- |
 | names | Array | Y | 삭제할 함수 이름 목록 |
+
+<a id="delete-functions-response"></a>
 
 ### 응답
 
@@ -451,15 +521,21 @@ DELETE /v1.0/functions
 
 ---
 
+<a id="execute-function-get"></a>
+
 ## 함수 실행(GET)
 
 GET 방식으로 함수를 실행합니다.
+
+<a id="execute-function-get-request"></a>
 
 ### 요청
 
 ```
 GET /v1.0/functions/{functionName}/invoke
 ```
+
+<a id="execute-function-get-request-parameter"></a>
 
 ### 요청 파라미터
 
@@ -469,9 +545,13 @@ GET /v1.0/functions/{functionName}/invoke
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 실행할 함수 이름 |
 
+<a id="execute-function-get-request-body"></a>
+
 ### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
+
+<a id="execute-function-get-response"></a>
 
 ### 응답
 
@@ -497,15 +577,21 @@ GET /v1.0/functions/{functionName}/invoke
 
 ---
 
+<a id="execute-function-post"></a>
+
 ## 함수 실행(POST)
 
 POST 방식으로 함수를 실행합니다. body를 전달할 수 있습니다.
+
+<a id="execute-function-post-request"></a>
 
 ### 요청
 
 ```
 POST /v1.0/functions/{functionName}/invoke
 ```
+
+<a id="execute-function-post-request-parameter"></a>
 
 ### 요청 파라미터
 
@@ -514,6 +600,8 @@ POST /v1.0/functions/{functionName}/invoke
 | X-NHN-appkey | Header | String | Y | 앱키 |
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 실행할 함수 이름 |
+
+<a id="execute-function-post-request-body"></a>
 
 ### 요청 본문
 
@@ -531,6 +619,8 @@ POST /v1.0/functions/{functionName}/invoke
 | 이름 | 타입   | 필수 | 설명 |
 | --- |------| --- | --- |
 | body | JSON | N | 함수에 전달할 body |
+
+<a id="execute-function-post-response"></a>
 
 ### 응답
 
@@ -556,15 +646,21 @@ POST /v1.0/functions/{functionName}/invoke
 
 ---
 
+<a id="list-versions"></a>
+
 ## 버전 목록 조회
 
 함수의 버전(패키지) 목록을 조회합니다.
+
+<a id="list-versions-request"></a>
 
 ### 요청
 
 ```
 GET /v1.0/functions/{functionName}/versions
 ```
+
+<a id="list-versions-request-parameter"></a>
 
 ### 요청 파라미터
 
@@ -574,9 +670,13 @@ GET /v1.0/functions/{functionName}/versions
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 함수 이름 |
 
+<a id="list-versions-request-body"></a>
+
 ### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
+
+<a id="list-versions-response"></a>
 
 ### 응답
 
@@ -625,15 +725,21 @@ GET /v1.0/functions/{functionName}/versions
 
 ---
 
+<a id="switch-version"></a>
+
 ## 버전 전환
 
 함수의 현재 활성 버전을 변경합니다.
+
+<a id="switch-version-request"></a>
 
 ### 요청
 
 ```
 PUT /v1.0/functions/{functionName}/versions
 ```
+
+<a id="switch-version-request-parameter"></a>
 
 ### 요청 파라미터
 
@@ -642,6 +748,8 @@ PUT /v1.0/functions/{functionName}/versions
 | X-NHN-appkey | Header | String | Y | 앱키 |
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 함수 이름 |
+
+<a id="switch-version-request-body"></a>
 
 ### 요청 본문
 
@@ -660,6 +768,8 @@ PUT /v1.0/functions/{functionName}/versions
 | --- | --- | --- | --- |
 | versionId | Integer | Y | 전환할 버전 ID |
 
+<a id="switch-version-response"></a>
+
 ### 응답
 
 <details>
@@ -680,17 +790,23 @@ PUT /v1.0/functions/{functionName}/versions
 
 ---
 
+<a id="delete-versions"></a>
+
 ## 버전 삭제
 
 함수의 버전을 일괄 삭제합니다.
 
 현재 활성 버전은 삭제할 수 없습니다.
 
+<a id="delete-versions-request"></a>
+
 ### 요청
 
 ```
 DELETE /v1.0/functions/{functionName}/versions
 ```
+
+<a id="delete-versions-request-parameter"></a>
 
 ### 요청 파라미터
 
@@ -699,6 +815,8 @@ DELETE /v1.0/functions/{functionName}/versions
 | X-NHN-appkey | Header | String | Y | 앱키 |
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 함수 이름 |
+
+<a id="delete-versions-request-body"></a>
 
 ### 요청 본문
 
@@ -717,6 +835,8 @@ DELETE /v1.0/functions/{functionName}/versions
 | --- | --- | --- | --- |
 | versionIds | Array | Y | 삭제할 버전 ID 목록 |
 
+<a id="delete-versions-response"></a>
+
 ### 응답
 
 <details>
@@ -737,15 +857,21 @@ DELETE /v1.0/functions/{functionName}/versions
 
 ---
 
+<a id="list-triggers"></a>
+
 ## 트리거 목록 조회
 
 함수의 트리거 목록을 조회합니다.
+
+<a id="list-triggers-request"></a>
 
 ### 요청
 
 ```
 GET /v1.0/triggers/{functionName}
 ```
+
+<a id="list-triggers-request-parameter"></a>
 
 ### 요청 파라미터
 
@@ -755,9 +881,13 @@ GET /v1.0/triggers/{functionName}
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 함수 이름 |
 
+<a id="list-triggers-request-body"></a>
+
 ### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
+
+<a id="list-triggers-response"></a>
 
 ### 응답
 
@@ -800,15 +930,21 @@ GET /v1.0/triggers/{functionName}
 
 ---
 
+<a id="create-time-trigger"></a>
+
 ## 타임 트리거 생성
 
 함수에 타임 트리거를 생성합니다.
+
+<a id="create-time-trigger-request"></a>
 
 ### 요청
 
 ```
 POST /v1.0/triggers/{functionName}/time
 ```
+
+<a id="create-time-trigger-request-parameter"></a>
 
 ### 요청 파라미터
 
@@ -817,6 +953,8 @@ POST /v1.0/triggers/{functionName}/time
 | X-NHN-appkey | Header | String | Y | 앱키 |
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 함수 이름 |
+
+<a id="create-time-trigger-request-body"></a>
 
 ### 요청 본문
 
@@ -834,6 +972,8 @@ POST /v1.0/triggers/{functionName}/time
 | 이름 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- |
 | cron | String | Y | cron 표현식 |
+
+<a id="create-time-trigger-response"></a>
 
 ### 응답
 
@@ -855,15 +995,21 @@ POST /v1.0/triggers/{functionName}/time
 
 ---
 
+<a id="modify-time-trigger"></a>
+
 ## 타임 트리거 수정
 
 타임 트리거의 cron 표현식을 수정합니다.
+
+<a id="modify-time-trigger-request"></a>
 
 ### 요청
 
 ```
 PUT /v1.0/triggers/{functionName}/time
 ```
+
+<a id="modify-time-trigger-request-parameter"></a>
 
 ### 요청 파라미터
 
@@ -872,6 +1018,8 @@ PUT /v1.0/triggers/{functionName}/time
 | X-NHN-appkey | Header | String | Y | 앱키 |
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 함수 이름 |
+
+<a id="modify-time-trigger-request-body"></a>
 
 ### 요청 본문
 
@@ -891,6 +1039,8 @@ PUT /v1.0/triggers/{functionName}/time
 | --- | --- | --- | --- |
 | name | String | Y | 트리거 이름 |
 | cron | String | Y | cron 표현식 |
+
+<a id="modify-time-trigger-response"></a>
 
 ### 응답
 
@@ -912,15 +1062,21 @@ PUT /v1.0/triggers/{functionName}/time
 
 ---
 
+<a id="delete-time-triggers"></a>
+
 ## 타임 트리거 삭제
 
 타임 트리거를 일괄 삭제합니다.
+
+<a id="delete-time-triggers-request"></a>
 
 ### 요청
 
 ```
 DELETE /v1.0/triggers/{functionName}/time
 ```
+
+<a id="delete-time-triggers-request-parameter"></a>
 
 ### 요청 파라미터
 
@@ -929,6 +1085,8 @@ DELETE /v1.0/triggers/{functionName}/time
 | X-NHN-appkey | Header | String | Y | 앱키 |
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 함수 이름 |
+
+<a id="delete-time-triggers-request-body"></a>
 
 ### 요청 본문
 
@@ -946,6 +1104,8 @@ DELETE /v1.0/triggers/{functionName}/time
 | 이름 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- |
 | names | Array | Y | 삭제할 트리거 이름 목록 |
+
+<a id="delete-time-triggers-response"></a>
 
 ### 응답
 

--- a/ko/code-template-dotnet-guide.md
+++ b/ko/code-template-dotnet-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=3c324618eb1e -->
+
 ## Compute > Cloud Functions > 코드 템플릿 가이드 > .NET
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 .NET을 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
+
+<a id="template-information"></a>
 
 ## 템플릿 정보
 | 항목              | 값       |
@@ -9,7 +13,11 @@
 | **파일명**         | func.cs |
 | **Entry Point** | func    |
 
+<a id="basic-template"></a>
+
 ## 기본 템플릿
+
+<a id="hello-world-example"></a>
 
 ### Hello World 예시
 가장 기본적인 함수 형태입니다. `Nhn.DotNetCore.Api` 네임스페이스의 `NhnContext`를 사용하여 로거 및 요청 정보에 접근합니다.
@@ -49,6 +57,8 @@ public class NhnFunction
     }
 }
 ```
+
+<a id="context-object"></a>
 
 ### Context 객체
 `NhnContext` 객체를 통해 로거, 요청(Request), 응답(Response) 객체에 접근할 수 있습니다.
@@ -95,12 +105,18 @@ public class NhnFunction
 }
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## 템플릿 파일 다운로드 및 활용
+
+<a id="template-download"></a>
 
 ### 템플릿 다운로드
 Cloud Functions에서 제공하는 .NET 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 **템플릿 다운로드 링크**: [dotnet.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/dotnet/dotnet.zip)
+
+<a id="template-file-structure"></a>
 
 ### 템플릿 파일 구조
 다운로드한 템플릿 파일의 구조는 다음과 같습니다.
@@ -112,7 +128,11 @@ dotnet.zip
 └── nuget.txt     # 의존성 관리 파일
 ```
 
+<a id="local-development-process"></a>
+
 ### 로컬 개발 과정
+
+<a id="unzip"></a>
 
 #### 1. 압축 해제
 ```bash
@@ -122,6 +142,8 @@ unzip dotnet.zip -d my-function
 # 작업 디렉터리 이동
 cd my-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. 함수 코드 수정
 `func.cs` 파일을 원하는 로직으로 수정합니다.
@@ -178,6 +200,8 @@ public class NhnFunction
 }
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. ZIP 파일로 압축
 수정된 소스 코드를 다시 ZIP 파일로 압축합니다. `func.cs`와 `nuget.txt`가 최상위에 포함되도록 압축해야 합니다.
 
@@ -185,11 +209,17 @@ public class NhnFunction
 zip my-function.zip func.cs nuget.txt
 ```
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Cloud Functions 콘솔에서 업로드
 - 함수 생성 또는 수정 시, **사용자 로컬 환경** 방식을 선택합니다.
 - **파일 선택**을 클릭하여 생성한 `my-function.zip` 파일을 업로드합니다.
 
+<a id="process-by-http-method"></a>
+
 ## HTTP 메서드별 처리
+
+<a id="process-get-request"></a>
 
 ### GET 요청 처리
 ```csharp
@@ -219,6 +249,8 @@ public class NhnFunction
     }
 }
 ```
+
+<a id="process-post-request"></a>
 
 ### POST 요청 처리
 ```csharp
@@ -272,6 +304,8 @@ public class NhnFunction
 }
 ```
 
+<a id="manage-package-nugettxt"></a>
+
 ## 패키지 관리(`nuget.txt`)
 
 의존성(NuGet 패키지) 관리를 위해 `nuget.txt` 파일을 사용합니다. 필요한 패키지를 한 줄에 하나씩 작성합니다.
@@ -280,6 +314,8 @@ public class NhnFunction
 # nuget.txt
 Microsoft.Extensions.Configuration:8.0.0
 ```
+
+<a id="example-of-configuration-management"></a>
 
 ### 설정 관리 예시
 ```csharp
@@ -362,6 +398,8 @@ public class NhnFunction
 }
 ```
 
+<a id="configure-entry-point"></a>
+
 ## Entry Point 설정
 
 Entry Point는 **파일명**입니다. (확장자 제외)
@@ -370,6 +408,8 @@ Entry Point는 **파일명**입니다. (확장자 제외)
 - Entry Point: `func`
 
 **중요**: 클래스 이름은 `NhnFunction`이어야 하며, 함수 역할을 하는 메서드는 `public string Execute(NhnContext context)` 시그니처를 가져야 합니다.
+
+<a id="caution"></a>
 
 ### 주의사항
 - **패키지 버전**: `nuget.txt`에서 패키지 버전을 명시할 수 있습니다. (예: `Newtonsoft.Json:9.0.1`)

--- a/ko/code-template-go-guide.md
+++ b/ko/code-template-go-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=9b45d499c0b7 -->
+
 ## Compute > Cloud Functions > 코드 템플릿 가이드 > Go
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 Go를 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
+
+<a id="template-information"></a>
 
 ## 템플릿 정보
 | 항목              | 값                                        |
@@ -9,7 +13,11 @@
 | **파일명**         | functions.go                             |
 | **Entry Point** | Handler                                  |
 
+<a id="basic-template"></a>
+
 ## 기본 템플릿
+
+<a id="hello-world-example"></a>
 
 ### Hello World 예시
 가장 기본적인 함수 형태입니다.
@@ -37,6 +45,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 ```
+
+<a id="context-object"></a>
 
 ### Context 객체
 Go 함수에서는 `http.ResponseWriter`와 `*http.Request`를 통해 HTTP 요청과 응답을 처리합니다.
@@ -74,12 +84,18 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## 템플릿 파일 다운로드 및 활용
+
+<a id="template-download"></a>
 
 ### 템플릿 다운로드
 Cloud Functions에서 제공하는 Go 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 **템플릿 다운로드 링크**: [go.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/go/go.zip)
+
+<a id="template-file-structure"></a>
 
 ### 템플릿 파일 구조
 다운로드한 템플릿 파일의 구조는 다음과 같습니다.
@@ -89,6 +105,8 @@ go.zip
 ├── functions.go     # 메인 함수 파일
 └── go.mod          # 의존성 관리 파일
 ```
+
+<a id="functionsgo"></a>
 
 #### functions.go
 기본 fake 데이터 생성 함수가 포함되어 있습니다.
@@ -116,6 +134,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+<a id="gomod"></a>
+
 #### go.mod
 ```go
 module example.com/ncf
@@ -125,7 +145,11 @@ go 1.22
 require github.com/brianvoe/gofakeit/v6 v6.28.0
 ```
 
+<a id="local-development-process"></a>
+
 ### 로컬 개발 과정
+
+<a id="unzip"></a>
 
 #### 1. 압축 해제
 ```bash
@@ -135,6 +159,8 @@ unzip go.zip -d my-function
 # 작업 디렉터리 이동
 cd my-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. 함수 코드 수정
 `functions.go` 파일을 원하는 로직으로 수정합니다.
@@ -185,6 +211,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. ZIP 파일로 압축
 수정된 코드를 다시 ZIP 파일로 압축합니다.
 
@@ -202,10 +230,16 @@ zip my-function.zip functions.go go.mod
 zip -r my-function.zip . -x "*.git*" "go.sum" "test.go"
 ```
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Cloud Functions 콘솔에서 업로드
 > 함수를 생성하거나 수정할 때 사용자 로컬 환경의 파일을 업로드 시 사용. (콘솔 사용 가이드 참고)
 
+<a id="cautions-for-upload"></a>
+
 ### 업로드 시 주의사항
+
+<a id="zip-file-structure"></a>
 
 #### ZIP 파일 구조
 - ZIP 파일의 루트에 직접 `.go` 파일과 `go.mod`가 위치해야 합니다.
@@ -227,9 +261,13 @@ my-function.zip
     └── go.mod
 ```
 
+<a id="file-size-limit"></a>
+
 #### 파일 크기 제한
 - ZIP 파일 크기는 100MiB 이하로 제한됩니다.
 - `go.sum` 파일은 포함하지 마세요.
+
+<a id="files-to-exclude"></a>
 
 #### 제외할 파일들
 ```bash
@@ -243,7 +281,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
+<a id="process-by-http-method"></a>
+
 ## HTTP 메서드별 처리
+
+<a id="process-get-request"></a>
 
 ### GET 요청 처리
 ```go
@@ -282,6 +324,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(response)
 }
 ```
+
+<a id="process-post-request"></a>
 
 ### POST 요청 처리
 ```go
@@ -354,7 +398,11 @@ func getOrDefault(value, defaultValue string) string {
 }
 ```
 
+<a id="manage-packages"></a>
+
 ## 패키지 관리
+
+<a id="write-gomod"></a>
 
 ### go.mod 작성
 의존성 관리를 위해 `go.mod` 파일을 작성합니다.
@@ -369,6 +417,8 @@ require (
     github.com/gorilla/mux v1.8.1
 )
 ```
+
+<a id="example-of-external-api-call"></a>
 
 ### 외부 API 호출 예시
 ```go
@@ -422,6 +472,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(response)
 }
 ```
+
+<a id="data-processing-example"></a>
 
 ### 데이터 처리 예시
 ```go
@@ -516,13 +568,19 @@ func normalizeName(name string) string {
 }
 ```
 
+<a id="configure-entry-point"></a>
+
 ## Entry Point 설정
+
+<a id="single-function"></a>
 
 ### 단일 함수
 함수명을 Entry Point로 사용합니다.
 
 함수명: `Handler`
 Entry Point: `Handler`
+
+<a id="multiple-functions"></a>
 
 ### 다중 함수
 하나의 파일에서 여러 함수를 정의할 수 있습니다.
@@ -564,7 +622,11 @@ Entry Point 설정:
 - `CreateUser`
 - `UpdateUser`
 
+<a id="caution"></a>
+
 ## 주의사항
+
+<a id="go-version"></a>
 
 ### Go 버전
 | 버전 | 지원 중단일 | 사용 중단일 |
@@ -573,6 +635,8 @@ Entry Point 설정:
 | 1.24 | - | - |
 | 1.23 | 2026-02-21 | 2026-08-21 |
 | 1.22 | 2026-01-28 | 2026-07-28 |
+
+<a id="go-version-support-policy"></a>
 
 #### Go 버전 지원 정책
 Cloud Functions는 Go의 공식 릴리즈 정책을 따릅니다. Go는 연 2회(1월, 7월) 새로운 메이저 버전을 릴리즈하며, 각 버전은 최신 2개 메이저 버전까지만 지원됩니다.

--- a/ko/code-template-java-guide.md
+++ b/ko/code-template-java-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=65e9891c8f54 -->
+
 ## Compute > Cloud Functions > 코드 템플릿 가이드 > Java
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 Java를 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
+
+<a id="template-information"></a>
 
 ## 템플릿 정보
 | 항목              | 값                  |
@@ -9,7 +13,11 @@
 | **파일명**         | HelloWorld.java    |
 | **Entry Point** | example.HelloWorld |
 
+<a id="basic-template"></a>
+
 ## 기본 템플릿
+
+<a id="hello-world-example"></a>
 
 ### Hello World 예시
 가장 기본적인 함수 형태입니다.
@@ -28,6 +36,8 @@ public class HelloWorld {
 
 }
 ```
+
+<a id="context-object-requestentity"></a>
 
 ### Context 객체(RequestEntity)
 Java 함수에서는 Spring의 `RequestEntity`를 통해 HTTP 요청 정보에 접근할 수 있습니다.
@@ -62,12 +72,18 @@ public class HelloWorld {
 }
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## 템플릿 파일 다운로드 및 활용
+
+<a id="template-download"></a>
 
 ### 템플릿 다운로드
 Cloud Functions에서 제공하는 Java 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 **템플릿 다운로드 링크**: [java.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/java/java.zip)
+
+<a id="template-file-structure"></a>
 
 ### 템플릿 파일 구조
 다운로드한 템플릿은 Maven 프로젝트 구조를 따릅니다.
@@ -82,7 +98,11 @@ java.zip
                 └── HelloWorld.java
 ```
 
+<a id="local-development-process"></a>
+
 ### 로컬 개발 과정
+
+<a id="unzip"></a>
 
 #### 1. 압축 해제
 ```bash
@@ -92,6 +112,8 @@ unzip java.zip -d my-java-function
 # 작업 디렉터리 이동
 cd my-java-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. 함수 코드 수정
 `src/main/java/example/HelloWorld.java` 파일을 원하는 로직으로 수정합니다.
@@ -144,6 +166,8 @@ public class HelloWorld {
 }
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. ZIP 파일로 압축
 수정된 소스 코드를 다시 ZIP 파일로 압축합니다. `pom.xml` 파일과 `src` 디렉터리가 최상위에 포함되도록 압축해야 합니다.
 
@@ -161,9 +185,13 @@ zip -r my-function.zip pom.xml src
 zip -r my-function.zip . -x "*.git*" "target/*" "*.log"
 ```
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Cloud Functions 콘솔에서 업로드
 - 함수 생성 또는 수정 시, **사용자 로컬 환경** 방식을 선택합니다.
 - **파일 선택**을 클릭하여 생성한 `my-function.zip` 파일을 업로드합니다.
+
+<a id="cautions-for-upload"></a>
 
 ### 업로드 시 주의사항
 - **업로드 파일**: 소스 코드와 `pom.xml`이 포함된 **ZIP 파일**을 업로드해야 합니다.
@@ -171,7 +199,11 @@ zip -r my-function.zip . -x "*.git*" "target/*" "*.log"
 - **제외할 파일**: `target` 디렉터리, `.git` 디렉터리 등 불필요한 파일은 포함하지 마세요.
 - **파일 크기**: ZIP 파일 크기는 100MiB 이하로 제한됩니다.
 
+<a id="process-by-http-method"></a>
+
 ## HTTP 메서드별 처리
+
+<a id="process-get-request"></a>
 
 ### GET 요청 처리
 ```java
@@ -208,6 +240,8 @@ public class GetHandler {
     }
 }
 ```
+
+<a id="process-post-request"></a>
 
 ### POST 요청 처리
 ```java
@@ -250,6 +284,8 @@ public class PostHandler {
 }
 ```
 
+<a id="manage-package-pomxml"></a>
+
 ## 패키지 관리(`pom.xml`)
 
 의존성 관리를 위해 `pom.xml` 파일을 수정합니다. `dependencies` 섹션에 필요한 라이브러리를 추가하면, 함수 업로드 시 Cloud Functions가 자동으로 의존성을 다운로드하여 빌드에 포함합니다.
@@ -272,6 +308,8 @@ public class PostHandler {
     </dependency>
 </dependencies>
 ```
+
+<a id="example-of-using-external-libraries"></a>
 
 ### 외부 라이브러리 활용 예시
 ```java
@@ -307,7 +345,11 @@ public class StringUtilsHandler {
 }
 ```
 
+<a id="entry-point-configuration"></a>
+
 ## Entry Point 설정
+
+<a id="single-class"></a>
 
 ### 단일 클래스
 `패키지명.클래스명`을 Entry Point로 사용합니다.
@@ -316,6 +358,8 @@ public class StringUtilsHandler {
 - 클래스명: `HelloWorld`
 - Entry Point: `example.HelloWorld`
 - **중요**: 함수 역할을 하는 메서드는 `public ResponseEntity<?> call(RequestEntity<?> req)` 시그니처를 가져야 합니다.
+
+<a id="caution"></a>
 
 ### 주의사항
 - **프로젝트 구조**: `src/main/java` 디렉터리 구조를 유지해야 합니다.

--- a/ko/code-template-node-guide.md
+++ b/ko/code-template-node-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=ce91cd7cb2f1 -->
+
 ## Compute > Cloud Functions > 코드 템플릿 가이드 > Node.js
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 Node.js를 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
+
+<a id="template-information"></a>
 
 ## 템플릿 정보
 | 항목              | 값               |
@@ -9,7 +13,11 @@
 | **파일명**         | hello.js        |
 | **Entry Point** | hello           |
 
+<a id="basic-template"></a>
+
 ## 기본 템플릿
+<a id="hello-world-example"></a>
+
 ### Hello World 예시
 가장 기본적인 함수 형태입니다.
 
@@ -21,6 +29,8 @@ module.exports = async (context) => {
     };
 }
 ```
+
+<a id="context-object"></a>
 
 ### Context 객체
 함수에 전달되는 `context` 객체는 다음과 같은 정보를 포함합니다.
@@ -42,12 +52,18 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## 템플릿 파일 다운로드 및 활용
+
+<a id="template-download"></a>
 
 ### 템플릿 다운로드
 Cloud Functions에서 제공하는 Node.js 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 **템플릿 다운로드 링크**: [nodejs.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/nodejs/nodejs.zip)
+
+<a id="template-file-structure"></a>
 
 ### 템플릿 파일 구조
 다운로드한 템플릿 파일의 구조는 다음과 같습니다.
@@ -57,6 +73,8 @@ nodejs.zip
 ├── hello.js          # 메인 함수 파일
 └── package.json      # 의존성 관리 파일
 ```
+
+<a id="hellojs"></a>
 
 #### hello.js
 기본 Hello World 함수가 포함되어 있습니다.
@@ -69,12 +87,18 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="packagejson"></a>
+
 #### package.json
 ```json
 {}
 ```
 
+<a id="local-development-process"></a>
+
 ### 로컬 개발 과정
+
+<a id="unzip"></a>
 
 #### 1. 압축 해제
 ```bash
@@ -84,6 +108,8 @@ unzip nodejs.zip -d my-function
 # 작업 디렉터리 이동
 cd my-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. 함수 코드 수정
 `hello.js` 파일을 원하는 로직으로 수정합니다.
@@ -127,6 +153,8 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. ZIP 파일로 압축
 수정된 코드를 다시 ZIP 파일로 압축합니다.
 
@@ -144,10 +172,16 @@ zip my-function.zip hello.js package.json
 zip -r my-function.zip . -x "*.git*" "node_modules/*" "test.js"
 ```
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Cloud Functions 콘솔에서 업로드
 > 함수를 생성하거나 수정할 때 사용자 로컬 환경의 파일을 업로드 시 사용. (콘솔 사용 가이드 참고)
 
+<a id="cautions-for-upload"></a>
+
 ### 업로드 시 주의사항
+
+<a id="zip-file-structure"></a>
 
 #### ZIP 파일 구조
 - ZIP 파일의 루트에 직접 `.js` 파일과 `package.json`이 위치해야 합니다.
@@ -169,9 +203,13 @@ my-function.zip
     └── package.json
 ```
 
+<a id="file-size-limit"></a>
+
 #### 파일 크기 제한
 - ZIP 파일 크기는 100MiB 이하로 제한됩니다.
 - `node_modules` 폴더는 포함하지 마세요. (의존성은 `package.json`으로 관리)
+
+<a id="files-to-exclude"></a>
 
 #### 제외할 파일들
 ```bash
@@ -185,7 +223,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
+<a id="process-by-http-method"></a>
+
 ## HTTP 메서드별 처리
+
+<a id="process-get-request"></a>
 
 ### GET 요청 처리
 ```javascript
@@ -212,6 +254,8 @@ module.exports = async (context) => {
     };
 }
 ```
+
+<a id="process-post-request"></a>
 
 ### POST 요청 처리
 ```javascript
@@ -258,7 +302,11 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="manage-packages"></a>
+
 ## 패키지 관리
+
+<a id="write-packagejson"></a>
 
 ### package.json 작성
 의존성 관리를 위해 `package.json` 파일을 작성합니다.
@@ -277,6 +325,8 @@ module.exports = async (context) => {
   }
 }
 ```
+
+<a id="example-of-external-api-call"></a>
 
 ### 외부 API 호출 예시
 ```javascript
@@ -327,6 +377,8 @@ module.exports = async (context) => {
     }
 }
 ```
+
+<a id="data-processing-example"></a>
 
 ### 데이터 처리 예시
 ```javascript
@@ -382,13 +434,19 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="configure-entry-point"></a>
+
 ## Entry Point 설정
+
+<a id="single-function"></a>
 
 ### 단일 함수
 파일명을 Entry Point로 사용합니다.
 
 파일명: `hello.js`
 Entry Point: `hello`
+
+<a id="multiple-functions"></a>
 
 ### 다중 함수
 하나의 파일에서 여러 함수를 내보낼 수 있습니다.
@@ -425,6 +483,8 @@ Entry Point 설정:
 - `users.createUser`
 - `users.updateUser`
 
+<a id="entry-point-restriction"></a>
+
 ### Entry Point 제한 사항
 - **하위 디렉터리 지정 불가**: 루트 디렉터리의 하위 디렉터리에 있는 파일은 Entry Point로 지정할 수 없습니다.
 
@@ -443,7 +503,11 @@ modules/auth.js → modules.auth ❌
 
 모든 함수 파일은 ZIP 파일의 루트 레벨에 위치해야 합니다.
 
+<a id="caution"></a>
+
 ## 주의사항
+
+<a id="commonjs-vs-es-modules"></a>
 
 ### CommonJS vs ES Modules
 현재 Cloud Functions는 CommonJS 방식만 지원합니다.
@@ -463,6 +527,8 @@ export default async (context) => {  // ❌ 지원하지 않음
     // 함수 로직
 };
 ```
+
+<a id="considerations-for-memory-and-execution-time"></a>
 
 ### 메모리 및 실행 시간 고려사항
 - 함수는 제한된 메모리와 실행 시간 내에서 동작해야 합니다.

--- a/ko/code-template-python-guide.md
+++ b/ko/code-template-python-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=577d9bcb43c9 -->
+
 ## Compute > Cloud Functions > 코드 템플릿 가이드 > Python
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 Python을 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
+
+<a id="template-information"></a>
 
 ## 템플릿 정보
 | 항목              | 값                |
@@ -9,7 +13,11 @@
 | **파일명**         | user.py          |
 | **Entry Point** | user.main        |
 
+<a id="basic-template"></a>
+
 ## 기본 템플릿
+
+<a id="hello-world-example"></a>
 
 ### Hello World 예시
 가장 기본적인 함수 형태입니다.
@@ -28,6 +36,8 @@ document = """
 def main():
     return yaml.dump(yaml.safe_load(document))
 ```
+
+<a id="context-object"></a>
 
 ### Context 객체
 Python 함수에서는 Flask의 request 객체를 통해 HTTP 요청 정보에 접근할 수 있습니다.
@@ -57,12 +67,18 @@ def main():
     }
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## 템플릿 파일 다운로드 및 활용
+
+<a id="template-download"></a>
 
 ### 템플릿 다운로드
 Cloud Functions에서 제공하는 Python 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 **템플릿 다운로드 링크**: [python.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/python/python.zip)
+
+<a id="template-file-structure"></a>
 
 ### 템플릿 파일 구조
 다운로드한 템플릿 파일의 구조는 다음과 같습니다.
@@ -72,6 +88,8 @@ python.zip
 ├── user.py          # 메인 함수 파일
 └── requirements.txt # 의존성 관리 파일
 ```
+
+<a id="userpy"></a>
 
 #### user.py
 기본 YAML 처리 함수가 포함되어 있습니다.
@@ -90,12 +108,18 @@ def main():
     return yaml.dump(yaml.safe_load(document))
 ```
 
+<a id="requirementstxt"></a>
+
 #### requirements.txt
 ```txt
 pyyaml
 ```
 
+<a id="local-development-process"></a>
+
 ### 로컬 개발 과정
+
+<a id="unzip"></a>
 
 #### 1. 압축 해제
 ```bash
@@ -105,6 +129,8 @@ unzip python.zip -d my-function
 # 작업 디렉터리 이동
 cd my-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. 함수 코드 수정
 `user.py` 파일을 원하는 로직으로 수정합니다.
@@ -147,6 +173,8 @@ def main():
         }, ensure_ascii=False)
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. ZIP 파일로 압축
 수정된 코드를 다시 ZIP 파일로 압축합니다.
 
@@ -164,10 +192,16 @@ zip my-function.zip user.py requirements.txt
 zip -r my-function.zip . -x "*.git*" "__pycache__/*" "*.pyc" "test.py"
 ```
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Cloud Functions 콘솔에서 업로드
 > 함수를 생성하거나 수정할 때 사용자 로컬 환경의 파일을 업로드 시 사용. (콘솔 사용 가이드 참고)
 
+<a id="cautions-for-upload"></a>
+
 ### 업로드 시 주의사항
+
+<a id="zip-file-structure"></a>
 
 #### ZIP 파일 구조
 - ZIP 파일의 루트에 직접 `.py` 파일과 `requirements.txt`가 위치해야 합니다.
@@ -189,9 +223,13 @@ my-function.zip
     └── requirements.txt
 ```
 
+<a id="file-size-limit"></a>
+
 #### 파일 크기 제한
 - ZIP 파일 크기는 100MiB 이하로 제한됩니다.
 - `__pycache__` 폴더는 포함하지 마세요.
+
+<a id="files-to-exclude"></a>
 
 #### 제외할 파일들
 ```bash
@@ -206,7 +244,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
+<a id="process-by-http-method"></a>
+
 ## HTTP 메서드별 처리
+
+<a id="process-get-request"></a>
 
 ### GET 요청 처리
 ```python
@@ -230,6 +272,8 @@ def main():
 
     return json.dumps(result, ensure_ascii=False)
 ```
+
+<a id="process-post-request"></a>
 
 ### POST 요청 처리
 ```python
@@ -274,7 +318,11 @@ def main():
         }, ensure_ascii=False), 400
 ```
 
+<a id="manage-packages"></a>
+
 ## 패키지 관리
+
+<a id="write-requirementstxt"></a>
 
 ### requirements.txt 작성
 의존성 관리를 위해 `requirements.txt` 파일을 작성합니다.
@@ -284,6 +332,8 @@ pyyaml
 requests>=2.28.0
 python-dateutil>=2.8.0
 ```
+
+<a id="example-of-external-api-call"></a>
 
 ### 외부 API 호출 예시
 ```python
@@ -326,6 +376,8 @@ def main():
             'details': str(e)
         }, ensure_ascii=False), 500
 ```
+
+<a id="data-processing-example"></a>
 
 ### 데이터 처리 예시
 ```python
@@ -381,7 +433,11 @@ def normalize_name(name):
     return name.strip().title()
 ```
 
+<a id="configure-entry-point"></a>
+
 ## Entry Point 설정
+
+<a id="single-function"></a>
 
 ### 단일 함수
 `파일명.함수명`을 Entry Point로 사용합니다.
@@ -389,6 +445,8 @@ def normalize_name(name):
 파일명: `user.py`
 함수명: `main`
 Entry Point: `user.main`
+
+<a id="multiple-functions"></a>
 
 ### 다중 함수
 하나의 파일에서 여러 함수를 정의할 수 있습니다.
@@ -416,7 +474,11 @@ Entry Point 설정:
 - `handlers.create_user`
 - `handlers.update_user`
 
+<a id="caution"></a>
+
 ## 주의사항
+
+<a id="unsupported-packages"></a>
 
 ### 지원하지 않는 패키지
 현재 아래 특징이 있는 복잡한 패키지는 지원하지 않습니다.
@@ -431,6 +493,8 @@ Entry Point 설정:
 - `pyyaml` (YAML 처리)
 - `python-dateutil` (날짜/시간 처리)
 - `pillow` (이미지 처리 - 기본 기능)
+
+<a id="considerations-for-memory-and-execution-time"></a>
 
 ### 메모리 및 실행 시간 고려사항
 - 함수는 제한된 메모리와 실행 시간 내에서 동작해야 합니다.

--- a/ko/code-template-ruby-guide.md
+++ b/ko/code-template-ruby-guide.md
@@ -1,6 +1,10 @@
+<!-- pre-align:aligned sig=1d5361d8d187 -->
+
 ## Compute > Cloud Functions > 코드 템플릿 가이드 > Ruby
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 Ruby를 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
+
+<a id="template-information"></a>
 
 ## 템플릿 정보
 | 항목              | 값        |
@@ -9,7 +13,11 @@
 | **파일명**         | parse.rb |
 | **Entry Point** | handler  |
 
+<a id="basic-template"></a>
+
 ## 기본 템플릿
+
+<a id="hello-world-example"></a>
 
 ### Hello World 예시
 가장 기본적인 함수 형태입니다.
@@ -29,6 +37,8 @@ def handler(context)
   Rack::Response.new([msg, "\n"]).finish
 end
 ```
+
+<a id="context-object"></a>
 
 ### Context 객체
 함수에 전달되는 `context` 객체를 통해 로거와 요청 정보에 접근할 수 있습니다.
@@ -64,12 +74,18 @@ def handler(context)
 end
 ```
 
+<a id="download-and-use-template-file"></a>
+
 ## 템플릿 파일 다운로드 및 활용
+
+<a id="template-download"></a>
 
 ### 템플릿 다운로드
 Cloud Functions에서 제공하는 Ruby 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 **템플릿 다운로드 링크**: [ruby.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/ruby/ruby.zip)
+
+<a id="template-file-structure"></a>
 
 ### 템플릿 파일 구조
 다운로드한 템플릿 파일의 구조는 다음과 같습니다.
@@ -80,7 +96,11 @@ ruby.zip
 └── Gemfile
 ```
 
+<a id="local-development-process"></a>
+
 ### 로컬 개발 과정
+
+<a id="unzip"></a>
 
 #### 1. 압축 해제
 ```bash
@@ -90,6 +110,8 @@ unzip ruby.zip -d my-function
 # 작업 디렉터리 이동
 cd my-function
 ```
+
+<a id="modify-function-codes"></a>
 
 #### 2. 함수 코드 수정
 `parse.rb` 파일을 원하는 로직으로 수정합니다.
@@ -135,6 +157,8 @@ def handler(context)
 end
 ```
 
+<a id="compress-into-a-zip-file"></a>
+
 #### 3. ZIP 파일로 압축
 수정된 소스 코드를 다시 ZIP 파일로 압축합니다. `parse.rb`와 `Gemfile`이 최상위에 포함되도록 압축해야 합니다.
 
@@ -143,9 +167,13 @@ zip my-function.zip parse.rb Gemfile Gemfile.lock
 ```
 **참고**: `Gemfile.lock` 파일은 배포 단계에서 자동으로 생성되지만, 의존성의 정확한 버전을 미리 확인하거나 고정하고 싶은 경우 로컬에서 `bundle install`을 실행하여 직접 생성한 후 함께 압축할 수 있습니다. `Gemfile.lock` 파일이 포함된 경우 해당 파일에 명시된 버전을 사용하여 빌드됩니다.
 
+<a id="upload-from-cloud-functions-console"></a>
+
 ### Cloud Functions 콘솔에서 업로드
 - 함수 생성 또는 수정 시, **사용자 로컬 환경** 방식을 선택합니다.
 - **파일 선택**을 클릭하여 생성한 `my-function.zip` 파일을 업로드합니다.
+
+<a id="cautions-for-upload"></a>
 
 ### 업로드 시 주의사항
 - **업로드 파일**: `*.rb`, `Gemfile`이 포함된 **ZIP 파일**을 업로드해야 합니다.
@@ -153,7 +181,11 @@ zip my-function.zip parse.rb Gemfile Gemfile.lock
 - **ZIP 파일 구조**: ZIP 파일의 루트에 파일들이 위치해야 합니다.
 - **파일 크기**: ZIP 파일 크기는 100MiB 이하로 제한됩니다.
 
+<a id="process-post-request"></a>
+
 ## HTTP 메서드별 처리
+
+<a id="process-get-request"></a>
 
 ### GET 요청 처리
 ```ruby
@@ -178,6 +210,8 @@ def handler(context)
   Rack::Response.new([response_data], 200, { 'Content-Type' => 'application/json' }).finish
 end
 ```
+
+<a id="process-post-request-2"></a>
 
 ### POST 요청 처리
 ```ruby
@@ -214,6 +248,8 @@ def handler(context)
 end
 ```
 
+<a id="manage-package-gemfile"></a>
+
 ## 패키지 관리(`Gemfile`)
 
 의존성(Gem) 관리를 위해 `Gemfile`을 사용합니다. 필요한 Gem을 추가하고 `bundle install`을 실행하여 `Gemfile.lock`을 생성합니다.
@@ -227,6 +263,8 @@ source "https://rubygems.org"
 gem "nokogiri", "~> 1.18" # XML/HTML 파서
 gem "httparty", "~> 0.23" # HTTP 클라이언트
 ```
+
+<a id="example-of-external-api-call"></a>
 
 ### 외부 API 호출 예시
 ```ruby
@@ -268,6 +306,8 @@ def handler(context)
 end
 ```
 
+<a id="configure-entry-point"></a>
+
 ## Entry Point 설정
 
 Entry Point는 함수명을 사용합니다.
@@ -275,6 +315,8 @@ Entry Point는 함수명을 사용합니다.
 - 파일명: `parse.rb`
 - 함수명: `handler`
 - Entry Point: `handler`
+
+<a id="caution"></a>
 
 ### 주의사항
 - **Bundler 버전**: `Gemfile.lock` 생성 시 Bundler 2.6.2 이상 버전 사용을 권장합니다.

--- a/ko/console-guide.md
+++ b/ko/console-guide.md
@@ -1,14 +1,22 @@
+<!-- pre-align:aligned sig=fda183656939 -->
+
 ## Compute > Cloud Functions > 콘솔 사용 가이드
 이 문서는 Cloud Functions 콘솔에서 함수를 생성하고 관리하는 방법을 설명합니다.
 
+<a id="manage-functions"></a>
+
 ## 함수 관리
 함수를 생성, 수정, 삭제, 복사할 수 있습니다.
+
+<a id="create-functions"></a>
 
 ### 함수 생성
 함수 설정을 하고 코드를 작성하여 빌드한 뒤 **생성** 버튼을 클릭하면 마지막 빌드한 패키지로 함수가 생성됩니다.
 
 ![console-guide-07](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-07.png)
 ![console-guide-08](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-08.png)
+
+<a id="function-settings"></a>
 
 #### 함수 설정
 <table class="it">
@@ -87,6 +95,8 @@
 <br>
 
 
+<a id="code-writing"></a>
+
 #### 코드 작성
 
 ![console-guide-09](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-09.png)
@@ -150,18 +160,28 @@
 
 > **[참고]** <br> 빌드 버튼을 통해 생성된 패키지는 함수 생성/수정 시 마지막 빌드한 패키지가 함수 버전으로 연동됩니다. 함수 생성 전 최소 1회 이상 빌드를 수행해야 합니다.
 
+<a id="modify-functions"></a>
+
 ### 함수 수정
 기존 함수의 함수 설정 및 코드를 수정하기 위해 **수정** 버튼을 클릭해 함수를 수정합니다.
+<a id="non-modifiable-item"></a>
+
 #### 수정 불가 항목
 - 이름, 런타임 환경
     - 해당 항목을 제외한 모든 항목을 수정할 수 있습니다.
+<a id="source-code"></a>
+
 #### 소스 코드
 - 코드 에디터를 사용하는 경우 기존 코드가 로드됩니다.
 - 사용자 로컬 환경의 ZIP 파일을 업로드하여 함수를 생성했을 경우, 코드 에디터로 변경하면 ZIP 파일을 보여주지 않고 기본 템플릿 코드를 로드합니다.
 
+<a id="delete-a-function"></a>
+
 ### 함수 삭제
 ![console-guide-14](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-14.png)
 기존 함수를 선택하여 삭제합니다. 한 번에 여러 함수 삭제가 가능합니다.
+
+<a id="copy-a-function"></a>
 
 ### 함수 복사
 ![console-guide-13](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-13.png)
@@ -169,26 +189,38 @@
 - 트리거는 복사되지 않습니다. (HTTP 트리거는 기본 제공)
 - 버전은 현재 적용된 버전만 복사됩니다.
 
+<a id="about-functions"></a>
+
 ## 함수 정보
+<a id="list-of-functions"></a>
+
 ### 함수 목록
 ![console-guide-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-01.png)
 - 사용자가 생성한 함수 목록을 확인할 수 있습니다.
 - 빌드 상태는 현재 버전의 빌드 상태를 표시합니다.
+<a id="basic-information-of-functions"></a>
+
 ### 함수 기본 정보
 ![console-guide-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-02.png)
 - 함수의 기본 정보를 확인할 수 있습니다.
 - 로그 관리 항목에서 **Log & Crash Search** 버튼을 클릭해 Log & Crash Search 서비스로 이동하여 로그를 확인할 수 있습니다.
+
+<a id="function-versioning"></a>
 
 ### 함수 버전 관리
 ![console-guide-15](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2026-01-27/console-guide-15.png)
 - 함수의 버전을 관리할 수 있습니다.
 - 생성된 모든 버전의 이력을 확인하고, 이전 버전으로 롤백할 수 있습니다.
 
+<a id="versioning-overview"></a>
+
 #### 버전 관리 개요
 함수 생성/수정 화면에서 **빌드** 버튼을 클릭해 코드를 빌드하면 패키지가 생성됩니다.
 - 함수 생성/수정 시 마지막 빌드한 패키지가 함수 버전으로 연동됩니다.
 - 각 버전은 독립적으로 관리되며, 테스트한 버전을 그대로 함수에 적용할 수 있습니다.
 - 함수 생성 시 최소 1회 이상 빌드를 진행해야 함수 생성이 가능합니다.
+
+<a id="version-information"></a>
 
 #### 버전 정보
 <table class="it">
@@ -219,6 +251,8 @@
     </tr>
 </table>
 
+<a id="deploy-versions"></a>
+
 #### 버전 배포
 - 버전 목록에서 배포할 버전을 선택하고 **버전 배포** 버튼을 클릭하면 해당 버전으로 함수가 업데이트됩니다.
 - 현재 적용된 버전은 선택할 수 없습니다.
@@ -227,6 +261,8 @@
 
 > **[참고]**
 > <br>버전 배포 시 확인 팝업이 표시되며, 성공 시 버전 목록이 자동으로 갱신됩니다.
+
+<a id="delete-versions"></a>
 
 #### 버전 삭제
 - 버전 목록에서 삭제할 버전을 선택하고 **버전 삭제** 버튼을 클릭하면 해당 버전이 삭제됩니다.
@@ -237,11 +273,15 @@
 > **[참고]**
 > <br>버전 삭제 시 확인 팝업이 표시되며, 삭제된 버전은 복구할 수 없습니다.
 
+<a id="constraints"></a>
+
 #### 제약 사항
 - 함수 생성/수정 화면에서 빌드한 패키지는 함수 생성/수정을 취소하면 함수 버전으로 연동되지 않습니다.
 - 함수 삭제 시 해당 함수와 연동된 모든 버전도 함께 삭제됩니다.
 - 함수 복사 시 원본 함수의 현재 적용된 버전만 복사되며, 모든 버전 이력이 복사되지는 않습니다.
 - 함수 생성 시 여러 런타임으로 빌드할 수 있으나, 함수 수정 시에는 생성 당시 선택한 런타임으로만 빌드할 수 있습니다.
+
+<a id="manage-function-triggers"></a>
 
 ### 함수 트리거 관리
 - 함수를 실행할 수 있는 트리거를 관리할 수 있습니다.
@@ -254,14 +294,20 @@
     - 예시 : `https://{userdomain}/{함수명}`
     - Method : GET, POST
 
+<a id="createedit-triggers"></a>
+
 #### 트리거 생성/수정
 - Timer
     - Value: Cron 문자열로 주기를 입력합니다.
 - API Gateway
     - API Gateway 서비스를 이용하여 HTTP Endpoint를 추가할 수 있습니다.
 
+<a id="delete-triggers"></a>
+
 #### 트리거 삭제
 - 여러 건의 트리거를 선택하여 삭제할 수 있습니다. 기본 트리거인 HTTP 트리거는 삭제할 수 없습니다.
+
+<a id="monitor-functions"></a>
 
 ### 함수 모니터링
 ![console-guide-06](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-06.png)

--- a/ko/overview.md
+++ b/ko/overview.md
@@ -1,5 +1,9 @@
+<!-- pre-align:aligned sig=92acb111e0a0 -->
+
 ## Compute > Cloud Functions > 개요
 사용자는 함수 단위로 코드를 작성할 수 있으며, 특정 이벤트 발생 시 정의된 함수가 자동으로 실행되어 필요한 작업을 처리합니다. 서버 관리나 인프라 설정 없이 애플리케이션 로직에만 집중할 수 있습니다.
+
+<a id="features"></a>
 
 ### 특징
 - 비용 효율성
@@ -13,15 +17,21 @@
     - 다양한 언어 및 런타임을 지원합니다.
     - 이벤트 기반 아키텍처로 다양한 활용이 가능합니다.
 
+<a id="main-features"></a>
+
 ### 주요 기능
 - 다양한 언어(환경)를 제공합니다.
 - **코드 에디터**를 통해 간단한 함수 단위 코드를 작성할 수 있습니다.
 - 함수를 수행할 수 있는 HTTPS Endpoint를 기본 제공합니다.
 - 함수를 일정 주기로 반복 수행할 수 있습니다.
 
+<a id="two-modes-available"></a>
+
 ### 두 가지 모드 제공
 - Pool Manager
 - New Deployment
+<a id="pool-manager"></a>
+
 #### Pool Manager
 - 함수가 수행될 때만 인스턴스가 생성되어 리소스를 사용합니다.
 - 일정 기간 함수가 수행되지 않으면 인스턴스는 사라지고 리소스 사용량은 0이 됩니다.
@@ -29,12 +39,16 @@
 
 ![overview-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_1_ko.png)
 
+<a id="new-deployment"></a>
+
 #### New Deployment
 - 함수를 생성하면 바로 인스턴스가 생성되어 일정량의 리소스를 계속 사용합니다.
 - 빠른 응답을 위해 인스턴스 생성을 유지합니다.
 - 함수 수행 요청량이 많고 빠른 응답이 필요한 경우 사용합니다.
 
 ![overview-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_2_ko.png)
+
+<a id="supported-languages"></a>
 
 ### 지원 언어
 
@@ -56,6 +70,8 @@
 |        | 2.6.1(사용 중단)     | 2024-01-30 | 2025-01-30 |
 | .NET   | 8                 | 2026-11-10 | 2027-11-10 |
 |        | 7(사용 중단)         | 2024-05-14 | 2025-05-14 |
+
+<a id="trigger"></a>
 
 ### Trigger
 - HTTP Trigger

--- a/ko/release-notes.md
+++ b/ko/release-notes.md
@@ -1,22 +1,38 @@
+<!-- pre-align:aligned sig=06519d7ca905 -->
+
 ## Compute > Cloud Functions > 릴리스 노트
 
+<a id="april-14-2026"></a>
+
 ### 2026. 04. 14.
+
+<a id="added-features"></a>
 
 #### 기능 추가
 - Public API v1.0 추가
   - API로 Cloud Functions를 이용할 수 있습니다.
 
+<a id="january-27-2026"></a>
+
 ### 2026. 01. 27.
+
+<a id="january-27-2026-added-features"></a>
 
 #### 기능 추가
 - 함수 버전 관리 기능 추가
   - 빌드한 패키지를 버전으로 관리하고 이전 버전으로 롤백할 수 있습니다.
 
+<a id="november-25-2025"></a>
+
 ### 2025. 11. 25.
+
+<a id="november-25-2025-added-features"></a>
 
 #### 기능 추가
 - API Gateway 트리거 추가
   - 동일 프로젝트의 API Gateway 서비스를 활용하여 API Gateway 트리거를 생성할 수 있습니다.
+
+<a id="feature-updates"></a>
 
 #### 기능 개선
 - 런타임 환경 최신 버전 추가 및 일부 버전 사용 중단
@@ -26,7 +42,11 @@
   - Ruby 2.6.1 사용 중단, Ruby 3.4.5 추가
   - .NET 7 사용 중단, .NET 8 추가
 
+<a id="july-29-2025"></a>
+
 ### 2025. 07. 29.
+
+<a id="launch-cloud-functions-service"></a>
 
 #### Cloud Functions 서비스 출시
 - 사용자는 함수 단위로 코드를 작성할 수 있으며, 특정 이벤트 발생 시 정의된 함수가 자동으로 실행되어 필요한 작업을 처리합니다. 서버 관리나 인프라 설정 없이 애플리케이션 로직에만 집중할 수 있습니다.

--- a/ko/trigger-guide.md
+++ b/ko/trigger-guide.md
@@ -1,10 +1,16 @@
+<!-- pre-align:aligned sig=02be28f736c7 -->
+
 ## Compute > Cloud Functions > 트리거 가이드
 
 이 문서는 Cloud Functions에서 제공하는 트리거 유형과 설정 방법을 설명합니다.
 
+<a id="trigger-overview"></a>
+
 ## 트리거 개요
 
 트리거는 함수를 실행시키는 이벤트 소스입니다. Cloud Functions는 다양한 유형의 트리거를 제공하여 여러 방식으로 함수를 호출할 수 있습니다.
+
+<a id="supported-triggers"></a>
 
 ### 지원 트리거 유형
 
@@ -14,9 +20,13 @@
 | Timer       | 지정된 시간 또는 주기에 따라 함수 실행 | X     |
 | API Gateway | API Gateway를 통해 함수 실행  | X     |
 
+<a id="http-trigger"></a>
+
 ## HTTP 트리거
 
 HTTP 트리거는 함수 생성 시 기본으로 제공되며, HTTP 요청을 통해 함수를 실행할 수 있습니다.
+
+<a id="features"></a>
 
 ### 특징
 
@@ -24,19 +34,27 @@ HTTP 트리거는 함수 생성 시 기본으로 제공되며, HTTP 요청을 �
 - 삭제할 수 없으며, 활성화/비활성화만 가능합니다.
 - GET, POST 메서드를 지원합니다.
 
+<a id="url-format-of-http-trigger"></a>
+
 ### HTTP 트리거 URL 형식
 
 ```
 https://{userdomain}/{함수명}
 ```
 
+<a id="examples"></a>
+
 ### 사용 예시
+
+<a id="request-get"></a>
 
 #### GET 요청
 
 ```bash
 curl -X GET "https://{userdomain}/{함수명}?param1=value1&param2=value2"
 ```
+
+<a id="request-post"></a>
 
 #### POST 요청
 
@@ -45,6 +63,8 @@ curl -X POST "https://{userdomain}/{함수명}" \
   -H "Content-Type: application/json" \
   -d '{"key": "value"}'
 ```
+
+<a id="enabledisable-http-trigger"></a>
 
 ### HTTP 트리거 활성화/비활성화
 
@@ -55,9 +75,13 @@ curl -X POST "https://{userdomain}/{함수명}" \
 > **[참고]**
 > <br>비활성화된 HTTP 트리거로 요청을 보내면 함수가 실행되지 않습니다.
 
+<a id="timer-trigger"></a>
+
 ## Timer 트리거
 
 Timer 트리거는 지정된 시간 또는 주기에 따라 자동으로 함수를 실행합니다. Cron 표현식을 사용하여 실행 주기를 설정할 수 있습니다.
+
+<a id="create-timer-trigger"></a>
 
 ### Timer 트리거 생성
 
@@ -69,6 +93,8 @@ Timer 트리거는 지정된 시간 또는 주기에 따라 자동으로 함수�
 4. 트리거의 유형을 **Timer**로 선택합니다.
 5. **Value**에 Cron 표현식을 입력합니다.
 6. **생성**을 클릭합니다.
+
+<a id="cron-expression-format"></a>
 
 ### Cron 표현식 형식
 
@@ -85,6 +111,8 @@ Cron 표현식은 다음과 같은 형식을 따릅니다.
 └─────────── 초 (0-59)
 ```
 
+<a id="cron-expression-field"></a>
+
 #### Cron 표현식 필드
 
 | 필드              | 필수  | 허용 값            | 허용 특수 문자  |
@@ -95,6 +123,8 @@ Cron 표현식은 다음과 같은 형식을 따릅니다.
 | 일(Day of month) | Yes | 1-31            | * / , - ? |
 | 월(Month)        | Yes | 1-12 또는 JAN-DEC | * / , -   |
 | 요일(Day of week) | Yes | 0-6 또는 SUN-SAT  | * / , - ? |
+
+<a id="special-characters-details"></a>
 
 #### 특수 문자 설명
 
@@ -118,6 +148,8 @@ Cron 표현식은 다음과 같은 형식을 따릅니다.
 
 일(Day of month) 또는 요일(Day of week) 필드를 비워두기 위해 `*` 대신 사용할 수 있습니다.
 
+<a id="example-of-cron-expression"></a>
+
 ### Cron 표현식 예시
 
 | Cron 표현식               | 설명                              |
@@ -131,6 +163,8 @@ Cron 표현식은 다음과 같은 형식을 따릅니다.
 | `0 0 9-18 * * MON-FRI` | 평일(월-금) 오전 9시부터 오후 6시까지 매시간 실행 |
 | `30 0 12 * * *`        | 매일 오후 12시 0분 30초에 실행            |
 | `0 0 0 1 JAN *`        | 매년 1월 1일 자정에 실행                 |
+
+<a id="modify-timer-trigger"></a>
 
 ### Timer 트리거 수정
 
@@ -146,14 +180,20 @@ Cron 표현식은 다음과 같은 형식을 따릅니다.
 > **[참고]**
 > <br>월(Month)과 요일(Day of week) 필드 값은 대소문자를 구분하지 않습니다. "SUN", "Sun", "sun"은 모두 동일하게 인식됩니다.
 
+<a id="api-gateway-trigger"></a>
+
 ## API Gateway 트리거
 
 API Gateway 트리거는 동일 프로젝트의 API Gateway 서비스를 활용하여 함수를 실행할 수 있습니다. API Gateway를 통해 더욱 세밀한 API 관리와 제어가 가능합니다.
+
+<a id="prerequisites"></a>
 
 ### 사전 요구사항
 
 - 동일 프로젝트에 API Gateway 서비스가 활성화되어 있어야 합니다.
   - 활성화되어 있지 않는 경우 트리거 생성 시 활성화 가능합니다.
+
+<a id="create-api-gateway-trigger"></a>
 
 ### API Gateway 트리거 생성
 
@@ -167,19 +207,27 @@ API Gateway 트리거는 동일 프로젝트의 API Gateway 서비스를 활용�
    * 중복된 경로는 사용 불가능합니다.
 6. **생성**을 클릭합니다.
 
+<a id="api-gateway-trigger-url-format"></a>
+
 ### API Gateway 트리거 URL 형식
 
 ```
 https://{stageurl}/{경로}
 ```
 
+<a id="api-gateway-trigger-examples"></a>
+
 ### 사용 예시
+
+<a id="api-gateway-trigger-examples-request-get"></a>
 
 #### GET 요청
 
 ```bash
 curl -X GET "https://{stageurl}/{경로}?param1=value1&param2=value2"
 ```
+
+<a id="api-gateway-trigger-examples-request-post"></a>
 
 #### POST 요청
 
@@ -188,6 +236,8 @@ curl -X POST "https://{stageurl}/{경로}" \
   -H "Content-Type: application/json" \
   -d '{"key": "value"}'
 ```
+
+<a id="features-of-api-gateway-trigger"></a>
 
 ### API Gateway 트리거 특징
 
@@ -199,6 +249,8 @@ curl -X POST "https://{stageurl}/{경로}" \
 - API Gateway 콘솔에서 API 설정을 관리할 수 있습니다.
 - 자동으로 생성된 하나의 서비스에서만 함수 연동이 가능합니다.
 - HTTP 트리거와 동일하게 GET, POST 메서드를 지원합니다.
+
+<a id="modify-api-gateway-trigger"></a>
 
 ### API Gateway 트리거 수정
 
@@ -216,13 +268,19 @@ curl -X POST "https://{stageurl}/{경로}" \
 > <br>이로 인해 해당 리소스에 적용된 플러그인이 전부 제거됩니다.
 > <br>플러그인이 적용된 리소스 경로를 변경하려면 수정 대신 새로운 트리거를 추가하는 것을 권장합니다.
 
+<a id="use-with-api-gateway"></a>
+
 ### API Gateway와 함께 사용하기
 
 API Gateway 트리거를 생성하면 API Gateway 콘솔에서 추가 설정을 할 수 있습니다.
 
 자세한 내용은 [API Gateway 가이드](https://docs.nhncloud.com/ko/Application%20Service/API%20Gateway/ko/overview/)를 참고하세요.
 
+<a id="delete-trigger"></a>
+
 ## 트리거 삭제
+
+<a id="how-to-delete-trigger"></a>
 
 ### 트리거 삭제 방법
 
@@ -234,13 +292,19 @@ API Gateway 트리거를 생성하면 API Gateway 콘솔에서 추가 설정을 
 4. **트리거 삭제**를 클릭합니다.
 5. **트리거 삭제** 모달 창에서 **삭제**를 클릭합니다.
 
+<a id="cautions"></a>
+
 ### 주의사항
 
 - HTTP 트리거는 삭제할 수 없습니다. HTTP 트리거는 기본 트리거로 제공되며, 활성화/비활성화만 가능합니다.
 - 트리거를 삭제하면 해당 이벤트를 통해 함수를 실행할 수 없습니다.
 - 삭제된 트리거는 복구할 수 없습니다.
 
+<a id="restrictions"></a>
+
 ## 트리거 제한사항
+
+<a id="restrictions-for-api-gateway-trigger"></a>
 
 ### API Gateway 트리거 제한사항
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Existing body text is never modified.** The heading match only sees outlines and edits heading lines. Missing sections, however, get a **machine-translated body** (0 section[s] this run) — review the translated wording before merging.

## Analysis

| | |
| --- | --- |
| Engine | `claude-code (CLI)` |
| Model | `claude-haiku-4-5` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `alpha` |
| Scope | 11 doc(s) scanned · 33 file(s) changed |
| Self-verify | ✅ all aligned |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/main/26/ |
| Generated | 2026-07-07T00:18:48 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`alpha`): [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FCloud-Functions%2Ftree%2Falpha&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FCloud-Functions%2Fpull%2F56&source=ko&langs=en%2Cja)

## Link check

이 PR 의 링크 상태: [Link Check ↗](http://content-agent.cloud.toastoven.net:7700/link-check?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FCloud-Functions%2Fpull%2F56&ref=alpha&langs=en%2Cja)

<!-- LINK_CHECK_SUMMARY -->

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ko/api-guide-v1-0.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/api-guide-v1-0.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/api-guide-v1-0.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-dotnet-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-dotnet-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-dotnet-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-go-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-go-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-go-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-java-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-java-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-java-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-node-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-node-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-node-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-python-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-python-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-python-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-ruby-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-ruby-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-ruby-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/trigger-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/trigger-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/trigger-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Cloud-Functions`