### PR TITLE
chore(pre-align): align heading structure (11 docs) with ko

### DIFF
--- a/en/api-guide-v1-0.md
+++ b/en/api-guide-v1-0.md
@@ -1,16 +1,15 @@
 <!-- pre-align:aligned sig=f22611a38cd5 -->
 
-## Cloud Functions API v1.0 Guide
+<a id="cloud-functions-api-v10-guide"></a>
+## Cloud Functions API v1.0 Guide { #cloud-functions-api-v10-guide }
 
 **Compute > Cloud Functions > API Guide > API v1.0 Guide**
 
 <a id="cloud-functions-api-v10-common-information"></a>
-
-## Cloud Functions API v1.0 Common Information
+## Cloud Functions API v1.0 Common Information { #cloud-functions-api-v10-common-information }
 
 <a id="api-endpoint"></a>
-
-### API Endpoint
+### API Endpoint { #api-endpoint }
 
 The endpoints by region for calling the Cloud Functions API are as follows:
 
@@ -19,16 +18,14 @@ The endpoints by region for calling the Cloud Functions API are as follows:
 | Korea (Pangyo) Region | https://kr1-cloud-functions.api.nhncloudservice.com |
 
 <a id="authentication-and-authorization"></a>
-
-### Authentication and Authorization
+### Authentication and Authorization { #authentication-and-authorization }
 
 Cloud Functions uses User Access Key tokens for authentication and authorization when making API calls.
 The User Access Key token is a temporary, Bearer-type access token issued from a User Access Key.
 For more information on issuing and using User Access Key tokens, refer to the [User Access Key Token](/nhncloud/en/public-api/user-access-key-token).
 
 <a id="response-common-information"></a>
-
-### Response Common Information
+### Response Common Information { #response-common-information }
 
 Every API response follows the common format as below:
 
@@ -77,22 +74,19 @@ Every API response follows the common format as below:
 ---
 
 <a id="list-environments"></a>
-
-## List Environments
+## List Environments { #list-environments }
 
 Retrieves a list of available runtime environments.
 
 <a id="request"></a>
-
-### Request
+### Request { #request }
 
 ```
 GET /v1.0/env/list
 ```
 
 <a id="request-parameter"></a>
-
-### Request Parameter
+### Request Parameter { #request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -100,14 +94,12 @@ GET /v1.0/env/list
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 
 <a id="request-body"></a>
-
-### Request Body
+### Request Body { #request-body }
 
 This API does not require a request body.
 
 <a id="response"></a>
-
-### Response
+### Response { #response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -149,22 +141,19 @@ This API does not require a request body.
 ---
 
 <a id="list-functions"></a>
-
-## List Functions
+## List Functions { #list-functions }
 
 Retrieves a list of functions.
 
 <a id="list-functions-request"></a>
-
-### Request
+### Request { #list-functions-request }
 
 ```
 GET /v1.0/functions
 ```
 
 <a id="list-functions-request-parameter"></a>
-
-### Request Parameter
+### Request Parameter { #list-functions-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -174,14 +163,12 @@ GET /v1.0/functions
 | pageSize | Query | Integer | N | Number of items to display per page (default: 5,000) |
 
 <a id="list-functions-request-body"></a>
-
-### Request Body
+### Request Body { #list-functions-request-body }
 
 This API does not require a request body.
 
 <a id="list-functions-response"></a>
-
-### Response
+### Response { #list-functions-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -231,22 +218,19 @@ This API does not require a request body.
 ---
 
 <a id="get-function"></a>
-
-## Get Function
+## Get Function { #get-function }
 
 Retrieves detailed information and build logs for a function.
 
 <a id="get-function-request"></a>
-
-### Request
+### Request { #get-function-request }
 
 ```
 GET /v1.0/functions/{functionName}
 ```
 
 <a id="get-function-request-parameter"></a>
-
-### Request Parameter
+### Request Parameter { #get-function-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -255,14 +239,12 @@ GET /v1.0/functions/{functionName}
 | functionName | URL | String | Y | Function name |
 
 <a id="get-function-request-body"></a>
-
-### Request Body
+### Request Body { #get-function-request-body }
 
 This API does not require a request body.
 
 <a id="get-function-response"></a>
-
-### Response
+### Response { #get-function-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -321,8 +303,7 @@ This API does not require a request body.
 ---
 
 <a id="create-function"></a>
-
-## Create Function
+## Create Function { #create-function }
 
 Creates a new function. Upload the source file as multipart/form-data.
 The runtime must be entered in the `{environment}-{version}` format (e.g., NodeJS-22.5.0). Available runtimes can be checked using the List Environments API.
@@ -330,16 +311,14 @@ The runtime must be entered in the `{environment}-{version}` format (e.g., NodeJ
 Required parameters vary depending on the executorType. When using poolManager, requestPerPod is required. When using newDeployment, minInstance and maxInstance are required.
 
 <a id="create-function-request"></a>
-
-### Request
+### Request { #create-function-request }
 
 ```
 POST /v1.0/functions
 ```
 
 <a id="create-function-request-parameter"></a>
-
-### Request Parameter
+### Request Parameter { #create-function-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -347,8 +326,7 @@ POST /v1.0/functions
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 
 <a id="create-function-request-body"></a>
-
-### Request Body
+### Request Body { #create-function-request-body }
 
 Content-Type: multipart/form-data
 
@@ -368,8 +346,7 @@ Content-Type: multipart/form-data
 | sourceFile | Binary | Y | Source code file (ZIP) |
 
 <a id="create-function-response"></a>
-
-### Response
+### Response { #create-function-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -390,24 +367,21 @@ Content-Type: multipart/form-data
 ---
 
 <a id="modify-function"></a>
-
-## Modify Function
+## Modify Function { #modify-function }
 
 Modifies a function. The source file can be uploaded as multipart/form-data.
 
 The source file (sourceFile) is optional. If no source file is included, the existing source code is retained.
 
 <a id="modify-function-request"></a>
-
-### Request
+### Request { #modify-function-request }
 
 ```
 PUT /v1.0/functions/{functionName}
 ```
 
 <a id="modify-function-request-parameter"></a>
-
-### Request Parameter
+### Request Parameter { #modify-function-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -416,8 +390,7 @@ PUT /v1.0/functions/{functionName}
 | functionName | URL | String | Y | Name of the function to modify |
 
 <a id="modify-function-request-body"></a>
-
-### Request Body
+### Request Body { #modify-function-request-body }
 
 Content-Type: multipart/form-data
 
@@ -436,8 +409,7 @@ Content-Type: multipart/form-data
 | sourceFile | Binary | N | Source code file (ZIP) |
 
 <a id="modify-function-response"></a>
-
-### Response
+### Response { #modify-function-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -458,22 +430,19 @@ Content-Type: multipart/form-data
 ---
 
 <a id="delete-functions"></a>
-
-## Delete Functions
+## Delete Functions { #delete-functions }
 
 Deletes functions in bulk.
 
 <a id="delete-functions-request"></a>
-
-### Request
+### Request { #delete-functions-request }
 
 ```
 DELETE /v1.0/functions
 ```
 
 <a id="delete-functions-request-parameter"></a>
-
-### Request Parameter
+### Request Parameter { #delete-functions-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -481,8 +450,7 @@ DELETE /v1.0/functions
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 
 <a id="delete-functions-request-body"></a>
-
-### Request Body
+### Request Body { #delete-functions-request-body }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -500,8 +468,7 @@ DELETE /v1.0/functions
 | names | Array | Y | Function name list to delete |
 
 <a id="delete-functions-response"></a>
-
-### Response
+### Response { #delete-functions-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -522,22 +489,19 @@ DELETE /v1.0/functions
 ---
 
 <a id="execute-function-get"></a>
-
-## Execute Function (GET)
+## Execute Function (GET) { #execute-function-get }
 
 Executes a function using the GET method.
 
 <a id="execute-function-get-request"></a>
-
-### Request
+### Request { #execute-function-get-request }
 
 ```
 GET /v1.0/functions/{functionName}/invoke
 ```
 
 <a id="execute-function-get-request-parameter"></a>
-
-### Request Parameter
+### Request Parameter { #execute-function-get-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -546,14 +510,12 @@ GET /v1.0/functions/{functionName}/invoke
 | functionName | URL | String | Y | Function name to execute |
 
 <a id="execute-function-get-request-body"></a>
-
-### Request Body
+### Request Body { #execute-function-get-request-body }
 
 This API does not require a request body.
 
 <a id="execute-function-get-response"></a>
-
-### Response
+### Response { #execute-function-get-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -578,22 +540,19 @@ This API does not require a request body.
 ---
 
 <a id="execute-function-post"></a>
-
-## Execute Function (POST)
+## Execute Function (POST) { #execute-function-post }
 
 Executes a function using the POST method. A request body can be included.
 
 <a id="execute-function-post-request"></a>
-
-### Request
+### Request { #execute-function-post-request }
 
 ```
 POST /v1.0/functions/{functionName}/invoke
 ```
 
 <a id="execute-function-post-request-parameter"></a>
-
-### Request Parameter
+### Request Parameter { #execute-function-post-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -602,8 +561,7 @@ POST /v1.0/functions/{functionName}/invoke
 | functionName | URL | String | Y | Function name to execute |
 
 <a id="execute-function-post-request-body"></a>
-
-### Request Body
+### Request Body { #execute-function-post-request-body }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -621,8 +579,7 @@ POST /v1.0/functions/{functionName}/invoke
 | body | JSON | N | Body to send to the function |
 
 <a id="execute-function-post-response"></a>
-
-### Response
+### Response { #execute-function-post-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -647,22 +604,19 @@ POST /v1.0/functions/{functionName}/invoke
 ---
 
 <a id="list-versions"></a>
-
-## List Versions
+## List Versions { #list-versions }
 
 Retrieves a list of versions (packages) for a function.
 
 <a id="list-versions-request"></a>
-
-### Request
+### Request { #list-versions-request }
 
 ```
 GET /v1.0/functions/{functionName}/versions
 ```
 
 <a id="list-versions-request-parameter"></a>
-
-### Request Parameter
+### Request Parameter { #list-versions-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -671,14 +625,12 @@ GET /v1.0/functions/{functionName}/versions
 | functionName | URL | String | Y | Function name |
 
 <a id="list-versions-request-body"></a>
-
-### Request Body
+### Request Body { #list-versions-request-body }
 
 This API does not require a request body.
 
 <a id="list-versions-response"></a>
-
-### Response
+### Response { #list-versions-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -726,22 +678,19 @@ This API does not require a request body.
 ---
 
 <a id="switch-version"></a>
-
-## Switch Version
+## Switch Version { #switch-version }
 
 Changes the currently active version of a function.
 
 <a id="switch-version-request"></a>
-
-### Request
+### Request { #switch-version-request }
 
 ```
 PUT /v1.0/functions/{functionName}/versions
 ```
 
 <a id="switch-version-request-parameter"></a>
-
-### Request Parameter
+### Request Parameter { #switch-version-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -750,8 +699,7 @@ PUT /v1.0/functions/{functionName}/versions
 | functionName | URL | String | Y | Function name |
 
 <a id="switch-version-request-body"></a>
-
-### Request Body
+### Request Body { #switch-version-request-body }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -769,8 +717,7 @@ PUT /v1.0/functions/{functionName}/versions
 | versionId | Integer | Y | Version ID to convert |
 
 <a id="switch-version-response"></a>
-
-### Response
+### Response { #switch-version-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -791,24 +738,21 @@ PUT /v1.0/functions/{functionName}/versions
 ---
 
 <a id="delete-versions"></a>
-
-## Delete Versions
+## Delete Versions { #delete-versions }
 
 Deletes versions of a function in bulk.
 
 The currently active version cannot be deleted.
 
 <a id="delete-versions-request"></a>
-
-### Request
+### Request { #delete-versions-request }
 
 ```
 DELETE /v1.0/functions/{functionName}/versions
 ```
 
 <a id="delete-versions-request-parameter"></a>
-
-### Request Parameter
+### Request Parameter { #delete-versions-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -817,8 +761,7 @@ DELETE /v1.0/functions/{functionName}/versions
 | functionName | URL | String | Y | Function name |
 
 <a id="delete-versions-request-body"></a>
-
-### Request Body
+### Request Body { #delete-versions-request-body }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -836,8 +779,7 @@ DELETE /v1.0/functions/{functionName}/versions
 | versionIds | Array | Y | Version ID list to delete |
 
 <a id="delete-versions-response"></a>
-
-### Response
+### Response { #delete-versions-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -858,22 +800,19 @@ DELETE /v1.0/functions/{functionName}/versions
 ---
 
 <a id="list-triggers"></a>
-
-## List Triggers
+## List Triggers { #list-triggers }
 
 Retrieves a list of triggers for a function.
 
 <a id="list-triggers-request"></a>
-
-### Request
+### Request { #list-triggers-request }
 
 ```
 GET /v1.0/triggers/{functionName}
 ```
 
 <a id="list-triggers-request-parameter"></a>
-
-### Request Parameter
+### Request Parameter { #list-triggers-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -882,14 +821,12 @@ GET /v1.0/triggers/{functionName}
 | functionName | URL | String | Y | Function name |
 
 <a id="list-triggers-request-body"></a>
-
-### Request Body
+### Request Body { #list-triggers-request-body }
 
 This API does not require a request body.
 
 <a id="list-triggers-response"></a>
-
-### Response
+### Response { #list-triggers-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -931,22 +868,19 @@ This API does not require a request body.
 ---
 
 <a id="create-time-trigger"></a>
-
-## Create Time Trigger
+## Create Time Trigger { #create-time-trigger }
 
 Creates a time trigger for a function.
 
 <a id="create-time-trigger-request"></a>
-
-### Request
+### Request { #create-time-trigger-request }
 
 ```
 POST /v1.0/triggers/{functionName}/time
 ```
 
 <a id="create-time-trigger-request-parameter"></a>
-
-### Request Parameter
+### Request Parameter { #create-time-trigger-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -955,8 +889,7 @@ POST /v1.0/triggers/{functionName}/time
 | functionName | URL | String | Y | Function name |
 
 <a id="create-time-trigger-request-body"></a>
-
-### Request Body
+### Request Body { #create-time-trigger-request-body }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -974,8 +907,7 @@ POST /v1.0/triggers/{functionName}/time
 | cron | String | Y | cron expression |
 
 <a id="create-time-trigger-response"></a>
-
-### Response
+### Response { #create-time-trigger-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -996,22 +928,19 @@ POST /v1.0/triggers/{functionName}/time
 ---
 
 <a id="modify-time-trigger"></a>
-
-## Modify Time Trigger
+## Modify Time Trigger { #modify-time-trigger }
 
 Modifies the cron expression of a time trigger.
 
 <a id="modify-time-trigger-request"></a>
-
-### Request
+### Request { #modify-time-trigger-request }
 
 ```
 PUT /v1.0/triggers/{functionName}/time
 ```
 
 <a id="modify-time-trigger-request-parameter"></a>
-
-### Request Parameter
+### Request Parameter { #modify-time-trigger-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -1020,8 +949,7 @@ PUT /v1.0/triggers/{functionName}/time
 | functionName | URL | String | Y | Function name |
 
 <a id="modify-time-trigger-request-body"></a>
-
-### Request Body
+### Request Body { #modify-time-trigger-request-body }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -1041,8 +969,7 @@ PUT /v1.0/triggers/{functionName}/time
 | cron | String | Y | cron expression |
 
 <a id="modify-time-trigger-response"></a>
-
-### Response
+### Response { #modify-time-trigger-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -1063,22 +990,19 @@ PUT /v1.0/triggers/{functionName}/time
 ---
 
 <a id="delete-time-triggers"></a>
-
-## Delete Time Triggers
+## Delete Time Triggers { #delete-time-triggers }
 
 Deletes time triggers in bulk.
 
 <a id="delete-time-triggers-request"></a>
-
-### Request
+### Request { #delete-time-triggers-request }
 
 ```
 DELETE /v1.0/triggers/{functionName}/time
 ```
 
 <a id="delete-time-triggers-request-parameter"></a>
-
-### Request Parameter
+### Request Parameter { #delete-time-triggers-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -1087,8 +1011,7 @@ DELETE /v1.0/triggers/{functionName}/time
 | functionName | URL | String | Y | Function name |
 
 <a id="delete-time-triggers-request-body"></a>
-
-### Request Body
+### Request Body { #delete-time-triggers-request-body }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -1106,8 +1029,7 @@ DELETE /v1.0/triggers/{functionName}/time
 | names | Array | Y | List of trigger names to delete |
 
 <a id="delete-time-triggers-response"></a>
-
-### Response
+### Response { #delete-time-triggers-response }
 
 <details>
   <summary><strong>Example code</strong></summary>

--- a/en/code-template-dotnet-guide.md
+++ b/en/code-template-dotnet-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=3c324618eb1e -->
 
-## Compute > Cloud Functions > Code Template Guide > .NET
+<a id="compute-cloud-functions-code-template-guide-net"></a>
+## Compute > Cloud Functions > Code Template Guide > .NET { #compute-cloud-functions-code-template-guide-net }
 
 This document details how to develop functions by using .NET from NHN Cloud's Cloud Functions service.
 
 <a id="template-information"></a>
-
-## Template information
+## Template information { #template-information }
 | Item              | Value                  |
 |-----------------|---------|
 | **Supported version**       | 8       |
@@ -14,12 +14,10 @@ This document details how to develop functions by using .NET from NHN Cloud's Cl
 | **Entry point** | func             |
 
 <a id="basic-template"></a>
-
-## Basic template
+## Basic template { #basic-template }
 
 <a id="hello-world-example"></a>
-
-### Hello World example
+### Hello World example { #hello-world-example }
 A basic form of function. Use `NhnContext` of `Nhn.DotNetCore.Api` namespace to access the logger and request information.
 
 ```csharp
@@ -59,8 +57,7 @@ public class NhnFunction
 ```
 
 <a id="context-object"></a>
-
-### Context object
+### Context object { #context-object }
 With the `NhnContext` object, you can access the logger, request, and response.
 
 ```csharp
@@ -106,19 +103,16 @@ public class NhnFunction
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## Download and use template file
+## Download and use template file { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### Template download
+### Template download { #template-download }
 You can download the .NET template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [dotnet.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/dotnet/dotnet.zip)
 
 <a id="template-file-structure"></a>
-
-### Template file structure
+### Template file structure { #template-file-structure }
 The structure of the downloaded template file is as follows:
 
 ```
@@ -129,11 +123,9 @@ dotnet.zip
 ```
 
 <a id="local-development-process"></a>
-
-### Local development process
+### Local development process { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. Unzip
 ```bash
 # Unzip
@@ -144,7 +136,6 @@ cd my-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. Modify function codes
 Modify `func.cs` file with the logic you want.
 
@@ -201,7 +192,6 @@ public class NhnFunction
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file. You must compress it so that `func.cs` and `nuget.txt` are included at the top level.
 
@@ -210,18 +200,15 @@ zip my-function.zip func.cs nuget.txt
 ```
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Upload from Cloud Functions console
+### Upload from Cloud Functions console { #upload-from-cloud-functions-console }
 - When creating or modifying a function, select the **User Local Environment** method.
 - Click **Select File** to upload the `my-function.zip` file you created.
 
 <a id="process-by-http-method"></a>
-
-## Process by HTTP method
+## Process by HTTP method { #process-by-http-method }
 
 <a id="process-get-request"></a>
-
-### Process GET request
+### Process GET request { #process-get-request }
 ```csharp
 using System;
 using Nhn.DotNetCore.Api;
@@ -251,8 +238,7 @@ public class NhnFunction
 ```
 
 <a id="process-post-request"></a>
-
-### Process POST request
+### Process POST request { #process-post-request }
 ```csharp
 using System;
 using System.IO;
@@ -305,8 +291,7 @@ public class NhnFunction
 ```
 
 <a id="manage-package-nugettxt"></a>
-
-## Manage package (`nuget.txt`)
+## Manage package (`nuget.txt`) { #manage-package-nugettxt }
 
 Use the `nuget.txt` file to manage dependencies (NuGet packages). Write the required packages one per line.
 
@@ -316,8 +301,7 @@ Microsoft.Extensions.Configuration:8.0.0
 ```
 
 <a id="example-of-configuration-management"></a>
-
-### Example of configuration management
+### Example of configuration management { #example-of-configuration-management }
 ```csharp
 using System;
 using System.Collections.Generic;
@@ -399,8 +383,7 @@ public class NhnFunction
 ```
 
 <a id="configure-entry-point"></a>
-
-## Configure Entry Point
+## Configure Entry Point { #configure-entry-point }
 
 Entry Point is **file name**. (excluding extention)
 
@@ -410,7 +393,6 @@ Entry Point is **file name**. (excluding extention)
 **Important**: The class name must be `NhnFunction`, and the method acting as a function must have the signature `public string Execute(NhnContext context)`.
 
 <a id="caution"></a>
-
-### Caution
+### Caution { #caution }
 - **Package version**: You can specify the package version in `nuget.txt`. (example: `Newtonsoft.Json:9.0.1`)
 - **Type conflict**: Since type conflicts can occur when adding dependencies, we recommend using the .NET native library whenever possible or using a compatible version of the package.

--- a/en/code-template-go-guide.md
+++ b/en/code-template-go-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=9b45d499c0b7 -->
 
-## Compute > Cloud Functions > Code Template Guide > Go
+<a id="compute-cloud-functions-code-template-guide-go"></a>
+## Compute > Cloud Functions > Code Template Guide > Go { #compute-cloud-functions-code-template-guide-go }
 
 This document details how to develop functions by using Go from NHN Cloud's Cloud Functions service.
 
 <a id="template-information"></a>
-
-## Template information
+## Template information { #template-information }
 | Item              | Value                                        |
 |-----------------|------------------------------------------|
 | **Supported version**       | 1.22, 1.23, 1.24, 1.25 |
@@ -14,12 +14,10 @@ This document details how to develop functions by using Go from NHN Cloud's Clou
 | **Entry Point** | Handler                                  |
 
 <a id="basic-template"></a>
-
-## Basic template
+## Basic template { #basic-template }
 
 <a id="hello-world-example"></a>
-
-### Hello World example
+### Hello World example { #hello-world-example }
 A basic form of function.
 
 ```go
@@ -47,8 +45,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="context-object"></a>
-
-### Context object
+### Context object { #context-object }
 In Go functions, HTTP requests and responses are processed via `http.ResponseWriter` and `*http.Request`.
 
 ```go
@@ -85,19 +82,16 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## Download and use template file
+## Download and use template file { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### Template download
+### Template download { #template-download }
 You can download the Go template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [go.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/go/go.zip)
 
 <a id="template-file-structure"></a>
-
-### Template file structure
+### Template file structure { #template-file-structure }
 The structure of the downloaded template file is as follows:
 
 ```
@@ -107,7 +101,6 @@ go.zip
 ```
 
 <a id="functionsgo"></a>
-
 #### functions.go
 Include basic fake data generation functions.
 ```go
@@ -135,7 +128,6 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="gomod"></a>
-
 #### go.mod
 ```go
 module example.com/ncf
@@ -146,11 +138,9 @@ require github.com/brianvoe/gofakeit/v6 v6.28.0
 ```
 
 <a id="local-development-process"></a>
-
-### Local development process
+### Local development process { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. Unzip
 ```bash
 # Unzip
@@ -161,7 +151,6 @@ cd my-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. Modify function codes
 Modify `functions.go` file with the logic you want.
 
@@ -212,7 +201,6 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file.
 
@@ -231,16 +219,13 @@ zip -r my-function.zip . -x "*.git*" "go.sum" "test.go"
 ```
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Upload from Cloud Functions console
+### Upload from Cloud Functions console { #upload-from-cloud-functions-console }
 > Used when uploading files from the user's local environment when creating or modifying a function. (refer to Console Guide)
 
 <a id="cautions-for-upload"></a>
-
-### Cautions for upload
+### Cautions for upload { #cautions-for-upload }
 
 <a id="zip-file-structure"></a>
-
 #### ZIP file structure
 - The `.go` file and `go.mod` must be located directly in the root of the ZIP file.
 - We recommend avoiding unnecessary folder structures.
@@ -262,13 +247,11 @@ my-function.zip
 ```
 
 <a id="file-size-limit"></a>
-
 #### File size limit
 - ZIP file size is limited to 100MiB.
 - `go.sum` file should not be included.
 
 <a id="files-to-exclude"></a>
-
 #### Files to exclude
 ```bash
 # Similar to .gitignore, exclude the following files:
@@ -282,12 +265,10 @@ zip -r my-function.zip . -x \
 ```
 
 <a id="process-by-http-method"></a>
-
-## Process by HTTP method
+## Process by HTTP method { #process-by-http-method }
 
 <a id="process-get-request"></a>
-
-### Process GET request
+### Process GET request { #process-get-request }
 ```go
 package main
 
@@ -326,8 +307,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="process-post-request"></a>
-
-### Process POST request
+### Process POST request { #process-post-request }
 ```go
 package main
 
@@ -399,12 +379,10 @@ func getOrDefault(value, defaultValue string) string {
 ```
 
 <a id="manage-packages"></a>
-
-## Manage packages
+## Manage packages { #manage-packages }
 
 <a id="write-gomod"></a>
-
-### Write go.mod
+### Write go.mod { #write-gomod }
 Write `go.mod` to manage dependencies.
 
 ```go
@@ -419,8 +397,7 @@ require (
 ```
 
 <a id="example-of-external-api-call"></a>
-
-### Example of external API call
+### Example of external API call { #example-of-external-api-call }
 ```go
 package main
 
@@ -474,8 +451,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="data-processing-example"></a>
-
-### Data processing example
+### Data processing example { #data-processing-example }
 ```go
 package main
 
@@ -569,20 +545,17 @@ func normalizeName(name string) string {
 ```
 
 <a id="configure-entry-point"></a>
-
-## Configure Entry Point
+## Configure Entry Point { #configure-entry-point }
 
 <a id="single-function"></a>
-
-### Single function
+### Single function { #single-function }
 Use the function name as the Entry Point.
 
 Function name: `Handler`
 Entry Point: `Handler`
 
 <a id="multiple-functions"></a>
-
-### Multiple functions
+### Multiple functions { #multiple-functions }
 You can define multiple functions in a single file.
 
 ```go
@@ -623,12 +596,10 @@ Entry Point configuration:
 - `UpdateUser`
 
 <a id="caution"></a>
-
-## Caution
+## Caution { #caution }
 
 <a id="go-version"></a>
-
-### Go version
+### Go version { #go-version }
 | Version | End of Support | End of Service |
 |-----|-----------|-----------|
 | 1.25 | - | - |
@@ -637,7 +608,6 @@ Entry Point configuration:
 | 1.22 | 2026-01-28 | 2026-07-28 |
 
 <a id="go-version-support-policy"></a>
-
 #### Go Version Support Policy
 Cloud Functions follows Go's official release policy. Go releases new major versions twice a year (January and July), and each version is supported only up to the latest two major versions.
 

--- a/en/code-template-java-guide.md
+++ b/en/code-template-java-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=65e9891c8f54 -->
 
-## Compute > Cloud Functions > Code Template Guide > Java
+<a id="compute-cloud-functions-code-template-guide-java"></a>
+## Compute > Cloud Functions > Code Template Guide > Java { #compute-cloud-functions-code-template-guide-java }
 
 This document details how to develop functions by using Java from NHN Cloud's Cloud Functions service.
 
 <a id="template-information"></a>
-
-## Template information
+## Template information { #template-information }
 | Item               | Value                  |
 |-----------------|---------------------|
 | **Supported version**       | 17, 21             |
@@ -14,12 +14,10 @@ This document details how to develop functions by using Java from NHN Cloud's Cl
 | **Entry Point** | example.HelloWorld |
 
 <a id="basic-template"></a>
-
-## Basic template
+## Basic template { #basic-template }
 
 <a id="hello-world-example"></a>
-
-### Hello World example
+### Hello World example { #hello-world-example }
 A basic form of function.
 
 ```java
@@ -38,8 +36,7 @@ public class HelloWorld {
 ```
 
 <a id="context-object-requestentity"></a>
-
-### Context object (RequestEntity)
+### Context object (RequestEntity) { #context-object-requestentity }
 In a Java function, you can access HTTP request information through `RequestEntity`.
 
 ```java
@@ -73,19 +70,16 @@ public class HelloWorld {
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## Download and use template file
+## Download and use template file { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### Template download
+### Template download { #template-download }
 You can download the Java template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [java.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/java/java.zip)
 
 <a id="template-file-structure"></a>
-
-### Template file structure
+### Template file structure { #template-file-structure }
 The structure of the downloaded template file is as follows:
 
 ```
@@ -99,11 +93,9 @@ java.zip
 ```
 
 <a id="local-development-process"></a>
-
-### Local development process
+### Local development process { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. Unzip
 ```bash
 # Unzip
@@ -114,7 +106,6 @@ cd my-java-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. Modify function codes
 Modify `src/main/java/example/HelloWorld.java` file with the logic you want.
 
@@ -167,7 +158,6 @@ public class HelloWorld {
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file. You must compress it so that `pom.xml` and `src` are included at the top level.
 
@@ -186,26 +176,22 @@ zip -r my-function.zip . -x "*.git*" "target/*" "*.log"
 ```
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Upload from Cloud Functions console
+### Upload from Cloud Functions console { #upload-from-cloud-functions-console }
 - When creating or modifying a function, select the **User Local Environment** method.
 - Click **Select File** to upload the `my-function.zip` file you created.
 
 <a id="cautions-for-upload"></a>
-
-### Cautions for upload
+### Cautions for upload { #cautions-for-upload }
 - **Upload File**: Upload **ZIP file** which includes source code and `pom.xml`.
 - **ZIP File Structure**: The `pom.xml` and `src` directory must be located directly in the root of the ZIP file.
 - **File to Exclude**: Do not include unnecessary files such as the `target` directory, `.git` directory, etc.
 - **File Size**: ZIP file size is limited to 100 MiB.
 
 <a id="process-by-http-method"></a>
-
-## Process by HTTP method
+## Process by HTTP method { #process-by-http-method }
 
 <a id="process-get-request"></a>
-
-### Process GET request
+### Process GET request { #process-get-request }
 ```java
 package example;
 
@@ -242,8 +228,7 @@ public class GetHandler {
 ```
 
 <a id="process-post-request"></a>
-
-### Process POST request
+### Process POST request { #process-post-request }
 ```java
 package example;
 
@@ -285,8 +270,7 @@ public class PostHandler {
 ```
 
 <a id="manage-package-pomxml"></a>
-
-## Manage package (`pom.xml`)
+## Manage package (`pom.xml`) { #manage-package-pomxml }
 
 Use the `pom.xml` file to manage dependencies. When you add required libraries to the `dependencies` section, Cloud Functions automatically downloads the dependencies and includes them in the build when you upload your function.
 
@@ -310,8 +294,7 @@ Use the `pom.xml` file to manage dependencies. When you add required libraries t
 ```
 
 <a id="example-of-using-external-libraries"></a>
-
-### Example of using external libraries
+### Example of using external libraries { #example-of-using-external-libraries }
 ```java
 package example;
 
@@ -346,12 +329,10 @@ public class StringUtilsHandler {
 ```
 
 <a id="entry-point-configuration"></a>
-
-## Entry Point configuration
+## Entry Point configuration { #entry-point-configuration }
 
 <a id="single-class"></a>
-
-### Single class
+### Single class { #single-class }
 Use `packagename.classname` as an Entry Point.
 
 - Package name: `example`
@@ -360,7 +341,6 @@ Use `packagename.classname` as an Entry Point.
 - **Important**: Methods that act as functions must have the signature `public ResponseEntity<?> call(RequestEntity<?> req)`.
 
 <a id="caution"></a>
-
-### Caution
+### Caution { #caution }
 - **Project structure**: You must maintain the `src/main/java` directory structure.
 - **Memory and execution time**: Functions must operate within limited resources, so avoid heavy workloads and optimize the code.

--- a/en/code-template-node-guide.md
+++ b/en/code-template-node-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=ce91cd7cb2f1 -->
 
-## Compute > Cloud Functions > Code Template Guide > Node.js
+<a id="compute-cloud-functions-code-template-guide-nodejs"></a>
+## Compute > Cloud Functions > Code Template Guide > Node.js { #compute-cloud-functions-code-template-guide-nodejs }
 
 This document details how to develop functions by using Node.js from NHN Cloud's Cloud Functions service.
 
 <a id="template-information"></a>
-
-## Template information
+## Template information { #template-information }
 | Item           | Value                  |
 |-----------------|-----------------|
 | **Supported version**       | 20.16.0, 22.5.0 |
@@ -14,11 +14,9 @@ This document details how to develop functions by using Node.js from NHN Cloud's
 | **Entry Point** | hello           |
 
 <a id="basic-template"></a>
-
-## Basic template
+## Basic template { #basic-template }
 <a id="hello-world-example"></a>
-
-### Hello World example
+### Hello World example { #hello-world-example }
 A basic form of function.
 
 ```javascript
@@ -31,8 +29,7 @@ module.exports = async (context) => {
 ```
 
 <a id="context-object"></a>
-
-### Context object
+### Context object { #context-object }
 'context' object sent to functions include:
 
 ```javascript
@@ -53,19 +50,16 @@ module.exports = async (context) => {
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## Download and use template file
+## Download and use template file { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### Template download
+### Template download { #template-download }
 You can download the Node.js template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [nodejs.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/nodejs/nodejs.zip)
 
 <a id="template-file-structure"></a>
-
-### Template file structure
+### Template file structure { #template-file-structure }
 The structure of the downloaded template file is as follows:
 
 ```
@@ -75,7 +69,6 @@ nodejs.zip
 ```
 
 <a id="hellojs"></a>
-
 #### hello.js
 Basic Hello World function is included.
 ```javascript
@@ -88,18 +81,15 @@ module.exports = async (context) => {
 ```
 
 <a id="packagejson"></a>
-
 #### package.json
 ```json
 {}
 ```
 
 <a id="local-development-process"></a>
-
-### Local development process
+### Local development process { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. Unzip
 ```bash
 # Unzip
@@ -110,7 +100,6 @@ cd my-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. Modify function codes
 Modify `hello.js` file with the logic you want.
 
@@ -154,7 +143,6 @@ module.exports = async (context) => {
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file.
 
@@ -173,16 +161,13 @@ zip -r my-function.zip . -x "*.git*" "node_modules/*" "test.js"
 ```
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Upload from Cloud Functions console
+### Upload from Cloud Functions console { #upload-from-cloud-functions-console }
 > Used when uploading files from the user's local environment when creating or modifying a function. (refer to Console Guide)
 
 <a id="cautions-for-upload"></a>
-
-### Cautions for upload
+### Cautions for upload { #cautions-for-upload }
 
 <a id="zip-file-structure"></a>
-
 #### ZIP file structure
 - The `.js` file and `package.json` must be located directly in the root of the ZIP file.
 - We recommend avoiding unnecessary folder structures.
@@ -204,13 +189,11 @@ my-function.zip
 ```
 
 <a id="file-size-limit"></a>
-
 #### File size limit
 - ZIP file size is limited to 100MiB.
 - `node_modules` file should not be included. (for dependencies, manageed as `package.json`)
 
 <a id="files-to-exclude"></a>
-
 #### Files to exclude
 ```bash
 # Similar to .gitignore, exclude the following files:
@@ -224,12 +207,10 @@ zip -r my-function.zip . -x \
 ```
 
 <a id="process-by-http-method"></a>
-
-## Process by HTTP method
+## Process by HTTP method { #process-by-http-method }
 
 <a id="process-get-request"></a>
-
-### Process GET request
+### Process GET request { #process-get-request }
 ```javascript
 module.exports = async (context) => {
     if (context.request.method !== 'GET') {
@@ -256,8 +237,7 @@ module.exports = async (context) => {
 ```
 
 <a id="process-post-request"></a>
-
-### Process POST request
+### Process POST request { #process-post-request }
 ```javascript
 module.exports = async (context) => {
     if (context.request.method !== 'POST') {
@@ -303,12 +283,10 @@ module.exports = async (context) => {
 ```
 
 <a id="manage-packages"></a>
-
-## Manage packages
+## Manage packages { #manage-packages }
 
 <a id="write-packagejson"></a>
-
-### Write package.json
+### Write package.json { #write-packagejson }
 Write `package.json` to manage dependencies.
 
 ```json
@@ -327,8 +305,7 @@ Write `package.json` to manage dependencies.
 ```
 
 <a id="example-of-external-api-call"></a>
-
-### Example of external API call
+### Example of external API call { #example-of-external-api-call }
 ```javascript
 const axios = require('axios');
 
@@ -379,8 +356,7 @@ module.exports = async (context) => {
 ```
 
 <a id="data-processing-example"></a>
-
-### Data processing example
+### Data processing example { #data-processing-example }
 ```javascript
 const _ = require('lodash');
 const moment = require('moment');
@@ -435,20 +411,17 @@ module.exports = async (context) => {
 ```
 
 <a id="configure-entry-point"></a>
-
-## Configure Entry Point
+## Configure Entry Point { #configure-entry-point }
 
 <a id="single-function"></a>
-
-### Single function
+### Single function { #single-function }
 Use the function name as the Entry Point.
 
 File name: `hello.js`
 Entry Point: `hello`
 
 <a id="multiple-functions"></a>
-
-### Multiple functions
+### Multiple functions { #multiple-functions }
 You can define multiple functions in a single file.
 
 ```javascript
@@ -484,8 +457,7 @@ Entry Point Configuration:
 - `users.updateUser`
 
 <a id="entry-point-restriction"></a>
-
-### Entry Point restriction
+### Entry Point restriction { #entry-point-restriction }
 - **Subdirectory specification unavailable**: Files in subdirectories of the root directory cannot be specified as Entry Points.
 
 **Right Entry Point:**
@@ -504,12 +476,10 @@ modules/auth.js → modules.auth ❌
 All function files must be located at the root level of the ZIP file.
 
 <a id="caution"></a>
-
-## Caution
+## Caution { #caution }
 
 <a id="commonjs-vs-es-modules"></a>
-
-### CommonJS vs ES Modules
+### CommonJS vs ES Modules { #commonjs-vs-es-modules }
 Cloud Functions currently only supports CommonJS method.
 
 **Available (CommonJS):**
@@ -529,8 +499,7 @@ export default async (context) => {  // ❌ Not supported
 ```
 
 <a id="considerations-for-memory-and-execution-time"></a>
-
-### Considerations for Memory and execution time
+### Considerations for Memory and execution time { #considerations-for-memory-and-execution-time }
 - Functions must operate within limited memory and execution time.
 - Consider stream processing when handling large-scale data.
 - Split long-running tasks appropriately.

--- a/en/code-template-python-guide.md
+++ b/en/code-template-python-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=577d9bcb43c9 -->
 
-## Compute > Cloud Functions > Code Template Guide > Python
+<a id="compute-cloud-functions-code-template-guide-python"></a>
+## Compute > Cloud Functions > Code Template Guide > Python { #compute-cloud-functions-code-template-guide-python }
 
 This document details how to develop functions by using Python from NHN Cloud's Cloud Functions service.
 
 <a id="template-information"></a>
-
-## Template information
+## Template information { #template-information }
 | Item              | Value                  |
 |-----------------|------------------|
 | **Supported version**       | 3.11, 3.12, 3.13 |
@@ -14,12 +14,10 @@ This document details how to develop functions by using Python from NHN Cloud's 
 | **Entry Point** | user.main        |
 
 <a id="basic-template"></a>
-
-## Basic template
+## Basic template { #basic-template }
 
 <a id="hello-world-example"></a>
-
-### Hello World example
+### Hello World example { #hello-world-example }
 A basic form of function.
 
 ```python
@@ -38,8 +36,7 @@ def main():
 ```
 
 <a id="context-object"></a>
-
-### Context object
+### Context object { #context-object }
 Python functions can access HTTP request information through Flask's request object.
 
 ```python
@@ -68,19 +65,16 @@ def main():
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## Download and use template file
+## Download and use template file { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### Template download
+### Template download { #template-download }
 You can download the Python template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [python.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/python/python.zip)
 
 <a id="template-file-structure"></a>
-
-### Template file structure
+### Template file structure { #template-file-structure }
 The structure of the downloaded template file is as follows:
 
 ```
@@ -90,7 +84,6 @@ python.zip
 ```
 
 <a id="userpy"></a>
-
 #### user.py
 Include basic YAML processing functions.
 ```python
@@ -109,18 +102,15 @@ def main():
 ```
 
 <a id="requirementstxt"></a>
-
 #### requirements.txt
 ```txt
 pyyaml
 ```
 
 <a id="local-development-process"></a>
-
-### Local development process
+### Local development process { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. Unzip
 ```bash
 # Unzip
@@ -131,7 +121,6 @@ cd my-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. Modify function codes
 Modify `user.py` file with the logic you want.
 
@@ -174,7 +163,6 @@ def main():
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file.
 
@@ -193,16 +181,13 @@ zip -r my-function.zip . -x "*.git*" "__pycache__/*" "*.pyc" "test.py"
 ```
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Upload from Cloud Functions console
+### Upload from Cloud Functions console { #upload-from-cloud-functions-console }
 > Used when uploading files from the user's local environment when creating or modifying a function. (refer to Console Guide)
 
 <a id="cautions-for-upload"></a>
-
-### Cautions for upload
+### Cautions for upload { #cautions-for-upload }
 
 <a id="zip-file-structure"></a>
-
 #### ZIP file structure
 - The `.py` file and `requirements.txt` must be located directly in the root of the ZIP file.
 - We recommend avoiding unnecessary folder structures.
@@ -224,13 +209,11 @@ my-function.zip
 ```
 
 <a id="file-size-limit"></a>
-
 #### File size limit
 - ZIP file size is limited to 100MiB.
 - `__pycache__` file should not be included.
 
 <a id="files-to-exclude"></a>
-
 #### Files to exclude
 ```bash
 # Similar to .gitignore, exclude the following files:
@@ -245,12 +228,10 @@ zip -r my-function.zip . -x \
 ```
 
 <a id="process-by-http-method"></a>
-
-## Process by HTTP method
+## Process by HTTP method { #process-by-http-method }
 
 <a id="process-get-request"></a>
-
-### Process GET request
+### Process GET request { #process-get-request }
 ```python
 from flask import request
 import json
@@ -274,8 +255,7 @@ def main():
 ```
 
 <a id="process-post-request"></a>
-
-### Process POST request
+### Process POST request { #process-post-request }
 ```python
 from flask import request
 import json
@@ -319,12 +299,10 @@ def main():
 ```
 
 <a id="manage-packages"></a>
-
-## Manage packages
+## Manage packages { #manage-packages }
 
 <a id="write-requirementstxt"></a>
-
-### Write requirements.txt
+### Write requirements.txt { #write-requirementstxt }
 Write `requirements.txt` to manage dependencies.
 
 ```txt
@@ -334,8 +312,7 @@ python-dateutil>=2.8.0
 ```
 
 <a id="example-of-external-api-call"></a>
-
-### Example of external API call
+### Example of external API call { #example-of-external-api-call }
 ```python
 from flask import request
 import json
@@ -378,8 +355,7 @@ def main():
 ```
 
 <a id="data-processing-example"></a>
-
-### Data processing example
+### Data processing example { #data-processing-example }
 ```python
 from flask import request
 import json
@@ -434,12 +410,10 @@ def normalize_name(name):
 ```
 
 <a id="configure-entry-point"></a>
-
-## Configure Entry Point
+## Configure Entry Point { #configure-entry-point }
 
 <a id="single-function"></a>
-
-### Single function
+### Single function { #single-function }
 Use `filename.functionname` as the Entry Point.
 
 File name: `user.py`
@@ -447,8 +421,7 @@ Function name: `main`
 Entry Point: `user.main`
 
 <a id="multiple-functions"></a>
-
-### Multiple functions
+### Multiple functions { #multiple-functions }
 You can define multiple functions in a single file.
 
 ```python
@@ -475,12 +448,10 @@ Entry Point Configuration:
 - `handlers.update_user`
 
 <a id="caution"></a>
-
-## Caution
+## Caution { #caution }
 
 <a id="unsupported-packages"></a>
-
-### Unsupported packages
+### Unsupported packages { #unsupported-packages }
 Complex packages with the following features are not currently supported:
 
 **Examples of unsupported packages:**
@@ -495,8 +466,7 @@ Complex packages with the following features are not currently supported:
 - `pillow` (image processing - basic feature)
 
 <a id="considerations-for-memory-and-execution-time"></a>
-
-### Considerations for Memory and execution time
+### Considerations for Memory and execution time { #considerations-for-memory-and-execution-time }
 - Functions must operate within limited memory and execution time.
 - Consider generator and stream processing when handling large-scale data.
 - Split long-running tasks appropriately.

--- a/en/code-template-ruby-guide.md
+++ b/en/code-template-ruby-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=1d5361d8d187 -->
 
-## Compute > Cloud Functions > Code Template Guide   > Ruby
+<a id="compute-cloud-functions-code-template-guide-ruby"></a>
+## Compute > Cloud Functions > Code Template Guide   > Ruby { #compute-cloud-functions-code-template-guide-ruby }
 
 This document details how to develop functions by using Ruby from NHN Cloud's Cloud Functions service.
 
 <a id="template-information"></a>
-
-## Template information
+## Template information { #template-information }
 | Item         | Value        |
 |-----------------|----------|
 | **Supported version**      | 3.4.5    |
@@ -14,12 +14,10 @@ This document details how to develop functions by using Ruby from NHN Cloud's Cl
 | **Entry Point** | handler |
 
 <a id="basic-template"></a>
-
-## Basic template
+## Basic template { #basic-template }
 
 <a id="hello-world-example"></a>
-
-### Hello World example
+### Hello World example { #hello-world-example }
 A basic form of function.
 
 ```ruby
@@ -39,8 +37,7 @@ end
 ```
 
 <a id="context-object"></a>
-
-### Context object
+### Context object { #context-object }
 You can access logger and request information through the `context` object passed to the function.
 
 ```ruby
@@ -75,19 +72,16 @@ end
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## Download and use template file
+## Download and use template file { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### Template download
+### Template download { #template-download }
 You can download the Ruby template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [ruby.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/ruby/ruby.zip)
 
 <a id="template-file-structure"></a>
-
-### Template file structure
+### Template file structure { #template-file-structure }
 The structure of the downloaded template file is as follows:
 
 ```
@@ -97,11 +91,9 @@ ruby.zip
 ```
 
 <a id="local-development-process"></a>
-
-### Local development process
+### Local development process { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. Unzip
 ```bash
 # Unzip
@@ -112,7 +104,6 @@ cd my-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. Modify function codes
 Modify `parse.rb` file with the logic you want.
 
@@ -158,7 +149,6 @@ end
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file. You must compress it so that `parse.rb` and `Gemfile` are included at the top level.
 
@@ -168,26 +158,22 @@ zip my-function.zip parse.rb Gemfile Gemfile.lock
 **Note**: The `Gemfile.lock` file is automatically created during the deployment phase, but if you want to check or lock the exact versions of your dependencies in advance, you can create one yourself by running `bundle install` locally and then compress it together. If a `Gemfile.lock` file is included, the build will use the versions specified in it.
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Upload from Cloud Functions console
+### Upload from Cloud Functions console { #upload-from-cloud-functions-console }
 - When creating or modifying a function, select the **User Local Environment** method.
 - Click **Select File** to upload the `my-function.zip` file you created.
 
 <a id="cautions-for-upload"></a>
-
-### Cautions for upload
+### Cautions for upload { #cautions-for-upload }
 - **Upload File**: Upload **ZIP file** which includes `*.rb`, `Gemfile`.
   - `Gemfile.lock` file is optional. If included, it will be built with the version specified in the file, and if not present, it will be automatically created during the deployment phase.
 - **ZIP Files Structure**: Files must be located directly in the root of the ZIP file.
 - **File Size**: ZIP file size is limited to 100 MiB.
 
 <a id="process-post-request"></a>
-
-## Process POST request
+## Process POST request { #process-post-request }
 
 <a id="process-get-request"></a>
-
-### Process GET request
+### Process GET request { #process-get-request }
 ```ruby
 # frozen_string_literal: true
 
@@ -212,8 +198,7 @@ end
 ```
 
 <a id="process-post-request-2"></a>
-
-### Process POST request
+### Process POST request { #process-post-request-2 }
 ```ruby
 # frozen_string_literal: true
 
@@ -249,8 +234,7 @@ end
 ```
 
 <a id="manage-package-gemfile"></a>
-
-## Manage package (`Gemfile`)
+## Manage package (`Gemfile`) { #manage-package-gemfile }
 
 Use `Gemfile` to manage dependencies (gems). Add the required gems and run `bundle install` to generate `Gemfile.lock`.
 
@@ -265,8 +249,7 @@ gem "httparty", "~> 0.23" # HTTP client
 ```
 
 <a id="example-of-external-api-call"></a>
-
-### Example of external API call
+### Example of external API call { #example-of-external-api-call }
 ```ruby
 # frozen_string_literal: true
 
@@ -307,8 +290,7 @@ end
 ```
 
 <a id="configure-entry-point"></a>
-
-## Configure Entry Point
+## Configure Entry Point { #configure-entry-point }
 
 Entry Point uses the function name.
 
@@ -317,7 +299,6 @@ Entry Point uses the function name.
 - Entry Point: `handler`
 
 <a id="caution"></a>
-
-### Caution
+### Caution { #caution }
 - **Bundler version**: We recommend using Bundler 2.6.2 or later when generating `Gemfile.lock`.
 - **Some Gem compatibility such as ActiveSupport**: Some gems that rely on C extensions, such as `ActiveSupport`, or have complex internal structures may have compatibility issues with the current Cloud Functions environment. The `activesupport` Gem internally depends on the `zeitwerk` Gem, and the way this Gem navigates the filesystem may conflict with the execution environment, causing it to malfunction. Therefore, we recommend using standard libraries or Gems with fewer external dependencies as much as possible.

--- a/en/console-guide.md
+++ b/en/console-guide.md
@@ -1,23 +1,21 @@
 <!-- pre-align:aligned sig=fda183656939 -->
 
-## Compute > Cloud Functions > Console User Guide
+<a id="compute-cloud-functions-console-user-guide"></a>
+## Compute > Cloud Functions > Console User Guide { #compute-cloud-functions-console-user-guide }
 This document describes how to create and manage functions in Cloud Functions console.
 
 <a id="manage-functions"></a>
-
-## Manage functions
+## Manage functions { #manage-functions }
 You can create, edit, delete, and copy functions.
 
 <a id="create-functions"></a>
-
-### Create functions
+### Create functions { #create-functions }
 Configure the function, write your code, and build it. Then, click **Create** to deploy the function using the latest built package.
 
 ![console-guide-07](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-01.png)
 ![console-guide-08](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-02.png)
 
 <a id="function-settings"></a>
-
 #### Function settings
 <table class="it">
     <tr>
@@ -96,7 +94,6 @@ Configure the function, write your code, and build it. Then, click **Create** to
 
 
 <a id="code-writing"></a>
-
 #### Code writing
 
 ![console-guide-09](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-03.png)
@@ -161,59 +158,49 @@ Configure the function, write your code, and build it. Then, click **Create** to
 > **[Note]** <br> Packages generated via Build button are linked to the function version during creation or updates. You must perform at least one build before creating a function
 
 <a id="modify-functions"></a>
-
-### Modify functions
+### Modify functions { #modify-functions }
 To modify the function settings and code of an existing function, click **Modify** button to modify the function.
 <a id="non-modifiable-item"></a>
-
 #### Non-modifiable item
 - Name, runtime environment
     - You can edit everything except the item.
 <a id="source-code"></a>
-
 #### Source code
 - If you're using the code editor, the existing code is loaded.
 - If you created a function by uploading a ZIP file from the local environment, when you switch to the code editor, it loads the default template code without showing the ZIP file.
 
 <a id="delete-a-function"></a>
-
-### Delete a function
+### Delete a function { #delete-a-function }
 ![console-guide-14](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-06.png)
 Select an existing function to delete it. You can delete multiple functions at once.
 
 <a id="copy-a-function"></a>
-
-### Copy a function
+### Copy a function { #copy-a-function }
 ![console-guide-13](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-07.png)
 Copy a function that is identical to an existing function. The name cannot be duplicated, so you can rewrite the name before copying.
 - Triggers are not copied. (HTTP triggers are provided by default).
 - Only the currently applied version will be copied.
 
 <a id="about-functions"></a>
-
-## About functions
+## About functions { #about-functions }
 <a id="list-of-functions"></a>
-
-### List of functions
+### List of functions { #list-of-functions }
 ![console-guide-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-08.png)
 - You can see a list of functions that users have created.
 - Build status shows the build status of the current version.
 <a id="basic-information-of-functions"></a>
-
-### Basic information of functions
+### Basic information of functions { #basic-information-of-functions }
 ![console-guide-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-09.png)
 - You can see basic information about the function.
 - Click Log & Crash Search in the Log Management section to view your logs in the Log & Crash Search service.
 
 <a id="function-versioning"></a>
-
-### Function versioning
+### Function versioning { #function-versioning }
 ![console-guide-15](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2026-01-27/console-guide-en-15.png)
 - You can manage function versions.
 - You can view version history and rollback to any previous version.
 
 <a id="versioning-overview"></a>
-
 #### Versioning overview
 Build your code by clicking **Build** in the function creation or modification screen to generate a package.
 - When you create or update a function, the latest built package is integrated into the function version.
@@ -221,7 +208,6 @@ Build your code by clicking **Build** in the function creation or modification s
 - At least one build is required to enable function creation.
 
 <a id="version-information"></a>
-
 #### Version information
 <table class="it">
     <tr>
@@ -252,7 +238,6 @@ Build your code by clicking **Build** in the function creation or modification s
 </table>
 
 <a id="deploy-versions"></a>
-
 #### Deploy versions
 - Select a version from the list and click **Deploy Version** to update the function to the version.
 - The currently applied version cannot be selected for deployment.
@@ -263,7 +248,6 @@ Build your code by clicking **Build** in the function creation or modification s
 > <br>A confirmation popup will appear upon deployment. Once the deployment is successful, the version list will refresh automatically.
 
 <a id="delete-versions"></a>
-
 #### Delete versions
 - To delete a version, select it from the list and click **Delete Version**.
 - The currently applied version cannot be deleted.
@@ -274,7 +258,6 @@ Build your code by clicking **Build** in the function creation or modification s
 > <br>A confirmation popup will appear when deleting a version. Please note that deleted versions cannot be recovered.
 
 <a id="constraints"></a>
-
 #### Constraints
 - Canceling function creation or modification will prevent the built package from being integrated into a function version.
 - Deleting a function will permanently remove all integrated versions.
@@ -282,8 +265,7 @@ Build your code by clicking **Build** in the function creation or modification s
 - While multiple runtimes are available during function creation, you can only build using the initially selected runtime when modifying the function.
 
 <a id="manage-function-triggers"></a>
-
-### Manage function triggers
+### Manage function triggers { #manage-function-triggers }
 You can manage triggers that can perform functions.
 - HTTP triggers are built-in when creating a function.
     - You can set whether to use through the Enable/Disable features.
@@ -295,7 +277,6 @@ You can manage triggers that can perform functions.
     - Method : GET, POST
 
 <a id="createedit-triggers"></a>
-
 #### Create/edit triggers
 - Timer
     - Value: Enter the cycle as a Cron string.
@@ -303,13 +284,11 @@ You can manage triggers that can perform functions.
     - You can add HTTP Endpoint by using the API Gateway service.
 
 <a id="delete-triggers"></a>
-
 #### Delete triggers
 - You can select multiple triggers to delete. You can't delete the HTTP trigger, which is the default trigger.
 
 <a id="monitor-functions"></a>
-
-### Monitor functions
+### Monitor functions { #monitor-functions }
 ![console-guide-06](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-11.png)
 - You can check the usage of a function.
 - Provide metrics for the number of function calls, number of call rejections, number of errors, success rate, and function execution time.

--- a/en/overview.md
+++ b/en/overview.md
@@ -1,11 +1,11 @@
 <!-- pre-align:aligned sig=92acb111e0a0 -->
 
-## Compute > Cloud Functions > Overview
+<a id="compute-cloud-functions-overview"></a>
+## Compute > Cloud Functions > Overview { #compute-cloud-functions-overview }
 Users can write codes by function unit. Functions defined on a specific event are automatically executed, processing the required tasks. Without server management or infrastructure configuration, you can focus only on application logic.
 
 <a id="features"></a>
-
-### Features
+### Features { #features }
 - Cost-effectiveness
     - Save money with pay-as-you-go pricing.
     - You can reduce management cost as it allocates resources only when necessary.
@@ -18,20 +18,17 @@ Users can write codes by function unit. Functions defined on a specific event ar
     - The event-based architecture is versatile.
 
 <a id="main-features"></a>
-
-### Main features
+### Main features { #main-features }
 - We offer multiple languages (environments).
 - The **code editor** makes you write simple function unit code.
 - Provide an HTTPS Endpoint as standard to perform the function.
 - Iterate the function at regular cycles.
 
 <a id="two-modes-available"></a>
-
-### Two modes available
+### Two modes available { #two-modes-available }
 - Pool Manager
 - New Deployment
 <a id="pool-manager"></a>
-
 #### Pool Manager
 - Instances are created and use resources only when the function is performed.
 - If the function is not performed for a certain period, instances disappear, and the resource usage becomes 0.
@@ -40,7 +37,6 @@ Users can write codes by function unit. Functions defined on a specific event ar
 ![overview-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_1_en.png)
 
 <a id="new-deployment"></a>
-
 #### New Deployment
 - Once functions are created, instances are created, keeping a certain amount of resources being used.
 - Instances are kept to reduce response latency.
@@ -49,8 +45,7 @@ Users can write codes by function unit. Functions defined on a specific event ar
 ![overview-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_2_en.png)
 
 <a id="supported-languages"></a>
-
-### Supported languages
+### Supported languages { #supported-languages }
 | Language     | Version                | End of Support   | End of Service   |
 |--------|-------------------|------------|------------|
 | NodeJS | 22.5.0            | 2027-04-30 | 2027-10-30 |
@@ -71,8 +66,7 @@ Users can write codes by function unit. Functions defined on a specific event ar
 |        | 7 (end of service)         | 2024-05-14 | 2025-05-14 |
 
 <a id="trigger"></a>
-
-### Trigger
+### Trigger { #trigger }
 - HTTP Trigger
     - Basic (support GET, POST)
 - Timer Trigger

--- a/en/release-notes.md
+++ b/en/release-notes.md
@@ -1,39 +1,33 @@
 <!-- pre-align:aligned sig=06519d7ca905 -->
 
-## Compute > Cloud Functions > Release Notes
+<a id="compute-cloud-functions-release-notes"></a>
+## Compute > Cloud Functions > Release Notes { #compute-cloud-functions-release-notes }
 
 <a id="april-14-2026"></a>
-
-### April 14, 2026
+### April 14, 2026 { #april-14-2026 }
 
 <a id="added-features"></a>
-
 #### Added Features
 - Added Public API v1.0
   - Added support for using Cloud Functions via API.
 
 <a id="january-27-2026"></a>
-
-### January 27, 2026
+### January 27, 2026 { #january-27-2026 }
 
 <a id="january-27-2026-added-features"></a>
-
 #### Added Features
 - Added function versioning
   - Manage build packages by version and rollback to previous versions.
 
 <a id="november-25-2025"></a>
-
-### November 25, 2025
+### November 25, 2025 { #november-25-2025 }
 
 <a id="november-25-2025-added-features"></a>
-
 #### Added Features
 - Added API Gateway trigger
   - Added the feature to create API Gateway triggers by utilizing the API Gateway service in the same project.
 
 <a id="feature-updates"></a>
-
 #### Feature Updates
 - Added the latest runtime environment and deprecated some versions
   - Added Go 1.24, 1.25
@@ -43,10 +37,8 @@
   - Deprecated .NET 7, added .NET 8
 
 <a id="july-29-2025"></a>
-
-### July 29. 2025
+### July 29. 2025 { #july-29-2025 }
 
 <a id="launch-cloud-functions-service"></a>
-
 #### Launch Cloud Functions Service
 - Users can write codes by function unit. Functions defined on a specific event are automatically executed, processing the required tasks. Without server management or infrastructure configuration, you can focus only on application logic.

--- a/en/trigger-guide.md
+++ b/en/trigger-guide.md
@@ -1,18 +1,17 @@
 <!-- pre-align:aligned sig=02be28f736c7 -->
 
-## Compute > Cloud Functions > Trigger Guide
+<a id="compute-cloud-functions-trigger-guide"></a>
+## Compute > Cloud Functions > Trigger Guide { #compute-cloud-functions-trigger-guide }
 
 This document describes the trigger types available in Cloud Functions and how to set them up.
 
 <a id="trigger-overview"></a>
-
-## Trigger Overview
+## Trigger Overview { #trigger-overview }
 
 Trigger is an event source to execute functions. Cloud Functions provide various triggers to allow you to call functions in multiple ways.
 
 <a id="supported-triggers"></a>
-
-### Supported Triggers
+### Supported Triggers { #supported-triggers }
 
 | Types | Descriptions | Built-in |
 |-------------|------------------------|-------|
@@ -21,33 +20,28 @@ Trigger is an event source to execute functions. Cloud Functions provide various
 | API Gateway | Execute a function via API Gateway | No |
 
 <a id="http-trigger"></a>
-
-## HTTP Trigger
+## HTTP Trigger { #http-trigger }
 
 HTTP trigger is built-in when creating a function, and you can execute the function with an HTTP request.
 
 <a id="features"></a>
-
-### Features
+### Features { #features }
 
 - When creating a function, it will be automatically created.
 - It cannot be deleted but only enabled or disabled.
 - GET, POST methods are supported.
 
 <a id="url-format-of-http-trigger"></a>
-
-### URL Format of HTTP Trigger
+### URL Format of HTTP Trigger { #url-format-of-http-trigger }
 
 ```
 https://{userdomain}/{function name}
 ```
 
 <a id="examples"></a>
-
-### Examples
+### Examples { #examples }
 
 <a id="request-get"></a>
-
 #### Request GET
 
 ```bash
@@ -55,7 +49,6 @@ curl -X GET "https://{userdomain}/{function name}?param1=value1&param2=value2"
 ```
 
 <a id="request-post"></a>
-
 #### Request POST
 
 ```bash
@@ -65,8 +58,7 @@ curl -X POST "https://{userdomain}/{function name}" \
 ```
 
 <a id="enabledisable-http-trigger"></a>
-
-### Enable/disable HTTP Trigger
+### Enable/disable HTTP Trigger { #enabledisable-http-trigger }
 
 1. Select a function from the Cloud Functions console.
 2. Go to **Trigger** tab.
@@ -76,14 +68,12 @@ curl -X POST "https://{userdomain}/{function name}" \
 > <br>If you send a request with a disabled HTTP trigger, the function will not execute.
 
 <a id="timer-trigger"></a>
-
-## Timer Trigger
+## Timer Trigger { #timer-trigger }
 
 Timer trigger executes a function automatically at the specified time or cycle. You can set up the cycle by using the Cron expression.
 
 <a id="create-timer-trigger"></a>
-
-### Create Timer Trigger
+### Create Timer Trigger { #create-timer-trigger }
 
 ![trigger-guide-05](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-01.png)
 
@@ -95,8 +85,7 @@ Timer trigger executes a function automatically at the specified time or cycle. 
 6. Click **Create**.
 
 <a id="cron-expression-format"></a>
-
-### Cron Expression Format
+### Cron Expression Format { #cron-expression-format }
 
 Cron expression follows the format as below:
 
@@ -112,7 +101,6 @@ Cron expression follows the format as below:
 ```
 
 <a id="cron-expression-field"></a>
-
 #### Cron Expression Field
 
 | Field | Required | Allowed vale | Allowed special character |
@@ -125,7 +113,6 @@ Cron expression follows the format as below:
 | Day of week | Yes | 0-6 or SUN-SAT | * / , - ? |
 
 <a id="special-characters-details"></a>
-
 #### Special Characters Details
 
 `*`
@@ -149,8 +136,7 @@ Used to define scope. For example, using `9-17` in the third field (hours) means
 You can use * instead of leaving the Day of month or Day of week field blank.
 
 <a id="example-of-cron-expression"></a>
-
-### Example of Cron Expression
+### Example of Cron Expression { #example-of-cron-expression }
 
 | Cron Expression | Description |
 |------------------------|---------------------------------|
@@ -165,8 +151,7 @@ You can use * instead of leaving the Day of month or Day of week field blank.
 | `0 0 0 1 JAN *` | Execute every January 1st at midnight |
 
 <a id="modify-timer-trigger"></a>
-
-### Modify Timer Trigger
+### Modify Timer Trigger { #modify-timer-trigger }
 
 ![trigger-guide-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-02.png)
 
@@ -181,21 +166,18 @@ You can use * instead of leaving the Day of month or Day of week field blank.
 > <br>The Month and Day of week field values ​​are case-insensitive. "SUN", "Sun", "sun" are all recognized equally.
 
 <a id="api-gateway-trigger"></a>
-
-## API Gateway Trigger
+## API Gateway Trigger { #api-gateway-trigger }
 
 API Gateway triggers can execute functions by leveraging the API Gateway service in the same project. API Gateway enables more detailed API management and control.
 
 <a id="prerequisites"></a>
-
-### Prerequisites
+### Prerequisites { #prerequisites }
 
 - The API Gateway service must be enabled in the same project.
   - If it isn't enabled, you can enable it when creating a trigger.
 
 <a id="create-api-gateway-trigger"></a>
-
-### Create API Gateway Trigger
+### Create API Gateway Trigger { #create-api-gateway-trigger }
 
 ![trigger-guide-04](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-04.png)
 
@@ -208,19 +190,16 @@ API Gateway triggers can execute functions by leveraging the API Gateway service
 6. Click **Create**.
 
 <a id="api-gateway-trigger-url-format"></a>
-
-### API Gateway Trigger URL Format
+### API Gateway Trigger URL Format { #api-gateway-trigger-url-format }
 
 ```
 https://{stageurl}/{path}
 ```
 
 <a id="api-gateway-trigger-examples"></a>
-
-### Examples
+### Examples { #api-gateway-trigger-examples }
 
 <a id="api-gateway-trigger-examples-request-get"></a>
-
 #### Request GET
 
 ```bash
@@ -228,7 +207,6 @@ curl -X GET "https://{stageurl}/{path}?param1=value1&param2=value2"
 ```
 
 <a id="api-gateway-trigger-examples-request-post"></a>
-
 #### Request POST
 
 ```bash
@@ -238,8 +216,7 @@ curl -X POST "https://{stageurl}/{path}" \
 ```
 
 <a id="features-of-api-gateway-trigger"></a>
-
-### Features of API Gateway Trigger
+### Features of API Gateway Trigger { #features-of-api-gateway-trigger }
 
 - You can leverage various features of API Gateway.
   - Manage authentication and permission
@@ -251,8 +228,7 @@ curl -X POST "https://{stageurl}/{path}" \
 - The service supports GET and POST methods, same as HTTP triggers.
 
 <a id="modify-api-gateway-trigger"></a>
-
-### Modify API Gateway Trigger
+### Modify API Gateway Trigger { #modify-api-gateway-trigger }
 
 ![trigger-guide-05](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-05.png)
 
@@ -269,20 +245,17 @@ curl -X POST "https://{stageurl}/{path}" \
 > <br>If you want to change the resource path to which the plugin is applied, we recommend adding a new trigger instead of modifying it.
 
 <a id="use-with-api-gateway"></a>
-
-### Use with API Gateway
+### Use with API Gateway { #use-with-api-gateway }
 
 Once you create an API Gateway trigger, you can configure additional settings in the API Gateway console.
 
 For more details, please refer to the [API Gateway Guide](https://docs.nhncloud.com/ko/Application%20Service/API%20Gateway/ko/overview/).
 
 <a id="delete-trigger"></a>
-
-## Delete Trigger
+## Delete Trigger { #delete-trigger }
 
 <a id="how-to-delete-trigger"></a>
-
-### How to Delete Trigger
+### How to Delete Trigger { #how-to-delete-trigger }
 
 ![trigger-guide-03](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-03.png)
 
@@ -293,20 +266,17 @@ For more details, please refer to the [API Gateway Guide](https://docs.nhncloud.
 5. Click **Delete** from the modal window of **Delete Trigger**.
 
 <a id="cautions"></a>
-
-### Cautions
+### Cautions { #cautions }
 
 - You cannot delete HTTP trigger. HTTP trigger is built-in, only being enabled or disabled.
 - If deleting the trigger, you cannot execute the function through the event.
 - Deleted triggers cannot be recovered.
 
 <a id="restrictions"></a>
-
-## Restrictions
+## Restrictions { #restrictions }
 
 <a id="restrictions-for-api-gateway-trigger"></a>
-
-### Restrictions for API Gateway Trigger
+### Restrictions for API Gateway Trigger { #restrictions-for-api-gateway-trigger }
 
 - You can only connect API Gateways within the same project.
 - A single API Gateway resource can only be connected with one function. A single function can register multiple API Gateway triggers.

--- a/ja/api-guide-v1-0.md
+++ b/ja/api-guide-v1-0.md
@@ -1,16 +1,15 @@
 <!-- pre-align:aligned sig=f22611a38cd5 -->
 
-## Cloud Functions API v1.0 ガイド
+<a id="cloud-functions-api-v10-guide"></a>
+## Cloud Functions API v1.0 ガイド { #cloud-functions-api-v10-guide }
 
 **Compute > Cloud Functions > API ガイド > API v1.0 ガイド**
 
 <a id="cloud-functions-api-v10-common-information"></a>
-
-## Cloud Functions API v1.0 共通情報
+## Cloud Functions API v1.0 共通情報 { #cloud-functions-api-v10-common-information }
 
 <a id="api-endpoint"></a>
-
-### API エンドポイント
+### API エンドポイント { #api-endpoint }
 
 Cloud Functions APIを呼び出すためのリージョン別エンドポイントは以下のとおりです。
 
@@ -19,16 +18,14 @@ Cloud Functions APIを呼び出すためのリージョン別エンドポイン�
 | 韓国(パンギョ)リージョン | https://kr1-cloud-functions.api.nhncloudservice.com |
 
 <a id="authentication-and-authorization"></a>
-
-### 認証及び権限
+### 認証及び権限 { #authentication-and-authorization }
 
 Cloud Functionsは、API呼び出し時の認証/認可にUser Access Keyトークンを使用します。
 User Access Keyトークンは、User Access Keyをもとに発行されるBearerタイプの一時的なアクセストークンです。
 User Access Keyトークンの発行手順や使用方法の詳細は、[User Access Keyトークン](/nhncloud/ko/public-api/user-access-key-token)をご参照ください。
 
 <a id="response-common-information"></a>
-
-### レスポンス共通情報
+### レスポンス共通情報 { #response-common-information }
 
 全てのAPIレスポンスは以下の共通形式に従います。
 
@@ -77,22 +74,19 @@ User Access Keyトークンの発行手順や使用方法の詳細は、[User Ac
 ---
 
 <a id="list-environments"></a>
-
-## 環境一覧
+## 環境一覧 { #list-environments }
 
 使用可能なランタイム環境一覧を照会します。
 
 <a id="request"></a>
-
-### リクエスト
+### リクエスト { #request }
 
 ```
 GET /v1.0/env/list
 ```
 
 <a id="request-parameter"></a>
-
-### リクエストパラメータ
+### リクエストパラメータ { #request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -100,14 +94,12 @@ GET /v1.0/env/list
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 
 <a id="request-body"></a>
-
-### リクエストボディ
+### リクエストボディ { #request-body }
 
 このAPIはリクエストボディを必要としません。
 
 <a id="response"></a>
-
-### レスポンス
+### レスポンス { #response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -149,22 +141,19 @@ GET /v1.0/env/list
 ---
 
 <a id="list-functions"></a>
-
-## 関数一覧
+## 関数一覧 { #list-functions }
 
 関数一覧を照会します。
 
 <a id="list-functions-request"></a>
-
-### リクエスト
+### リクエスト { #list-functions-request }
 
 ```
 GET /v1.0/functions
 ```
 
 <a id="list-functions-request-parameter"></a>
-
-### リクエストパラメータ
+### リクエストパラメータ { #list-functions-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -174,14 +163,12 @@ GET /v1.0/functions
 | pageSize | Query | Integer | N | 1ページに表示する件数(デフォルト値: 5000) |
 
 <a id="list-functions-request-body"></a>
-
-### リクエストボディ
+### リクエストボディ { #list-functions-request-body }
 
 このAPIはリクエストボディを必要としません。
 
 <a id="list-functions-response"></a>
-
-### レスポンス
+### レスポンス { #list-functions-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -231,22 +218,19 @@ GET /v1.0/functions
 ---
 
 <a id="get-function"></a>
-
-## 関数詳細照会
+## 関数詳細照会 { #get-function }
 
 関数の詳細情報とビルドログを同時に照会します。
 
 <a id="get-function-request"></a>
-
-### リクエスト
+### リクエスト { #get-function-request }
 
 ```
 GET /v1.0/functions/{functionName}
 ```
 
 <a id="get-function-request-parameter"></a>
-
-### リクエストパラメータ
+### リクエストパラメータ { #get-function-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -255,14 +239,12 @@ GET /v1.0/functions/{functionName}
 | functionName | URL | String | Y | 関数名 |
 
 <a id="get-function-request-body"></a>
-
-### リクエストボディ
+### リクエストボディ { #get-function-request-body }
 
 このAPIはリクエストボディを必要としません。
 
 <a id="get-function-response"></a>
-
-### レスポンス
+### レスポンス { #get-function-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -321,8 +303,7 @@ GET /v1.0/functions/{functionName}
 ---
 
 <a id="create-function"></a>
-
-## 関数作成
+## 関数作成 { #create-function }
 
 新しい関数を作成します。multipart/form-dataでソースファイルをアップロードします。
 runtimeは`{environment}-{version}`形式で入力する必要があります(例: NodeJS-22.5.0)。使用可能なランタイムは環境一覧照会APIで確認できます。
@@ -330,16 +311,14 @@ runtimeは`{environment}-{version}`形式で入力する必要があります(�
 executorTypeによって必須パラメータが異なります。poolManagerの場合はrequestPerPodが、newDeploymentの場合はminInstanceとmaxInstanceが必須です。
 
 <a id="create-function-request"></a>
-
-### リクエスト
+### リクエスト { #create-function-request }
 
 ```
 POST /v1.0/functions
 ```
 
 <a id="create-function-request-parameter"></a>
-
-### リクエストパラメータ
+### リクエストパラメータ { #create-function-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -347,8 +326,7 @@ POST /v1.0/functions
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 
 <a id="create-function-request-body"></a>
-
-### リクエストボディ
+### リクエストボディ { #create-function-request-body }
 
 Content-Type: multipart/form-data
 
@@ -368,8 +346,7 @@ Content-Type: multipart/form-data
 | sourceFile | Binary | Y | ソースコードファイル(ZIP) |
 
 <a id="create-function-response"></a>
-
-### レスポンス
+### レスポンス { #create-function-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -390,24 +367,21 @@ Content-Type: multipart/form-data
 ---
 
 <a id="modify-function"></a>
-
-## 関数修正
+## 関数修正 { #modify-function }
 
 関数を修正します。multipart/form-dataでソースファイルをアップロードできます。
 
 ソースファイル(sourceFile)は任意項目です。ソースファイルを指定しない場合、既存のソースコードが維持されます。
 
 <a id="modify-function-request"></a>
-
-### リクエスト
+### リクエスト { #modify-function-request }
 
 ```
 PUT /v1.0/functions/{functionName}
 ```
 
 <a id="modify-function-request-parameter"></a>
-
-### リクエストパラメータ
+### リクエストパラメータ { #modify-function-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -416,8 +390,7 @@ PUT /v1.0/functions/{functionName}
 | functionName | URL | String | Y | 修正する関数名 |
 
 <a id="modify-function-request-body"></a>
-
-### リクエストボディ
+### リクエストボディ { #modify-function-request-body }
 
 Content-Type: multipart/form-data
 
@@ -436,8 +409,7 @@ Content-Type: multipart/form-data
 | sourceFile | Binary | N | ソースコードファイル(ZIP) |
 
 <a id="modify-function-response"></a>
-
-### レスポンス
+### レスポンス { #modify-function-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -458,22 +430,19 @@ Content-Type: multipart/form-data
 ---
 
 <a id="delete-functions"></a>
-
-## 関数削除
+## 関数削除 { #delete-functions }
 
 関数を一括削除します。
 
 <a id="delete-functions-request"></a>
-
-### リクエスト
+### リクエスト { #delete-functions-request }
 
 ```
 DELETE /v1.0/functions
 ```
 
 <a id="delete-functions-request-parameter"></a>
-
-### リクエストパラメータ
+### リクエストパラメータ { #delete-functions-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -481,8 +450,7 @@ DELETE /v1.0/functions
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 
 <a id="delete-functions-request-body"></a>
-
-### リクエストボディ
+### リクエストボディ { #delete-functions-request-body }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -500,8 +468,7 @@ DELETE /v1.0/functions
 | names | Array | Y | 削除する関数名一覧 |
 
 <a id="delete-functions-response"></a>
-
-### レスポンス
+### レスポンス { #delete-functions-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -522,22 +489,19 @@ DELETE /v1.0/functions
 ---
 
 <a id="execute-function-get"></a>
-
-## 関数実行(GET)
+## 関数実行(GET) { #execute-function-get }
 
 GETメソッドで関数を実行します。
 
 <a id="execute-function-get-request"></a>
-
-### リクエスト
+### リクエスト { #execute-function-get-request }
 
 ```
 GET /v1.0/functions/{functionName}/invoke
 ```
 
 <a id="execute-function-get-request-parameter"></a>
-
-### リクエストパラメータ
+### リクエストパラメータ { #execute-function-get-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -546,14 +510,12 @@ GET /v1.0/functions/{functionName}/invoke
 | functionName | URL | String | Y | 実行する関数名 |
 
 <a id="execute-function-get-request-body"></a>
-
-### リクエストボディ
+### リクエストボディ { #execute-function-get-request-body }
 
 このAPIはリクエストボディを必要としません。
 
 <a id="execute-function-get-response"></a>
-
-### レスポンス
+### レスポンス { #execute-function-get-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -578,22 +540,19 @@ GET /v1.0/functions/{functionName}/invoke
 ---
 
 <a id="execute-function-post"></a>
-
-## 関数実行(POST)
+## 関数実行(POST) { #execute-function-post }
 
 POSTメソッドで関数を実行します。bodyを送信できます。
 
 <a id="execute-function-post-request"></a>
-
-### リクエスト
+### リクエスト { #execute-function-post-request }
 
 ```
 POST /v1.0/functions/{functionName}/invoke
 ```
 
 <a id="execute-function-post-request-parameter"></a>
-
-### リクエストパラメータ
+### リクエストパラメータ { #execute-function-post-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -602,8 +561,7 @@ POST /v1.0/functions/{functionName}/invoke
 | functionName | URL | String | Y | 実行する関数名 |
 
 <a id="execute-function-post-request-body"></a>
-
-### リクエストボディ
+### リクエストボディ { #execute-function-post-request-body }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -621,8 +579,7 @@ POST /v1.0/functions/{functionName}/invoke
 | body | JSON | N | 関数に渡すbody |
 
 <a id="execute-function-post-response"></a>
-
-### レスポンス
+### レスポンス { #execute-function-post-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -647,22 +604,19 @@ POST /v1.0/functions/{functionName}/invoke
 ---
 
 <a id="list-versions"></a>
-
-## バージョン一覧
+## バージョン一覧 { #list-versions }
 
 関数のバージョン(パッケージ)一覧を照会します。
 
 <a id="list-versions-request"></a>
-
-### リクエスト
+### リクエスト { #list-versions-request }
 
 ```
 GET /v1.0/functions/{functionName}/versions
 ```
 
 <a id="list-versions-request-parameter"></a>
-
-### リクエストパラメータ
+### リクエストパラメータ { #list-versions-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -671,14 +625,12 @@ GET /v1.0/functions/{functionName}/versions
 | functionName | URL | String | Y | 関数名 |
 
 <a id="list-versions-request-body"></a>
-
-### リクエストボディ
+### リクエストボディ { #list-versions-request-body }
 
 このAPIはリクエストボディを必要としません。
 
 <a id="list-versions-response"></a>
-
-### レスポンス
+### レスポンス { #list-versions-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -726,22 +678,19 @@ GET /v1.0/functions/{functionName}/versions
 ---
 
 <a id="switch-version"></a>
-
-## バージョン切り替え
+## バージョン切り替え { #switch-version }
 
 関数の現在のアクティブバージョンを変更します。
 
 <a id="switch-version-request"></a>
-
-### リクエスト
+### リクエスト { #switch-version-request }
 
 ```
 PUT /v1.0/functions/{functionName}/versions
 ```
 
 <a id="switch-version-request-parameter"></a>
-
-### リクエストパラメータ
+### リクエストパラメータ { #switch-version-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -750,8 +699,7 @@ PUT /v1.0/functions/{functionName}/versions
 | functionName | URL | String | Y | 関数名 |
 
 <a id="switch-version-request-body"></a>
-
-### リクエストボディ
+### リクエストボディ { #switch-version-request-body }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -769,8 +717,7 @@ PUT /v1.0/functions/{functionName}/versions
 | versionId | Integer | Y | 切り替えるバージョンID |
 
 <a id="switch-version-response"></a>
-
-### レスポンス
+### レスポンス { #switch-version-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -791,24 +738,21 @@ PUT /v1.0/functions/{functionName}/versions
 ---
 
 <a id="delete-versions"></a>
-
-## バージョン削除
+## バージョン削除 { #delete-versions }
 
 関数のバージョンを一括削除します。
 
 現在のアクティブバージョンは削除できません。
 
 <a id="delete-versions-request"></a>
-
-### リクエスト
+### リクエスト { #delete-versions-request }
 
 ```
 DELETE /v1.0/functions/{functionName}/versions
 ```
 
 <a id="delete-versions-request-parameter"></a>
-
-### リクエストパラメータ
+### リクエストパラメータ { #delete-versions-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -817,8 +761,7 @@ DELETE /v1.0/functions/{functionName}/versions
 | functionName | URL | String | Y | 関数名 |
 
 <a id="delete-versions-request-body"></a>
-
-### リクエストボディ
+### リクエストボディ { #delete-versions-request-body }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -836,8 +779,7 @@ DELETE /v1.0/functions/{functionName}/versions
 | versionIds | Array | Y | 削除するバージョンID一覧 |
 
 <a id="delete-versions-response"></a>
-
-### レスポンス
+### レスポンス { #delete-versions-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -858,22 +800,19 @@ DELETE /v1.0/functions/{functionName}/versions
 ---
 
 <a id="list-triggers"></a>
-
-## トリガー一覧
+## トリガー一覧 { #list-triggers }
 
 関数のトリガー一覧を照会します。
 
 <a id="list-triggers-request"></a>
-
-### リクエスト
+### リクエスト { #list-triggers-request }
 
 ```
 GET /v1.0/triggers/{functionName}
 ```
 
 <a id="list-triggers-request-parameter"></a>
-
-### リクエストパラメータ
+### リクエストパラメータ { #list-triggers-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -882,14 +821,12 @@ GET /v1.0/triggers/{functionName}
 | functionName | URL | String | Y | 関数名 |
 
 <a id="list-triggers-request-body"></a>
-
-### リクエストボディ
+### リクエストボディ { #list-triggers-request-body }
 
 このAPIはリクエストボディを必要としません。
 
 <a id="list-triggers-response"></a>
-
-### レスポンス
+### レスポンス { #list-triggers-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -931,22 +868,19 @@ GET /v1.0/triggers/{functionName}
 ---
 
 <a id="create-time-trigger"></a>
-
-## タイムトリガー作成
+## タイムトリガー作成 { #create-time-trigger }
 
 関数にタイムトリガーを作成します。
 
 <a id="create-time-trigger-request"></a>
-
-### リクエスト
+### リクエスト { #create-time-trigger-request }
 
 ```
 POST /v1.0/triggers/{functionName}/time
 ```
 
 <a id="create-time-trigger-request-parameter"></a>
-
-### リクエストパラメータ
+### リクエストパラメータ { #create-time-trigger-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -955,8 +889,7 @@ POST /v1.0/triggers/{functionName}/time
 | functionName | URL | String | Y | 関数名 |
 
 <a id="create-time-trigger-request-body"></a>
-
-### リクエストボディ
+### リクエストボディ { #create-time-trigger-request-body }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -974,8 +907,7 @@ POST /v1.0/triggers/{functionName}/time
 | cron | String | Y | cron式 |
 
 <a id="create-time-trigger-response"></a>
-
-### レスポンス
+### レスポンス { #create-time-trigger-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -996,22 +928,19 @@ POST /v1.0/triggers/{functionName}/time
 ---
 
 <a id="modify-time-trigger"></a>
-
-## タイムトリガー修正
+## タイムトリガー修正 { #modify-time-trigger }
 
 タイムトリガーのcron式を修正します。
 
 <a id="modify-time-trigger-request"></a>
-
-### リクエスト
+### リクエスト { #modify-time-trigger-request }
 
 ```
 PUT /v1.0/triggers/{functionName}/time
 ```
 
 <a id="modify-time-trigger-request-parameter"></a>
-
-### リクエストパラメータ
+### リクエストパラメータ { #modify-time-trigger-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -1020,8 +949,7 @@ PUT /v1.0/triggers/{functionName}/time
 | functionName | URL | String | Y | 関数名 |
 
 <a id="modify-time-trigger-request-body"></a>
-
-### リクエストボディ
+### リクエストボディ { #modify-time-trigger-request-body }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -1041,8 +969,7 @@ PUT /v1.0/triggers/{functionName}/time
 | cron | String | Y | cron式 |
 
 <a id="modify-time-trigger-response"></a>
-
-### レスポンス
+### レスポンス { #modify-time-trigger-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -1063,22 +990,19 @@ PUT /v1.0/triggers/{functionName}/time
 ---
 
 <a id="delete-time-triggers"></a>
-
-## タイムトリガー削除
+## タイムトリガー削除 { #delete-time-triggers }
 
 タイムトリガーを一括削除します。
 
 <a id="delete-time-triggers-request"></a>
-
-### リクエスト
+### リクエスト { #delete-time-triggers-request }
 
 ```
 DELETE /v1.0/triggers/{functionName}/time
 ```
 
 <a id="delete-time-triggers-request-parameter"></a>
-
-### リクエストパラメータ
+### リクエストパラメータ { #delete-time-triggers-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -1087,8 +1011,7 @@ DELETE /v1.0/triggers/{functionName}/time
 | functionName | URL | String | Y | 関数名 |
 
 <a id="delete-time-triggers-request-body"></a>
-
-### リクエストボディ
+### リクエストボディ { #delete-time-triggers-request-body }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -1106,8 +1029,7 @@ DELETE /v1.0/triggers/{functionName}/time
 | names | Array | Y | 削除するトリガー名一覧 |
 
 <a id="delete-time-triggers-response"></a>
-
-### レスポンス
+### レスポンス { #delete-time-triggers-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>

--- a/ja/code-template-dotnet-guide.md
+++ b/ja/code-template-dotnet-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=3c324618eb1e -->
 
-## Compute > Cloud Functions > コードテンプレートガイド > .NET
+<a id="compute-cloud-functions-code-template-guide-net"></a>
+## Compute > Cloud Functions > コードテンプレートガイド > .NET { #compute-cloud-functions-code-template-guide-net }
 
 このドキュメントでは、NHN CloudのCloud Functionsサービスで.NETを使用して関数を開発する方法を詳しく説明します。
 
 <a id="template-information"></a>
-
-## テンプレート情報
+## テンプレート情報 { #template-information }
 | 項目       | 値                |
 |-----------------|---------|
 | **サポートバージョン** | 8                  |
@@ -14,12 +14,10 @@
 | **Entry Point** | func             |
 
 <a id="basic-template"></a>
-
-## 基本テンプレート
+## 基本テンプレート { #basic-template }
 
 <a id="hello-world-example"></a>
-
-### Hello Worldの例
+### Hello Worldの例 { #hello-world-example }
 最も基本的な関数の形式です。`Nhn.DotNetCore.Api`名前空間の`NhnContext`を使用して、ロガーやリクエスト情報にアクセスします。
 
 ```csharp
@@ -59,8 +57,7 @@ public class NhnFunction
 ```
 
 <a id="context-object"></a>
-
-### Contextオブジェクト
+### Contextオブジェクト { #context-object }
 `NhnContext`オブジェクトを通じて、ロガー、リクエスト(Request)、レスポンス(Response)オブジェクトにアクセスできます。
 
 ```csharp
@@ -106,19 +103,16 @@ public class NhnFunction
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## テンプレートファイルのダウンロードと活用
+## テンプレートファイルのダウンロードと活用 { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### テンプレートのダウンロード
+### テンプレートのダウンロード { #template-download }
 Cloud Functionsが提供する.NETテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [dotnet.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/dotnet/dotnet.zip)
 
 <a id="template-file-structure"></a>
-
-### テンプレートのファイル構造
+### テンプレートのファイル構造 { #template-file-structure }
 ダウンロードしたテンプレートファイルの構造は次のとおりです。
 
 ```
@@ -129,11 +123,9 @@ dotnet.zip
 ```
 
 <a id="local-development-process"></a>
-
-### ローカルでの開発プロセス
+### ローカルでの開発プロセス { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. 解凍
 ```bash
 # 解凍
@@ -144,7 +136,6 @@ cd my-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. 関数コードの修正
 `func.cs`ファイルを、目的のロジックに合わせて修正します。
 
@@ -201,7 +192,6 @@ public class NhnFunction
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. ZIPファイルへ圧縮
 修正したソースコードを、再度ZIPファイルへ圧縮します。`func.cs`と`nuget.txt`がルートディレクトリに含まれるように圧縮する必要があります。
 
@@ -210,18 +200,15 @@ zip my-function.zip func.cs nuget.txt
 ```
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Cloud Functionsコンソールでのアップロード
+### Cloud Functionsコンソールでのアップロード { #upload-from-cloud-functions-console }
 - 関数を作成または修正する際に、**ユーザーローカル環境**方式を選択します。
 - **ファイルを選択**をクリックし、作成した`my-function.zip`ファイルをアップロードします。
 
 <a id="process-by-http-method"></a>
-
-## HTTPメソッド別の処理
+## HTTPメソッド別の処理 { #process-by-http-method }
 
 <a id="process-get-request"></a>
-
-### GETリクエストの処理
+### GETリクエストの処理 { #process-get-request }
 ```csharp
 using System;
 using Nhn.DotNetCore.Api;
@@ -251,8 +238,7 @@ public class NhnFunction
 ```
 
 <a id="process-post-request"></a>
-
-### POSTリクエストの処理
+### POSTリクエストの処理 { #process-post-request }
 ```csharp
 using System;
 using System.IO;
@@ -305,8 +291,7 @@ public class NhnFunction
 ```
 
 <a id="manage-package-nugettxt"></a>
-
-## パッケージ管理(`nuget.txt`)
+## パッケージ管理(`nuget.txt`) { #manage-package-nugettxt }
 
 依存関係(NuGetパッケージ)の管理には、`nuget.txt`ファイルを使用します。必要なパッケージを1行に1つずつ記述してください。
 
@@ -316,8 +301,7 @@ Microsoft.Extensions.Configuration:8.0.0
 ```
 
 <a id="example-of-configuration-management"></a>
-
-### 設定管理の例
+### 設定管理の例 { #example-of-configuration-management }
 ```csharp
 using System;
 using System.Collections.Generic;
@@ -399,8 +383,7 @@ public class NhnFunction
 ```
 
 <a id="configure-entry-point"></a>
-
-## エントリーポイントの設定
+## エントリーポイントの設定 { #configure-entry-point }
 
 エントリーポイントは**ファイル名**です。(拡張子を除く)
 
@@ -410,7 +393,6 @@ public class NhnFunction
 **重要**:クラス名は`NhnFunction`である必要があり、関数として機能するメソッドは`public string Execute(NhnContext context)`というシグネチャを持つ必要があります。
 
 <a id="caution"></a>
-
-### 注意事項
+### 注意事項 { #caution }
 - **パッケージバージョン**: `nuget.txt`でパッケージのバージョンを明記できます。(例: `Newtonsoft.Json:9.0.1`)
 - **タイプの競合**:依存関係を追加する際にタイプの競合が発生する可能性があるため、可能な限り.NETの基本ライブラリを使用するか、互換性のあるバージョンのパッケージを使用することを推奨します。

--- a/ja/code-template-go-guide.md
+++ b/ja/code-template-go-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=9b45d499c0b7 -->
 
-## Compute > Cloud Functions > コードテンプレートガイド > Go
+<a id="compute-cloud-functions-code-template-guide-go"></a>
+## Compute > Cloud Functions > コードテンプレートガイド > Go { #compute-cloud-functions-code-template-guide-go }
 
 このドキュメントでは、NHN CloudのCloud FunctionsサービスでGoを使用して関数を開発する方法を詳しく説明します。
 
 <a id="template-information"></a>
-
-## テンプレート情報
+## テンプレート情報 { #template-information }
 | 項目             | 値                                       |
 |-----------------|------------------------------------------|
 | **サポートバージョン**       | 1.22, 1.23, 1.24, 1.25 |
@@ -14,12 +14,10 @@
 | **Entry Point** | Handler                                  |
 
 <a id="basic-template"></a>
-
-## 基本テンプレート
+## 基本テンプレート { #basic-template }
 
 <a id="hello-world-example"></a>
-
-### Hello Worldの例
+### Hello Worldの例 { #hello-world-example }
 最も基本的な関数の形式です。
 
 ```go
@@ -47,8 +45,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="context-object"></a>
-
-### Contextオブジェクト
+### Contextオブジェクト { #context-object }
 Goの関数では、`http.ResponseWriter`と`*http.Request`を通じてHTTPのリクエストとレスポンスを処理します。
 
 ```go
@@ -85,19 +82,16 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## テンプレートファイルのダウンロードと活用
+## テンプレートファイルのダウンロードと活用 { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### テンプレートのダウンロード
+### テンプレートのダウンロード { #template-download }
 Cloud Functionsが提供するGoテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [go.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/go/go.zip)
 
 <a id="template-file-structure"></a>
-
-### テンプレートのファイル構造
+### テンプレートのファイル構造 { #template-file-structure }
 ダウンロードしたテンプレートファイルの構造は次のとおりです。
 
 ```
@@ -107,7 +101,6 @@ go.zip
 ```
 
 <a id="functionsgo"></a>
-
 #### functions.go
 基本的なfakeデータ生成関数が含まれています。
 ```go
@@ -135,7 +128,6 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="gomod"></a>
-
 #### go.mod
 ```go
 module example.com/ncf
@@ -146,11 +138,9 @@ require github.com/brianvoe/gofakeit/v6 v6.28.0
 ```
 
 <a id="local-development-process"></a>
-
-### ローカルでの開発プロセス
+### ローカルでの開発プロセス { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. 解凍
 ```bash
 # 解凍
@@ -161,7 +151,6 @@ cd my-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. 関数コードの修正
 `functions.go`ファイルを、目的のロジックに合わせて修正します。
 
@@ -212,7 +201,6 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. ZIPファイルへ圧縮
 修正したコードを、再度ZIPファイルへ圧縮します。
 
@@ -231,16 +219,13 @@ zip -r my-function.zip . -x "*.git*" "go.sum" "test.go"
 ```
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Cloud Functionsコンソールでのアップロード
+### Cloud Functionsコンソールでのアップロード { #upload-from-cloud-functions-console }
 > 関数を作成または修正する際に、ユーザーのローカル環境にあるファイルをアップロードする場合に使用します。(コンソール利用ガイド参照)
 
 <a id="cautions-for-upload"></a>
-
-### アップロード時の注意事項
+### アップロード時の注意事項 { #cautions-for-upload }
 
 <a id="zip-file-structure"></a>
-
 #### ZIPファイルの構造
 - ZIPファイルのルートに、直接`.go`ファイルと`go.mod`を配置する必要があります。
 - 不要なフォルダ構造は避けることを推奨します。
@@ -262,13 +247,11 @@ my-function.zip
 ```
 
 <a id="file-size-limit"></a>
-
 #### ファイルサイズの制限
 - ZIPファイルのサイズは100MiB以下に制限されます。
 - `go.sum`ファイルは含めないでください。
 
 <a id="files-to-exclude"></a>
-
 #### 除外するファイル
 ```bash
 # .gitignoreと同様に、以下のファイルは除外
@@ -282,12 +265,10 @@ zip -r my-function.zip . -x \
 ```
 
 <a id="process-by-http-method"></a>
-
-## HTTPメソッド別の処理
+## HTTPメソッド別の処理 { #process-by-http-method }
 
 <a id="process-get-request"></a>
-
-### GETリクエストの処理
+### GETリクエストの処理 { #process-get-request }
 ```go
 package main
 
@@ -326,8 +307,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="process-post-request"></a>
-
-### POSTリクエストの処理
+### POSTリクエストの処理 { #process-post-request }
 ```go
 package main
 
@@ -399,12 +379,10 @@ func getOrDefault(value, defaultValue string) string {
 ```
 
 <a id="manage-packages"></a>
-
-## パッケージ管理
+## パッケージ管理 { #manage-packages }
 
 <a id="write-gomod"></a>
-
-### go.modの作成
+### go.modの作成 { #write-gomod }
 依存関係の管理には、`go.mod`ファイルを作成します。
 
 ```go
@@ -419,8 +397,7 @@ require (
 ```
 
 <a id="example-of-external-api-call"></a>
-
-### 外部API呼び出しの例
+### 外部API呼び出しの例 { #example-of-external-api-call }
 ```go
 package main
 
@@ -474,8 +451,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="data-processing-example"></a>
-
-### データ処理の例
+### データ処理の例 { #data-processing-example }
 ```go
 package main
 
@@ -569,20 +545,17 @@ func normalizeName(name string) string {
 ```
 
 <a id="configure-entry-point"></a>
-
-## エントリーポイントの設定
+## エントリーポイントの設定 { #configure-entry-point }
 
 <a id="single-function"></a>
-
-### 単一関数
+### 単一関数 { #single-function }
 関数名をエントリーポイントとして使用します。
 
 関数名: `Handler`
 Entry Point: `Handler`
 
 <a id="multiple-functions"></a>
-
-### 複数関数
+### 複数関数 { #multiple-functions }
 1つのファイルで複数の関数を定義できます。
 
 ```go
@@ -623,12 +596,10 @@ func UpdateUser(w http.ResponseWriter, r *http.Request) {
 - `UpdateUser`
 
 <a id="caution"></a>
-
-## 注意事項
+## 注意事項 { #caution }
 
 <a id="go-version"></a>
-
-### Goのバージョン
+### Goのバージョン { #go-version }
 | バージョン | サポート終了日 | 利用終了日 |
 |-----|-----------|-----------|
 | 1.25 | - | - |
@@ -637,7 +608,6 @@ func UpdateUser(w http.ResponseWriter, r *http.Request) {
 | 1.22 | 2026-01-28 | 2026-07-28 |
 
 <a id="go-version-support-policy"></a>
-
 #### Goバージョンサポートポリシー
 Cloud Functionsは、Goの公式リリース方針に従います。Goは年2回(1月、7月)新しいメジャーバージョンをリリースしており、各バージョンは最新の2つのメジャーバージョンまでサポートされます。
 

--- a/ja/code-template-java-guide.md
+++ b/ja/code-template-java-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=65e9891c8f54 -->
 
-## Compute > Cloud Functions > コードテンプレートガイド > Java
+<a id="compute-cloud-functions-code-template-guide-java"></a>
+## Compute > Cloud Functions > コードテンプレートガイド > Java { #compute-cloud-functions-code-template-guide-java }
 
 このドキュメントでは、NHN CloudのCloud FunctionsサービスでJavaを使用して関数を開発する方法を詳しく説明します。
 
 <a id="template-information"></a>
-
-## テンプレート情報
+## テンプレート情報 { #template-information }
 | 項目       | 値                |
 |-----------------|--------------------|
 | **サポートバージョン** | 17, 21             |
@@ -14,12 +14,10 @@
 | **Entry Point** | example.HelloWorld |
 
 <a id="basic-template"></a>
-
-## 基本テンプレート
+## 基本テンプレート { #basic-template }
 
 <a id="hello-world-example"></a>
-
-### Hello Worldの例
+### Hello Worldの例 { #hello-world-example }
 最も基本的な関数の形式です。
 
 ```java
@@ -38,8 +36,7 @@ public class HelloWorld {
 ```
 
 <a id="context-object-requestentity"></a>
-
-### Contextオブジェクト(RequestEntity)
+### Contextオブジェクト(RequestEntity) { #context-object-requestentity }
 Javaの関数では、Springの`RequestEntity`を通じてHTTPリクエスト情報にアクセスできます。
 
 ```java
@@ -73,19 +70,16 @@ public class HelloWorld {
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## テンプレートファイルのダウンロードと活用
+## テンプレートファイルのダウンロードと活用 { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### テンプレートのダウンロード
+### テンプレートのダウンロード { #template-download }
 Cloud Functionsが提供するJavaテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [java.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/java/java.zip)
 
 <a id="template-file-structure"></a>
-
-### テンプレートのファイル構造
+### テンプレートのファイル構造 { #template-file-structure }
 ダウンロードしたテンプレートは、Mavenのプロジェクト構造に従っています。
 
 ```
@@ -99,11 +93,9 @@ java.zip
 ```
 
 <a id="local-development-process"></a>
-
-### ローカルでの開発プロセス
+### ローカルでの開発プロセス { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. 解凍
 ```bash
 # 解凍
@@ -114,7 +106,6 @@ cd my-java-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. 関数コードの修正
 `src/main/java/example/HelloWorld.java`ファイルを、目的のロジックに合わせて修正します。
 
@@ -167,7 +158,6 @@ public class HelloWorld {
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. ZIPファイルへ圧縮
 修正したソースコードを、再度ZIPファイルへ圧縮します。`pom.xml`ファイルと`src`ディレクトリがルートディレクトリに含まれるように圧縮する必要があります。
 
@@ -186,26 +176,22 @@ zip -r my-function.zip . -x "*.git*" "target/*" "*.log"
 ```
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Cloud Functionsコンソールでのアップロード
+### Cloud Functionsコンソールでのアップロード { #upload-from-cloud-functions-console }
 - 関数を作成または修正する際に、**ユーザーローカル環境**方式を選択します。
 - **ファイルを選択**をクリックし、作成した`my-function.zip`ファイルをアップロードします。
 
 <a id="cautions-for-upload"></a>
-
-### アップロード時の注意事項
+### アップロード時の注意事項 { #cautions-for-upload }
 - **アップロードファイル**:ソースコードと`pom.xml`が含まれた**ZIPファイル**をアップロードする必要があります。
 - **ZIPファイルの構造**: ZIPファイルのルートに`pom.xml`と`src`ディレクトリを配置する必要があります。
 - **除外するファイル**: `target`ディレクトリや`.git`ディレクトリなど、不要なファイルは含めないでください。
 - **ファイルサイズ**: ZIPファイルのサイズは100MiB以下に制限されます。
 
 <a id="process-by-http-method"></a>
-
-## HTTPメソッド別の処理
+## HTTPメソッド別の処理 { #process-by-http-method }
 
 <a id="process-get-request"></a>
-
-### GETリクエストの処理
+### GETリクエストの処理 { #process-get-request }
 ```java
 package example;
 
@@ -242,8 +228,7 @@ public class GetHandler {
 ```
 
 <a id="process-post-request"></a>
-
-### POSTリクエストの処理
+### POSTリクエストの処理 { #process-post-request }
 ```java
 package example;
 
@@ -285,8 +270,7 @@ public class PostHandler {
 ```
 
 <a id="manage-package-pomxml"></a>
-
-## パッケージ管理(`pom.xml`)
+## パッケージ管理(`pom.xml`) { #manage-package-pomxml }
 
 依存関係の管理には、`pom.xml`ファイルを修正します。`dependencies`セクションに必要なライブラリを追加すると、関数のアップロード時にCloud Functionsが自動で依存関係をダウンロードし、ビルドに含めます。
 
@@ -310,8 +294,7 @@ public class PostHandler {
 ```
 
 <a id="example-of-using-external-libraries"></a>
-
-### 外部ライブラリの活用例
+### 外部ライブラリの活用例 { #example-of-using-external-libraries }
 ```java
 package example;
 
@@ -346,12 +329,10 @@ public class StringUtilsHandler {
 ```
 
 <a id="entry-point-configuration"></a>
-
-## エントリーポイントの設定
+## エントリーポイントの設定 { #entry-point-configuration }
 
 <a id="single-class"></a>
-
-### 単一クラス
+### 単一クラス { #single-class }
 `パッケージ名。クラス名`をエントリーポイントとして使用します。
 
 - パッケージ名: `example`
@@ -360,7 +341,6 @@ public class StringUtilsHandler {
 - **重要**:関数として機能するメソッドは、`public ResponseEntity<?> call(RequestEntity<?> req)`というシグネチャを持つ必要があります。
 
 <a id="caution"></a>
-
-### 注意事項
+### 注意事項 { #caution }
 - **プロジェクト構造**: `src/main/java`のディレクトリ構造を維持する必要があります。
 - **メモリと実行時間**:関数は限られたリソース内で動作する必要があるため、重い処理は避け、コードを最適化してください。

--- a/ja/code-template-node-guide.md
+++ b/ja/code-template-node-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=ce91cd7cb2f1 -->
 
-## Compute > Cloud Functions > コードテンプレートガイド > Node.js
+<a id="compute-cloud-functions-code-template-guide-nodejs"></a>
+## Compute > Cloud Functions > コードテンプレートガイド > Node.js { #compute-cloud-functions-code-template-guide-nodejs }
 
 このドキュメントでは、NHN CloudのCloud FunctionsサービスでNode.jsを使用して関数を開発する方法を詳しく説明します。
 
 <a id="template-information"></a>
-
-## テンプレート情報
+## テンプレート情報 { #template-information }
 | 項目       | 値                |
 |-----------------|-----------------|
 | **サポートバージョン** | 20.16.0, 22.5.0   |
@@ -14,11 +14,9 @@
 | **Entry Point** | hello            |
 
 <a id="basic-template"></a>
-
-## 基本テンプレート
+## 基本テンプレート { #basic-template }
 <a id="hello-world-example"></a>
-
-### Hello Worldの例
+### Hello Worldの例 { #hello-world-example }
 最も基本的な関数の形式です。
 
 ```javascript
@@ -31,8 +29,7 @@ module.exports = async (context) => {
 ```
 
 <a id="context-object"></a>
-
-### Contextオブジェクト
+### Contextオブジェクト { #context-object }
 関数に渡される`context`オブジェクトには、以下の情報が含まれます。
 
 ```javascript
@@ -53,19 +50,16 @@ module.exports = async (context) => {
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## テンプレートファイルのダウンロードと活用
+## テンプレートファイルのダウンロードと活用 { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### テンプレートのダウンロード
+### テンプレートのダウンロード { #template-download }
 Cloud Functionsが提供するNode.jsテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [nodejs.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/nodejs/nodejs.zip)
 
 <a id="template-file-structure"></a>
-
-### テンプレートのファイル構造
+### テンプレートのファイル構造 { #template-file-structure }
 ダウンロードしたテンプレートファイルの構造は次のとおりです。
 
 ```
@@ -75,7 +69,6 @@ nodejs.zip
 ```
 
 <a id="hellojs"></a>
-
 #### hello.js
 基本的なHello World関数が含まれています。
 ```javascript
@@ -88,18 +81,15 @@ module.exports = async (context) => {
 ```
 
 <a id="packagejson"></a>
-
 #### package.json
 ```json
 {}
 ```
 
 <a id="local-development-process"></a>
-
-### ローカルでの開発プロセス
+### ローカルでの開発プロセス { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. 解凍
 ```bash
 # 解凍
@@ -110,7 +100,6 @@ cd my-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. 関数コードの修正
 `hello.js`ファイルを、目的のロジックに合わせて修正します。
 
@@ -154,7 +143,6 @@ module.exports = async (context) => {
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. ZIPファイルへ圧縮
 修正したコードを、再度ZIPファイルへ圧縮します。
 
@@ -173,16 +161,13 @@ zip -r my-function.zip . -x "*.git*" "node_modules/*" "test.js"
 ```
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Cloud Functionsコンソールでのアップロード
+### Cloud Functionsコンソールでのアップロード { #upload-from-cloud-functions-console }
 > 関数を作成または修正する際に、ユーザーのローカル環境にあるファイルをアップロードする場合に使用します。(コンソール利用ガイド参照)
 
 <a id="cautions-for-upload"></a>
-
-### アップロード時の注意事項
+### アップロード時の注意事項 { #cautions-for-upload }
 
 <a id="zip-file-structure"></a>
-
 #### ZIPファイルの構造
 - ZIPファイルのルートに、直接`.js`ファイルと`package.json`を配置する必要があります。
 - 不要なフォルダ構造は避けることを推奨します。
@@ -204,13 +189,11 @@ my-function.zip
 ```
 
 <a id="file-size-limit"></a>
-
 #### ファイルサイズの制限
 - ZIPファイルのサイズは100MiB以下に制限されます。
 - `node_modules`フォルダは含めないでください。(依存関係は`package.json`で管理)
 
 <a id="files-to-exclude"></a>
-
 #### 除外するファイル
 ```bash
 # .gitignoreと同様に、以下のファイルは除外
@@ -224,12 +207,10 @@ zip -r my-function.zip . -x \
 ```
 
 <a id="process-by-http-method"></a>
-
-## HTTPメソッド別の処理
+## HTTPメソッド別の処理 { #process-by-http-method }
 
 <a id="process-get-request"></a>
-
-### GETリクエストの処理
+### GETリクエストの処理 { #process-get-request }
 ```javascript
 module.exports = async (context) => {
     if (context.request.method !== 'GET') {
@@ -256,8 +237,7 @@ module.exports = async (context) => {
 ```
 
 <a id="process-post-request"></a>
-
-### POSTリクエストの処理
+### POSTリクエストの処理 { #process-post-request }
 ```javascript
 module.exports = async (context) => {
     if (context.request.method !== 'POST') {
@@ -303,12 +283,10 @@ module.exports = async (context) => {
 ```
 
 <a id="manage-packages"></a>
-
-## パッケージ管理
+## パッケージ管理 { #manage-packages }
 
 <a id="write-packagejson"></a>
-
-### package.jsonの作成
+### package.jsonの作成 { #write-packagejson }
 依存関係の管理には、`package.json`ファイルを作成します。
 
 ```json
@@ -327,8 +305,7 @@ module.exports = async (context) => {
 ```
 
 <a id="example-of-external-api-call"></a>
-
-### 外部API呼び出しの例
+### 外部API呼び出しの例 { #example-of-external-api-call }
 ```javascript
 const axios = require('axios');
 
@@ -379,8 +356,7 @@ module.exports = async (context) => {
 ```
 
 <a id="data-processing-example"></a>
-
-### データ処理の例
+### データ処理の例 { #data-processing-example }
 ```javascript
 const _ = require('lodash');
 const moment = require('moment');
@@ -435,20 +411,17 @@ module.exports = async (context) => {
 ```
 
 <a id="configure-entry-point"></a>
-
-## エントリーポイントの設定
+## エントリーポイントの設定 { #configure-entry-point }
 
 <a id="single-function"></a>
-
-### 単一関数
+### 単一関数 { #single-function }
 ファイル名をエントリーポイントとして使用します。
 
 ファイル名: `hello.js`
 Entry Point: `hello`
 
 <a id="multiple-functions"></a>
-
-### 複数関数
+### 複数関数 { #multiple-functions }
 1つのファイルで複数の関数をエクスポートできます。
 
 ```javascript
@@ -484,8 +457,7 @@ module.exports.updateUser = async (context) => {
 - `users.updateUser`
 
 <a id="entry-point-restriction"></a>
-
-### エントリーポイントの制限事項
+### エントリーポイントの制限事項 { #entry-point-restriction }
 - **サブディレクトリの指定不可**:ルートディレクトリのサブディレクトリにあるファイルは、エントリーポイントとして指定できません。
 
 **正しいエントリーポイント:**
@@ -504,12 +476,10 @@ modules/auth.js → modules.auth ❌
 全ての関数ファイルは、ZIPファイルのルートレベルに配置する必要があります。
 
 <a id="caution"></a>
-
-## 注意事項
+## 注意事項 { #caution }
 
 <a id="commonjs-vs-es-modules"></a>
-
-### CommonJS vs ES Modules
+### CommonJS vs ES Modules { #commonjs-vs-es-modules }
 現在、Cloud FunctionsはCommonJS方式のみをサポートしています。
 
 **使用可能(CommonJS):**
@@ -529,8 +499,7 @@ export default async (context) => { // ❌サポートしていません
 ```
 
 <a id="considerations-for-memory-and-execution-time"></a>
-
-### メモリ及び実行時間に関する考慮事項
+### メモリ及び実行時間に関する考慮事項 { #considerations-for-memory-and-execution-time }
 - 関数は、限られたメモリと実行時間内で動作する必要があります。
 - 大容量データを処理する際は、ストリーム処理を検討してください。
 - 長時間実行されるタスクは、適切に分割してください。

--- a/ja/code-template-python-guide.md
+++ b/ja/code-template-python-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=577d9bcb43c9 -->
 
-## Compute > Cloud Functions > コードテンプレートガイド > Python
+<a id="compute-cloud-functions-code-template-guide-python"></a>
+## Compute > Cloud Functions > コードテンプレートガイド > Python { #compute-cloud-functions-code-template-guide-python }
 
 このドキュメントでは、NHN CloudのCloud FunctionsサービスでPythonを使用して関数を開発する方法を詳しく説明します。
 
 <a id="template-information"></a>
-
-## テンプレート情報
+## テンプレート情報 { #template-information }
 | 項目             | 値               |
 |-----------------|------------------|
 | **サポートバージョン**       | 3.11, 3.12, 3.13 |
@@ -14,12 +14,10 @@
 | **Entry Point** | user.main        |
 
 <a id="basic-template"></a>
-
-## 基本テンプレート
+## 基本テンプレート { #basic-template }
 
 <a id="hello-world-example"></a>
-
-### Hello Worldの例
+### Hello Worldの例 { #hello-world-example }
 最も基本的な関数の形式です。
 
 ```python
@@ -38,8 +36,7 @@ def main():
 ```
 
 <a id="context-object"></a>
-
-### Contextオブジェクト
+### Contextオブジェクト { #context-object }
 Pythonの関数では、Flaskのrequestオブジェクトを通じてHTTPリクエスト情報にアクセスできます。
 
 ```python
@@ -68,19 +65,16 @@ def main():
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## テンプレートファイルのダウンロードと活用
+## テンプレートファイルのダウンロードと活用 { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### テンプレートのダウンロード
+### テンプレートのダウンロード { #template-download }
 Cloud Functionsが提供するPythonテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [python.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/python/python.zip)
 
 <a id="template-file-structure"></a>
-
-### テンプレートのファイル構造
+### テンプレートのファイル構造 { #template-file-structure }
 ダウンロードしたテンプレートファイルの構造は以下の通りです:
 
 ```
@@ -90,7 +84,6 @@ python.zip
 ```
 
 <a id="userpy"></a>
-
 #### user.py
 基本的なYAML処理関数が含まれています。
 ```python
@@ -109,18 +102,15 @@ def main():
 ```
 
 <a id="requirementstxt"></a>
-
 #### requirements.txt
 ```txt
 pyyaml
 ```
 
 <a id="local-development-process"></a>
-
-### ローカルでの開発プロセス
+### ローカルでの開発プロセス { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. 解凍
 ```bash
 # 解凍
@@ -131,7 +121,6 @@ cd my-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. 関数コードの修正
 `user.py`ファイルを、目的のロジックに合わせて修正します。
 
@@ -174,7 +163,6 @@ def main():
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. ZIPファイルへ圧縮
 修正したコードを、再度ZIPファイルへ圧縮します。
 
@@ -193,16 +181,13 @@ zip -r my-function.zip . -x "*.git*" "__pycache__/*" "*.pyc" "test.py"
 ```
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Cloud Functionsコンソールでのアップロード
+### Cloud Functionsコンソールでのアップロード { #upload-from-cloud-functions-console }
 > 関数を作成または修正する際に、ユーザーのローカル環境にあるファイルをアップロードする場合に使用します。(コンソール利用ガイド参照)
 
 <a id="cautions-for-upload"></a>
-
-### アップロード時の注意事項
+### アップロード時の注意事項 { #cautions-for-upload }
 
 <a id="zip-file-structure"></a>
-
 #### ZIPファイルの構造
 - ZIPファイルのルートに、直接`.py`ファイルと`requirements.txt`を配置する必要があります。
 - 不要なフォルダ構造は避けることを推奨します。
@@ -224,13 +209,11 @@ my-function.zip
 ```
 
 <a id="file-size-limit"></a>
-
 #### ファイルサイズの制限
 - ZIPファイルのサイズは100MiB以下に制限されます。
 - `__pycache__`フォルダは含めないでください。
 
 <a id="files-to-exclude"></a>
-
 #### 除外するファイル
 ```bash
 # .gitignoreと同様に、以下のファイルは除外
@@ -245,12 +228,10 @@ zip -r my-function.zip . -x \
 ```
 
 <a id="process-by-http-method"></a>
-
-## HTTPメソッド別の処理
+## HTTPメソッド別の処理 { #process-by-http-method }
 
 <a id="process-get-request"></a>
-
-### GETリクエストの処理
+### GETリクエストの処理 { #process-get-request }
 ```python
 from flask import request
 import json
@@ -274,8 +255,7 @@ def main():
 ```
 
 <a id="process-post-request"></a>
-
-### POSTリクエストの処理
+### POSTリクエストの処理 { #process-post-request }
 ```python
 from flask import request
 import json
@@ -319,12 +299,10 @@ def main():
 ```
 
 <a id="manage-packages"></a>
-
-## パッケージ管理
+## パッケージ管理 { #manage-packages }
 
 <a id="write-requirementstxt"></a>
-
-### requirements.txtの作成
+### requirements.txtの作成 { #write-requirementstxt }
 依存関係の管理には、`requirements.txt`ファイルを作成します。
 
 ```txt
@@ -334,8 +312,7 @@ python-dateutil>=2.8.0
 ```
 
 <a id="example-of-external-api-call"></a>
-
-### 外部API呼び出しの例
+### 外部API呼び出しの例 { #example-of-external-api-call }
 ```python
 from flask import request
 import json
@@ -378,8 +355,7 @@ def main():
 ```
 
 <a id="data-processing-example"></a>
-
-### データ処理の例
+### データ処理の例 { #data-processing-example }
 ```python
 from flask import request
 import json
@@ -434,12 +410,10 @@ def normalize_name(name):
 ```
 
 <a id="configure-entry-point"></a>
-
-## エントリーポイントの設定
+## エントリーポイントの設定 { #configure-entry-point }
 
 <a id="single-function"></a>
-
-### 単一関数
+### 単一関数 { #single-function }
 `ファイル名.関数名`をエントリーポイントとして使用します。
 
 ファイル名: `user.py`
@@ -447,8 +421,7 @@ def normalize_name(name):
 Entry Point: `user.main`
 
 <a id="multiple-functions"></a>
-
-### 複数関数
+### 複数関数 { #multiple-functions }
 1つのファイルで複数の関数を定義できます。
 
 ```python
@@ -475,12 +448,10 @@ def update_user():
 - `handlers.update_user`
 
 <a id="caution"></a>
-
-## 注意事項
+## 注意事項 { #caution }
 
 <a id="unsupported-packages"></a>
-
-### サポートしていないパッケージ
+### サポートしていないパッケージ { #unsupported-packages }
 現在、以下の特徴を持つ複雑なパッケージはサポートしていません。
 
 **サポートしていないパッケージの例:**
@@ -495,8 +466,7 @@ def update_user():
 - `pillow` (画像処理 - 基本機能)
 
 <a id="considerations-for-memory-and-execution-time"></a>
-
-### メモリ及び実行時間に関する考慮事項
+### メモリ及び実行時間に関する考慮事項 { #considerations-for-memory-and-execution-time }
 - 関数は、限られたメモリと実行時間内で動作する必要があります。
 - 大容量データを処理する際は、ジェネレータやストリーム処理を検討してください。
 - 長時間実行されるタスクは、適切に分割してください。

--- a/ja/code-template-ruby-guide.md
+++ b/ja/code-template-ruby-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=1d5361d8d187 -->
 
-## Compute > Cloud Functions > コードテンプレートガイド > Ruby
+<a id="compute-cloud-functions-code-template-guide-ruby"></a>
+## Compute > Cloud Functions > コードテンプレートガイド > Ruby { #compute-cloud-functions-code-template-guide-ruby }
 
 このドキュメントでは、NHN CloudのCloud FunctionsサービスでRubyを使用して関数を開発する方法を詳しく説明します。
 
 <a id="template-information"></a>
-
-## テンプレート情報
+## テンプレート情報 { #template-information }
 | 項目             | 値       |
 |-----------------|----------|
 | **サポートバージョン**       | 3.4.5    |
@@ -14,12 +14,10 @@
 | **Entry Point** | handler  |
 
 <a id="basic-template"></a>
-
-## 基本テンプレート
+## 基本テンプレート { #basic-template }
 
 <a id="hello-world-example"></a>
-
-### Hello Worldの例
+### Hello Worldの例 { #hello-world-example }
 最も基本的な関数の形式です。
 
 ```ruby
@@ -39,8 +37,7 @@ end
 ```
 
 <a id="context-object"></a>
-
-### Contextオブジェクト
+### Contextオブジェクト { #context-object }
 関数に渡される`context`オブジェクトを通じて、ロガーやリクエスト情報にアクセスできます。
 
 ```ruby
@@ -75,19 +72,16 @@ end
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## テンプレートファイルのダウンロードと活用
+## テンプレートファイルのダウンロードと活用 { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### テンプレートのダウンロード
+### テンプレートのダウンロード { #template-download }
 Cloud Functionsが提供するRubyテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [ruby.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/ruby/ruby.zip)
 
 <a id="template-file-structure"></a>
-
-### テンプレートのファイル構造
+### テンプレートのファイル構造 { #template-file-structure }
 ダウンロードしたテンプレートファイルの構造は次のとおりです。
 
 ```
@@ -97,11 +91,9 @@ ruby.zip
 ```
 
 <a id="local-development-process"></a>
-
-### ローカルでの開発プロセス
+### ローカルでの開発プロセス { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. 解凍
 ```bash
 # 解凍
@@ -112,7 +104,6 @@ cd my-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. 関数コードの修正
 `parse.rb`ファイルを、目的のロジックに合わせて修正します。
 
@@ -158,7 +149,6 @@ end
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. ZIPファイルへ圧縮
 修正したソースコードを、再度ZIPファイルへ圧縮します。`parse.rb`と`Gemfile`がルートディレクトリに含まれるように圧縮する必要があります。
 
@@ -168,26 +158,22 @@ zip my-function.zip parse.rb Gemfile Gemfile.lock
 **参考**: `Gemfile.lock`ファイルはデプロイ段階で自動的に生成されますが、依存関係の正確なバージョンを事前に確認または固定したい場合は、ローカルで`bundle install`を実行して直接生成した後、一緒に圧縮できます。`Gemfile.lock`ファイルが含まれている場合、そのファイルに明記されたバージョンを使用してビルドされます。
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Cloud Functionsコンソールでのアップロード
+### Cloud Functionsコンソールでのアップロード { #upload-from-cloud-functions-console }
 - 関数を作成または修正する際に、**ユーザーローカル環境**方式を選択します。
 - **ファイルを選択**をクリックし、作成した`my-function.zip`ファイルをアップロードします。
 
 <a id="cautions-for-upload"></a>
-
-### アップロード時の注意事項
+### アップロード時の注意事項 { #cautions-for-upload }
 - **アップロードファイル**: `*.rb`、`Gemfile`が含まれた**ZIPファイル**をアップロードする必要があります。
   - `Gemfile.lock`ファイルは任意です。含まれている場合はそのファイルに明記されたバージョンでビルドされ、ない場合はデプロイ段階で自動的に生成されます。
 - **ZIPファイルの構造**: ZIPファイルのルートに各ファイルを配置する必要があります。
 - **ファイルサイズ**: ZIPファイルのサイズは100MiB以下に制限されます。
 
 <a id="process-post-request"></a>
-
-## HTTPメソッド別の処理
+## HTTPメソッド別の処理 { #process-post-request }
 
 <a id="process-get-request"></a>
-
-### GETリクエストの処理
+### GETリクエストの処理 { #process-get-request }
 ```ruby
 # frozen_string_literal: true
 
@@ -212,8 +198,7 @@ end
 ```
 
 <a id="process-post-request-2"></a>
-
-### POSTリクエストの処理
+### POSTリクエストの処理 { #process-post-request-2 }
 ```ruby
 # frozen_string_literal: true
 
@@ -249,8 +234,7 @@ end
 ```
 
 <a id="manage-package-gemfile"></a>
-
-## パッケージ管理(`Gemfile`)
+## パッケージ管理(`Gemfile`) { #manage-package-gemfile }
 
 依存関係(Gem)の管理には`Gemfile`を使用します。必要なGemを追加し、`bundle install`を実行して`Gemfile.lock`を生成します。
 
@@ -265,8 +249,7 @@ gem "httparty", "~> 0.23" # HTTPクライアント
 ```
 
 <a id="example-of-external-api-call"></a>
-
-### 外部API呼び出しの例
+### 外部API呼び出しの例 { #example-of-external-api-call }
 ```ruby
 # frozen_string_literal: true
 
@@ -307,8 +290,7 @@ end
 ```
 
 <a id="configure-entry-point"></a>
-
-## エントリーポイントの設定
+## エントリーポイントの設定 { #configure-entry-point }
 
 エントリーポイントには関数名を使用します。
 
@@ -317,7 +299,6 @@ end
 - Entry Point: `handler`
 
 <a id="caution"></a>
-
-### 注意事項
+### 注意事項 { #caution }
 - **Bundlerのバージョン**: `Gemfile.lock`を作成する際には、Bundler 2.6.2以上のバージョンの使用を推奨します。
 - **ActiveSupportなど一部のGemの互換性**: `ActiveSupport`のようにC拡張(C extension)に依存したり、内部構造が複雑だったりする一部のGemは、現在のCloud Functions環境と互換性の問題が発生する可能性があります。`activesupport` Gemは内部で`zeitwerk` Gemに依存しており、このGemがファイルシステムを探索する方法が実行環境と競合し、正常に動作しない場合があります。そのため、できるだけ標準ライブラリや外部依存の少ないGemを使用することを推奨します。

--- a/ja/console-guide.md
+++ b/ja/console-guide.md
@@ -1,23 +1,21 @@
 <!-- pre-align:aligned sig=fda183656939 -->
 
-## Compute > Cloud Functions > コンソール使用ガイド
+<a id="compute-cloud-functions-console-user-guide"></a>
+## Compute > Cloud Functions > コンソール使用ガイド { #compute-cloud-functions-console-user-guide }
 この文書では、NHN Cloud Functionsコンソールで関数を作成し、管理する方法について説明します。
 
 <a id="manage-functions"></a>
-
-## 関数管理
+## 関数管理 { #manage-functions }
 関数を作成、修正、削除、コピーできます。
 
 <a id="create-functions"></a>
-
-### 関数作成
+### 関数作成 { #create-functions }
 関数設定を行いコードを作成してビルドした後、**作成**ボタンをクリックすると、最後にビルドしたパッケージで関数が作成されます。
 
 ![console-guide-07](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-01.png)
 ![console-guide-08](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-02.png)
 
 <a id="function-settings"></a>
-
 #### 関数設定
 <table class="it">
     <tr>
@@ -96,7 +94,6 @@
 
 
 <a id="code-writing"></a>
-
 #### コード作成
 
 ![console-guide-09](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-03.png)
@@ -161,62 +158,52 @@
 > **[参考]** <br>ビルドボタンを通じて作成されたパッケージは、関数の作成/修正時に最後にビルドされたパッケージが関数バージョンとして連携されます。関数作成前に少なくとも1回以上ビルドを実行する必要があります。
 
 <a id="modify-functions"></a>
-
-### 関数修正
+### 関数修正 { #modify-functions }
 既存の関数の設定とコードを修正するために、**修正**ボタンを クリックして 関数を修正します。
 
 <a id="non-modifiable-item"></a>
-
 #### 修正不可項目
 - 名前、ランタイム環境
     - 該当項目を除く全ての項目を修正できます。
     
 <a id="source-code"></a>
-
 #### ソースコード
 - コードエディタを使用する場合既存コードが読み込まれます。
 - ユーザーローカル環境のZIPファイルをアップロードして関数を生成した場合、コードエディタに変更するとZIPファイルを表示せず、基本テンプレートコードが読み込まれます。
 
 <a id="delete-a-function"></a>
-
-### 関数削除
+### 関数削除 { #delete-a-function }
 ![console-guide-14](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-06.png)
 既存の関数を選択して削除します。一度に複数の関数を削除可能です。
 
 <a id="copy-a-function"></a>
-
-### 関数コピー
+### 関数コピー { #copy-a-function }
 ![console-guide-13](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-07.png)
 既存の関数と同一の関数をコピーします。名前は重複不可のため、コピー前に新しい名前を指定できます。
 - トリガーはコピーされません。(HTTPトリガーはデフォルトで提供)
 - バージョンは現在適用されているバージョンのみコピーされます。
 
 <a id="about-functions"></a>
-
-## 関数情報
+## 関数情報 { #about-functions }
 <a id="list-of-functions"></a>
-
-### 関数リスト
+### 関数リスト { #list-of-functions }
 ![console-guide-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-08.png)
 - ユーザーが作成した関数リストを確認できます。
 - ビルドの状態は 現在のバージョンのビルド状態を表示します。
 
 <a id="basic-information-of-functions"></a>
-
-### 関数基本情報
+### 関数基本情報 { #basic-information-of-functions }
 ![console-guide-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-09.png)
 - 関数の基本情報を確認できます。
 - ログ管理項目で **Log & Crash Search** ボタンをクリックし、Log & Crash Searchサービスへ移動してログを確認できます。
 
 <a id="function-versioning"></a>
-
-### 関数バージョン管理
+### 関数バージョン管理 { #function-versioning }
 ![console-guide-15](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2026-01-27/console-guide-jp-15.png)
 - 関数のバージョンを管理できます。
 - 作成された全てのバージョンの履歴を確認し、以前のバージョンにロールバックできます。
 
 <a id="versioning-overview"></a>
-
 #### バージョン管理の概要
 関数作成/修正画面で **ビルド** ボタンをクリックし、コードをビルドするとパッケージが作成されます。
 - 関数の作成/修正時に最後にビルドしたパッケージが関数バージョンとして連携されます。
@@ -224,7 +211,6 @@
 - 関数作成時、少なくとも1回以上ビルドを実行する必要があります。
 
 <a id="version-information"></a>
-
 #### バージョン情報
 <table class="it">
     <tr>
@@ -255,7 +241,6 @@
 </table>
 
 <a id="deploy-versions"></a>
-
 #### バージョン配布
 - バージョンリストから配布するバージョンを選択し、**バージョン配布**ボタンをクリックすると、該当バージョンで関数が更新されます。
 - 現在適用されているバージョンは選択できません。
@@ -265,7 +250,6 @@
 > **[参考]**
 > <br>バージョン配布時に確認ポップアップが表示され、成功するとバージョンリストが自動的に更新されます。
 <a id="delete-versions"></a>
-
 #### バージョン削除
 - バージョンリストから削除するバージョンを選択し、**バージョン削除**ボタンをクリックすると、該当バージョンが削除されます。
 - 現在適用されているバージョンは削除できません。
@@ -275,7 +259,6 @@
 > **[参考]**
 > <br>バージョン削除時に確認ポップアップが表示され、削除されたバージョンは復元できません。
 <a id="constraints"></a>
-
 #### 制約事項
 - 関数作成/修正画面でビルドしたパッケージは、関数の作成/修正をキャンセルすると関数バージョンとして連携されません。
 - 関数削除時、該当関数と連携された全てのバージョンも一緒に削除されます。
@@ -283,8 +266,7 @@
 - 関数作成時には複数のランタイムでビルドできますが、関数修正時には作成時に選択したランタイムでのみビルドできます。
 
 <a id="manage-function-triggers"></a>
-
-### 関数トリガー管理
+### 関数トリガー管理 { #manage-function-triggers }
 - 関数を実行できるトリガーを管理できます。
 - HTTPトリガーは関数の作成時にデフォルトで提供されます。
     - 有効化/無効化により、使用するかどうかを設定できます。
@@ -296,7 +278,6 @@
     - Method : GET, POST
 
 <a id="createedit-triggers"></a>
-
 #### トリガー作成/修正
 - Timer
     - Value: Cron文字列で周期を入力します。
@@ -304,13 +285,11 @@
     - API Gatewayサービスを利用してHTTPエンドポイントを追加できます。
         
 <a id="delete-triggers"></a>
-
 #### トリガー削除
 - 複数のトリガーを選択して削除できます。デフォルトのトリガーであるHTTPトリガーは削除できません。
 
 <a id="monitor-functions"></a>
-
-### 関数モニタリング
+### 関数モニタリング { #monitor-functions }
 ![console-guide-06](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-11.png)
 - 関数の使用量を確認できます。
 - 関数呼び出し回数、呼び出し拒否数、エラー発生回数、成功率、関数実行時間指標を提供します。

--- a/ja/overview.md
+++ b/ja/overview.md
@@ -1,11 +1,11 @@
 <!-- pre-align:aligned sig=92acb111e0a0 -->
 
-## Compute > Cloud Functions > 概要
+<a id="compute-cloud-functions-overview"></a>
+## Compute > Cloud Functions > 概要 { #compute-cloud-functions-overview }
 ユーザーは関数単位でコードを作成でき、特定のイベントが発生した際に定義された関数が自動で実行され、必要な処理を行います。サーバー管理やインフラ設定を行うことなく、アプリケーションロジックに専念することができます。
 
 <a id="features"></a>
-
-### 特徴
+### 特徴 { #features }
 - コスト効率性
     - 使用した分だけ課金するため、コストを削減できます。
     - 必要な時にのみリソースを割り当てるため、管理コストを削減できます。
@@ -18,20 +18,17 @@
     - イベントベースのアーキテクチャにより、多様な活用が可能です。
 
 <a id="main-features"></a>
-
-### 主な機能
+### 主な機能 { #main-features }
 - 様々な言語(環境)を提供します。
 - **コードエディタ**を使用して、簡単な関数単位コードを作成できます。
 - 関数を実行できるHTTPSエンドポイントを標準で提供します。
 - 関数を一定間隔で繰り返し実行できます。
 
 <a id="two-modes-available"></a>
-
-### 2つのモードを提供
+### 2つのモードを提供 { #two-modes-available }
 - Pool Manager
 - New Deployment
 <a id="pool-manager"></a>
-
 #### Pool Manager
 - 関数が実行される際にのみインスタンスが作成され、リソースを使用します。
 - 一定期間関数が実行されない場合、インスタンスは消滅し、リソース使用量は0になります。
@@ -40,7 +37,6 @@
 ![overview-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_1_ja.png)
 
 <a id="new-deployment"></a>
-
 #### New Deployment
 - 関数を作成すると、すぐにインスタンスが作成され、一定量のリソースを継続して使用します。
 - 高速な応答のためにインスタンス作成を維持します。
@@ -49,8 +45,7 @@
 ![overview-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_2_ja.png)
 
 <a id="supported-languages"></a>
-
-### サポート言語
+### サポート言語 { #supported-languages }
 
 | 言語     | バージョン                | サポート終了日   | 利用終了日   |
 |--------|-------------------|------------|------------|
@@ -72,8 +67,7 @@
 |        | 7(利用停止)         | 2024-05-14 | 2025-05-14 |
 
 <a id="trigger"></a>
-
-### Trigger
+### Trigger { #trigger }
 - HTTP Trigger
     - 基本提供(GET、POSTサポート)
 - Timer Trigger

--- a/ja/release-notes.md
+++ b/ja/release-notes.md
@@ -1,39 +1,33 @@
 <!-- pre-align:aligned sig=06519d7ca905 -->
 
-## Compute > Cloud Functions > リリースノート
+<a id="compute-cloud-functions-release-notes"></a>
+## Compute > Cloud Functions > リリースノート { #compute-cloud-functions-release-notes }
 
 <a id="april-14-2026"></a>
-
-### 2026. 04. 14.
+### 2026. 04. 14. { #april-14-2026 }
 
 <a id="added-features"></a>
-
 #### 機能追加
 - Public API v1.0追加
   - APIでCloud Functionsを利用できます。
   
 <a id="january-27-2026"></a>
-
-### 2026. 01. 27.
+### 2026. 01. 27. { #january-27-2026 }
 
 <a id="january-27-2026-added-features"></a>
-
 #### 機能追加
 - 関数バージョン管理機能の追加
   - ビルドしたパッケージをバージョンとして管理し、以前のバージョンにロールバックできます。
     
 <a id="november-25-2025"></a>
-
-### 2025. 11. 25.
+### 2025. 11. 25. { #november-25-2025 }
 
 <a id="november-25-2025-added-features"></a>
-
 #### 機能追加
 - API Gatewayトリガーの追加
   - 同一プロジェクトのAPI Gatewayサービスを活用してAPI Gatewayトリガーを作成できます。
 
 <a id="feature-updates"></a>
-
 #### 機能改善
 - ランタイム環境の最新バージョンの追加及び一部バージョンの使用中止
   - Go 1.24、1.25の追加
@@ -43,10 +37,8 @@
   - .NET 7の使用中止、.NET 8の追加
     
 <a id="july-29-2025"></a>
-
-### 2025. 07. 29.
+### 2025. 07. 29. { #july-29-2025 }
 
 <a id="launch-cloud-functions-service"></a>
-
 #### Cloud Functionsサービスリリース
 - ユーザーは関数単位でコードを作成でき、特定のイベントが発生した際に定義された関数が自動で実行され、必要な処理を行います。サーバー管理やインフラ設定を行うことなく、アプリケーションロジックに専念することができます。

--- a/ja/trigger-guide.md
+++ b/ja/trigger-guide.md
@@ -1,18 +1,17 @@
 <!-- pre-align:aligned sig=02be28f736c7 -->
 
-## Compute > Cloud Functions > トリガーガイド
+<a id="compute-cloud-functions-trigger-guide"></a>
+## Compute > Cloud Functions > トリガーガイド { #compute-cloud-functions-trigger-guide }
 
 このドキュメントでは、Cloud Functionsで提供するトリガーの種類と設定方法について説明します。
 
 <a id="trigger-overview"></a>
-
-## トリガーの概要
+## トリガーの概要 { #trigger-overview }
 
 トリガーは関数を実行させるイベントソースです。Cloud Functionsは様々な種類のトリガーを提供しており、複数の方法で関数を呼び出すことができます。
 
 <a id="supported-triggers"></a>
-
-### サポートするトリガーの種類
+### サポートするトリガーの種類 { #supported-triggers }
 
 | トリガーの種類      | 説明                      | デフォルト提供 |
 |-------------|------------------------|-------|
@@ -21,33 +20,28 @@
 | API Gateway | API Gatewayを通じて関数を実行  | X      |
 
 <a id="http-trigger"></a>
-
-## HTTPトリガー
+## HTTPトリガー { #http-trigger }
 
 HTTPトリガーは関数の作成時にデフォルトで提供され、HTTPリクエストを通じて関数を実行できます。
 
 <a id="features"></a>
-
-### 特徴
+### 特徴 { #features }
 
 - 関数の作成時に自動的に生成されます。
 - 削除することはできず、有効化/無効化のみ可能です。
 - GET, POSTメソッドをサポートします。
 
 <a id="url-format-of-http-trigger"></a>
-
-### HTTPトリガーURL形式
+### HTTPトリガーURL形式 { #url-format-of-http-trigger }
 
 ```
 https://{userdomain}/{関数名}
 ```
 
 <a id="examples"></a>
-
-### 使用例
+### 使用例 { #examples }
 
 <a id="request-get"></a>
-
 #### GETリクエスト
 
 ```bash
@@ -55,7 +49,6 @@ curl -X GET "https://{userdomain}/{関数名}?param1=value1&param2=value2"
 ```
 
 <a id="request-post"></a>
-
 #### POSTリクエスト
 
 ```bash
@@ -65,8 +58,7 @@ curl -X POST "https://{userdomain}/{関数名}" \
 ```
 
 <a id="enabledisable-http-trigger"></a>
-
-### HTTPトリガーの有効化/無効化
+### HTTPトリガーの有効化/無効化 { #enabledisable-http-trigger }
 
 1. Cloud Functionsコンソールで関数を選択します。
 2. **トリガー**タブに移動します。
@@ -76,14 +68,12 @@ curl -X POST "https://{userdomain}/{関数名}" \
 > <br>無効化されたHTTPトリガーにリクエストを送信しても、関数は実行されません。
 
 <a id="timer-trigger"></a>
-
-## Timerトリガー
+## Timerトリガー { #timer-trigger }
 
 Timerトリガーは、指定された時間または周期に従って自動的に関数を実行します。Cron式を使用して実行周期を設定できます。
 
 <a id="create-timer-trigger"></a>
-
-### Timerトリガーの作成
+### Timerトリガーの作成 { #create-timer-trigger }
 
 ![trigger-guide-05](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-01.png)
 
@@ -95,8 +85,7 @@ Timerトリガーは、指定された時間または周期に従って自動的
 6. **作成**をクリックします。
 
 <a id="cron-expression-format"></a>
-
-### Cron式の形式
+### Cron式の形式 { #cron-expression-format }
 
 Cron式は次のような形式に従います。
 
@@ -112,7 +101,6 @@ Cron式は次のような形式に従います。
 ```
 
 <a id="cron-expression-field"></a>
-
 #### Cron式のフィールド
 
 | フィールド              | 必須  | 許容値             | 許容される記号  |
@@ -125,7 +113,6 @@ Cron式は次のような形式に従います。
 | 曜日(Day of week) | Yes | 0-6 または SUN-SAT  | * / , - ? |
 
 <a id="special-characters-details"></a>
-
 #### 記号の説明
 
 `*`
@@ -149,8 +136,7 @@ Cron式は次のような形式に従います。
 日(Day of month)または曜日(Day of week)フィールドを空けておくために、`*`の代わりに使用できます。
 
 <a id="example-of-cron-expression"></a>
-
-### Cron式の例
+### Cron式の例 { #example-of-cron-expression }
 
 | Cron式              | 説明                             |
 |------------------------|---------------------------------|
@@ -165,8 +151,7 @@ Cron式は次のような形式に従います。
 | `0 0 0 1 JAN *`        | 毎年1月1日の午前0時に実行                  |
 
 <a id="modify-timer-trigger"></a>
-
-### Timerトリガーの修正
+### Timerトリガーの修正 { #modify-timer-trigger }
 
 ![trigger-guide-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-02.png)
 
@@ -181,21 +166,18 @@ Cron式は次のような形式に従います。
 > <br>月(Month)と曜日(Day of week)フィールドの値は、大文字と小文字を区別しません。"SUN"、"Sun"、"sun"は全て同じものとして認識されます。
 
 <a id="api-gateway-trigger"></a>
-
-## API Gatewayトリガー
+## API Gatewayトリガー { #api-gateway-trigger }
 
 API Gatewayトリガーは、同一プロジェクトのAPI Gatewayサービスを活用して関数を実行できます。API Gatewayを通じて、よりきめ細かいAPI管理と制御が可能になります。
 
 <a id="prerequisites"></a>
-
-### 事前要件
+### 事前要件 { #prerequisites }
 
 - 同一プロジェクトでAPI Gatewayサービスが有効になっている必要があります。
   - 有効になっていない場合、トリガー作成時に有効化できます。
 
 <a id="create-api-gateway-trigger"></a>
-
-### API Gatewayトリガーの作成
+### API Gatewayトリガーの作成 { #create-api-gateway-trigger }
 
 ![trigger-guide-04](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-04.png)
 
@@ -208,19 +190,16 @@ API Gatewayトリガーは、同一プロジェクトのAPI Gatewayサービス�
 6. **作成**をクリックします。
 
 <a id="api-gateway-trigger-url-format"></a>
-
-### API GatewayトリガーURL形式
+### API GatewayトリガーURL形式 { #api-gateway-trigger-url-format }
 
 ```
 https://{stageurl}/{パス}
 ```
 
 <a id="api-gateway-trigger-examples"></a>
-
-### 使用例
+### 使用例 { #api-gateway-trigger-examples }
 
 <a id="api-gateway-trigger-examples-request-get"></a>
-
 #### GETリクエスト
 
 ```bash
@@ -228,7 +207,6 @@ curl -X GET "https://{stageurl}/{パス}?param1=value1&param2=value2"
 ```
 
 <a id="api-gateway-trigger-examples-request-post"></a>
-
 #### POSTリクエスト
 
 ```bash
@@ -238,8 +216,7 @@ curl -X POST "https://{stageurl}/{パス}" \
 ```
 
 <a id="features-of-api-gateway-trigger"></a>
-
-### API Gatewayトリガーの特徴
+### API Gatewayトリガーの特徴 { #features-of-api-gateway-trigger }
 
 - API Gatewayの様々な機能を活用できます。
   - 認証及び権限管理
@@ -251,8 +228,7 @@ curl -X POST "https://{stageurl}/{パス}" \
 - HTTPトリガーと同様にGET,POSTメソッドをサポートします。
 
 <a id="modify-api-gateway-trigger"></a>
-
-### API Gatewayトリガーの修正
+### API Gatewayトリガーの修正 { #modify-api-gateway-trigger }
 
 ![trigger-guide-05](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-05.png)
 
@@ -269,20 +245,17 @@ curl -X POST "https://{stageurl}/{パス}" \
 > <br>プラグインが適用されたリソースパスを変更する場合は、修正の代わりに新しいトリガーを追加することを推奨します。
 
 <a id="use-with-api-gateway"></a>
-
-### API Gatewayと併用する
+### API Gatewayと併用する { #use-with-api-gateway }
 
 API Gatewayトリガーを作成すると、API Gatewayコンソールで追加設定を行えます。
 
 詳細は[API Gatewayガイド](https://docs.nhncloud.com/ko/Application%20Service/API%20Gateway/ko/overview/)を参照してください。
 
 <a id="delete-trigger"></a>
-
-## トリガーの削除
+## トリガーの削除 { #delete-trigger }
 
 <a id="how-to-delete-trigger"></a>
-
-### トリガーの削除方法
+### トリガーの削除方法 { #how-to-delete-trigger }
 
 ![trigger-guide-03](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-03.png)
 
@@ -293,20 +266,17 @@ API Gatewayトリガーを作成すると、API Gatewayコンソールで追加�
 5. **トリガー削除**モーダルウィンドウで**削除**をクリックします。
 
 <a id="cautions"></a>
-
-### 注意事項
+### 注意事項 { #cautions }
 
 - HTTPトリガーは削除できません。HTTPトリガーは基本トリガーとして提供され、有効化/無効化のみ可能です。
 - トリガーを削除すると、そのイベントを通じて関数を実行できなくなります。
 - 削除されたトリガーは復元できません。
 
 <a id="restrictions"></a>
-
-## トリガーの制限事項
+## トリガーの制限事項 { #restrictions }
 
 <a id="restrictions-for-api-gateway-trigger"></a>
-
-### API Gatewayトリガーの制限事項
+### API Gatewayトリガーの制限事項 { #restrictions-for-api-gateway-trigger }
 
 - 同一プロジェクト内のAPI Gatewayのみ接続できます。
 - 1つのAPI Gatewayリソースには、1つの関数のみ接続できます。

--- a/ko/api-guide-v1-0.md
+++ b/ko/api-guide-v1-0.md
@@ -1,16 +1,15 @@
 <!-- pre-align:aligned sig=f22611a38cd5 -->
 
-## Cloud Functions API v1.0 가이드
+<a id="cloud-functions-api-v10-guide"></a>
+## Cloud Functions API v1.0 가이드 { #cloud-functions-api-v10-guide }
 
 **Compute > Cloud Functions > API 가이드 > API v1.0 가이드**
 
 <a id="cloud-functions-api-v10-common-information"></a>
-
-## Cloud Functions API v1.0 공통 정보
+## Cloud Functions API v1.0 공통 정보 { #cloud-functions-api-v10-common-information }
 
 <a id="api-endpoint"></a>
-
-### API 엔드포인트
+### API 엔드포인트 { #api-endpoint }
 
 Cloud Functions API를 호출하기 위한 리전별 엔드포인트는 다음과 같습니다.
 
@@ -19,16 +18,14 @@ Cloud Functions API를 호출하기 위한 리전별 엔드포인트는 다음�
 | 한국(판교) 리전 | https://kr1-cloud-functions.api.nhncloudservice.com |
 
 <a id="authentication-and-authorization"></a>
-
-### 인증 및 권한
+### 인증 및 권한 { #authentication-and-authorization }
 
 Cloud Functions는 API 호출 시 인증/인가를 위해 User Access Key 토큰을 사용합니다.
 User Access Key 토큰은 User Access Key를 기반으로 발급되는 Bearer 타입의 일시적 액세스 토큰입니다.
 User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Access Key 토큰](/nhncloud/ko/public-api/user-access-key-token)을 참고하세요.
 
 <a id="response-common-information"></a>
-
-### 응답 공통 정보
+### 응답 공통 정보 { #response-common-information }
 
 모든 API 응답은 다음과 같은 공통 형식을 따릅니다.
 
@@ -77,22 +74,19 @@ User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Acc
 ---
 
 <a id="list-environments"></a>
-
-## 환경 목록 조회
+## 환경 목록 조회 { #list-environments }
 
 사용 가능한 런타임 환경 목록을 조회합니다.
 
 <a id="request"></a>
-
-### 요청
+### 요청 { #request }
 
 ```
 GET /v1.0/env/list
 ```
 
 <a id="request-parameter"></a>
-
-### 요청 파라미터
+### 요청 파라미터 { #request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -100,14 +94,12 @@ GET /v1.0/env/list
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 
 <a id="request-body"></a>
-
-### 요청 본문
+### 요청 본문 { #request-body }
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 <a id="response"></a>
-
-### 응답
+### 응답 { #response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -149,22 +141,19 @@ GET /v1.0/env/list
 ---
 
 <a id="list-functions"></a>
-
-## 함수 목록 조회
+## 함수 목록 조회 { #list-functions }
 
 함수 목록을 조회합니다.
 
 <a id="list-functions-request"></a>
-
-### 요청
+### 요청 { #list-functions-request }
 
 ```
 GET /v1.0/functions
 ```
 
 <a id="list-functions-request-parameter"></a>
-
-### 요청 파라미터
+### 요청 파라미터 { #list-functions-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -174,14 +163,12 @@ GET /v1.0/functions
 | pageSize | Query | Integer | N | 한 페이지에 노출될 개수 |
 
 <a id="list-functions-request-body"></a>
-
-### 요청 본문
+### 요청 본문 { #list-functions-request-body }
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 <a id="list-functions-response"></a>
-
-### 응답
+### 응답 { #list-functions-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -231,22 +218,19 @@ GET /v1.0/functions
 ---
 
 <a id="get-function"></a>
-
-## 함수 상세 조회
+## 함수 상세 조회 { #get-function }
 
 함수의 상세 정보와 빌드 로그를 함께 조회합니다.
 
 <a id="get-function-request"></a>
-
-### 요청
+### 요청 { #get-function-request }
 
 ```
 GET /v1.0/functions/{functionName}
 ```
 
 <a id="get-function-request-parameter"></a>
-
-### 요청 파라미터
+### 요청 파라미터 { #get-function-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -255,14 +239,12 @@ GET /v1.0/functions/{functionName}
 | functionName | URL | String | Y | 함수 이름 |
 
 <a id="get-function-request-body"></a>
-
-### 요청 본문
+### 요청 본문 { #get-function-request-body }
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 <a id="get-function-response"></a>
-
-### 응답
+### 응답 { #get-function-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -321,8 +303,7 @@ GET /v1.0/functions/{functionName}
 ---
 
 <a id="create-function"></a>
-
-## 함수 생성
+## 함수 생성 { #create-function }
 
 새 함수를 생성합니다. multipart/form-data로 소스 파일을 업로드합니다.
 runtime은 `{environment}-{version}` 형식으로 입력해야 합니다(예: NodeJS-22.5.0). 사용 가능한 런타임은 환경 목록 조회 API로 확인할 수 있습니다.
@@ -330,16 +311,14 @@ runtime은 `{environment}-{version}` 형식으로 입력해야 합니다(예: No
 executorType에 따라 필수 파라미터가 달라집니다. poolManager일 때는 requestPerPod가, newDeployment일 때는 minInstance와 maxInstance가 필수입니다.
 
 <a id="create-function-request"></a>
-
-### 요청
+### 요청 { #create-function-request }
 
 ```
 POST /v1.0/functions
 ```
 
 <a id="create-function-request-parameter"></a>
-
-### 요청 파라미터
+### 요청 파라미터 { #create-function-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -347,8 +326,7 @@ POST /v1.0/functions
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 
 <a id="create-function-request-body"></a>
-
-### 요청 본문
+### 요청 본문 { #create-function-request-body }
 
 Content-Type: multipart/form-data
 
@@ -368,8 +346,7 @@ Content-Type: multipart/form-data
 | sourceFile | Binary | Y          | 소스 코드 파일(ZIP)                                                                                     |
 
 <a id="create-function-response"></a>
-
-### 응답
+### 응답 { #create-function-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -390,24 +367,21 @@ Content-Type: multipart/form-data
 ---
 
 <a id="modify-function"></a>
-
-## 함수 수정
+## 함수 수정 { #modify-function }
 
 함수를 수정합니다. multipart/form-data로 소스 파일을 업로드할 수 있습니다.
 
 소스 파일(sourceFile)은 선택 항목입니다. 소스 파일을 포함하지 않으면 기존 소스 코드가 유지됩니다.
 
 <a id="modify-function-request"></a>
-
-### 요청
+### 요청 { #modify-function-request }
 
 ```
 PUT /v1.0/functions/{functionName}
 ```
 
 <a id="modify-function-request-parameter"></a>
-
-### 요청 파라미터
+### 요청 파라미터 { #modify-function-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -416,8 +390,7 @@ PUT /v1.0/functions/{functionName}
 | functionName | URL | String | Y | 수정할 함수 이름 |
 
 <a id="modify-function-request-body"></a>
-
-### 요청 본문
+### 요청 본문 { #modify-function-request-body }
 
 Content-Type: multipart/form-data
 
@@ -436,8 +409,7 @@ Content-Type: multipart/form-data
 | sourceFile | Binary | N          | 소스 코드 파일(ZIP)                                                                                     |
 
 <a id="modify-function-response"></a>
-
-### 응답
+### 응답 { #modify-function-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -458,22 +430,19 @@ Content-Type: multipart/form-data
 ---
 
 <a id="delete-functions"></a>
-
-## 함수 삭제
+## 함수 삭제 { #delete-functions }
 
 함수를 일괄 삭제합니다.
 
 <a id="delete-functions-request"></a>
-
-### 요청
+### 요청 { #delete-functions-request }
 
 ```
 DELETE /v1.0/functions
 ```
 
 <a id="delete-functions-request-parameter"></a>
-
-### 요청 파라미터
+### 요청 파라미터 { #delete-functions-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -481,8 +450,7 @@ DELETE /v1.0/functions
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 
 <a id="delete-functions-request-body"></a>
-
-### 요청 본문
+### 요청 본문 { #delete-functions-request-body }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -500,8 +468,7 @@ DELETE /v1.0/functions
 | names | Array | Y | 삭제할 함수 이름 목록 |
 
 <a id="delete-functions-response"></a>
-
-### 응답
+### 응답 { #delete-functions-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -522,22 +489,19 @@ DELETE /v1.0/functions
 ---
 
 <a id="execute-function-get"></a>
-
-## 함수 실행(GET)
+## 함수 실행(GET) { #execute-function-get }
 
 GET 방식으로 함수를 실행합니다.
 
 <a id="execute-function-get-request"></a>
-
-### 요청
+### 요청 { #execute-function-get-request }
 
 ```
 GET /v1.0/functions/{functionName}/invoke
 ```
 
 <a id="execute-function-get-request-parameter"></a>
-
-### 요청 파라미터
+### 요청 파라미터 { #execute-function-get-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -546,14 +510,12 @@ GET /v1.0/functions/{functionName}/invoke
 | functionName | URL | String | Y | 실행할 함수 이름 |
 
 <a id="execute-function-get-request-body"></a>
-
-### 요청 본문
+### 요청 본문 { #execute-function-get-request-body }
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 <a id="execute-function-get-response"></a>
-
-### 응답
+### 응답 { #execute-function-get-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -578,22 +540,19 @@ GET /v1.0/functions/{functionName}/invoke
 ---
 
 <a id="execute-function-post"></a>
-
-## 함수 실행(POST)
+## 함수 실행(POST) { #execute-function-post }
 
 POST 방식으로 함수를 실행합니다. body를 전달할 수 있습니다.
 
 <a id="execute-function-post-request"></a>
-
-### 요청
+### 요청 { #execute-function-post-request }
 
 ```
 POST /v1.0/functions/{functionName}/invoke
 ```
 
 <a id="execute-function-post-request-parameter"></a>
-
-### 요청 파라미터
+### 요청 파라미터 { #execute-function-post-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -602,8 +561,7 @@ POST /v1.0/functions/{functionName}/invoke
 | functionName | URL | String | Y | 실행할 함수 이름 |
 
 <a id="execute-function-post-request-body"></a>
-
-### 요청 본문
+### 요청 본문 { #execute-function-post-request-body }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -621,8 +579,7 @@ POST /v1.0/functions/{functionName}/invoke
 | body | JSON | N | 함수에 전달할 body |
 
 <a id="execute-function-post-response"></a>
-
-### 응답
+### 응답 { #execute-function-post-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -647,22 +604,19 @@ POST /v1.0/functions/{functionName}/invoke
 ---
 
 <a id="list-versions"></a>
-
-## 버전 목록 조회
+## 버전 목록 조회 { #list-versions }
 
 함수의 버전(패키지) 목록을 조회합니다.
 
 <a id="list-versions-request"></a>
-
-### 요청
+### 요청 { #list-versions-request }
 
 ```
 GET /v1.0/functions/{functionName}/versions
 ```
 
 <a id="list-versions-request-parameter"></a>
-
-### 요청 파라미터
+### 요청 파라미터 { #list-versions-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -671,14 +625,12 @@ GET /v1.0/functions/{functionName}/versions
 | functionName | URL | String | Y | 함수 이름 |
 
 <a id="list-versions-request-body"></a>
-
-### 요청 본문
+### 요청 본문 { #list-versions-request-body }
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 <a id="list-versions-response"></a>
-
-### 응답
+### 응답 { #list-versions-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -726,22 +678,19 @@ GET /v1.0/functions/{functionName}/versions
 ---
 
 <a id="switch-version"></a>
-
-## 버전 전환
+## 버전 전환 { #switch-version }
 
 함수의 현재 활성 버전을 변경합니다.
 
 <a id="switch-version-request"></a>
-
-### 요청
+### 요청 { #switch-version-request }
 
 ```
 PUT /v1.0/functions/{functionName}/versions
 ```
 
 <a id="switch-version-request-parameter"></a>
-
-### 요청 파라미터
+### 요청 파라미터 { #switch-version-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -750,8 +699,7 @@ PUT /v1.0/functions/{functionName}/versions
 | functionName | URL | String | Y | 함수 이름 |
 
 <a id="switch-version-request-body"></a>
-
-### 요청 본문
+### 요청 본문 { #switch-version-request-body }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -769,8 +717,7 @@ PUT /v1.0/functions/{functionName}/versions
 | versionId | Integer | Y | 전환할 버전 ID |
 
 <a id="switch-version-response"></a>
-
-### 응답
+### 응답 { #switch-version-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -791,24 +738,21 @@ PUT /v1.0/functions/{functionName}/versions
 ---
 
 <a id="delete-versions"></a>
-
-## 버전 삭제
+## 버전 삭제 { #delete-versions }
 
 함수의 버전을 일괄 삭제합니다.
 
 현재 활성 버전은 삭제할 수 없습니다.
 
 <a id="delete-versions-request"></a>
-
-### 요청
+### 요청 { #delete-versions-request }
 
 ```
 DELETE /v1.0/functions/{functionName}/versions
 ```
 
 <a id="delete-versions-request-parameter"></a>
-
-### 요청 파라미터
+### 요청 파라미터 { #delete-versions-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -817,8 +761,7 @@ DELETE /v1.0/functions/{functionName}/versions
 | functionName | URL | String | Y | 함수 이름 |
 
 <a id="delete-versions-request-body"></a>
-
-### 요청 본문
+### 요청 본문 { #delete-versions-request-body }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -836,8 +779,7 @@ DELETE /v1.0/functions/{functionName}/versions
 | versionIds | Array | Y | 삭제할 버전 ID 목록 |
 
 <a id="delete-versions-response"></a>
-
-### 응답
+### 응답 { #delete-versions-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -858,22 +800,19 @@ DELETE /v1.0/functions/{functionName}/versions
 ---
 
 <a id="list-triggers"></a>
-
-## 트리거 목록 조회
+## 트리거 목록 조회 { #list-triggers }
 
 함수의 트리거 목록을 조회합니다.
 
 <a id="list-triggers-request"></a>
-
-### 요청
+### 요청 { #list-triggers-request }
 
 ```
 GET /v1.0/triggers/{functionName}
 ```
 
 <a id="list-triggers-request-parameter"></a>
-
-### 요청 파라미터
+### 요청 파라미터 { #list-triggers-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -882,14 +821,12 @@ GET /v1.0/triggers/{functionName}
 | functionName | URL | String | Y | 함수 이름 |
 
 <a id="list-triggers-request-body"></a>
-
-### 요청 본문
+### 요청 본문 { #list-triggers-request-body }
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 <a id="list-triggers-response"></a>
-
-### 응답
+### 응답 { #list-triggers-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -931,22 +868,19 @@ GET /v1.0/triggers/{functionName}
 ---
 
 <a id="create-time-trigger"></a>
-
-## 타임 트리거 생성
+## 타임 트리거 생성 { #create-time-trigger }
 
 함수에 타임 트리거를 생성합니다.
 
 <a id="create-time-trigger-request"></a>
-
-### 요청
+### 요청 { #create-time-trigger-request }
 
 ```
 POST /v1.0/triggers/{functionName}/time
 ```
 
 <a id="create-time-trigger-request-parameter"></a>
-
-### 요청 파라미터
+### 요청 파라미터 { #create-time-trigger-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -955,8 +889,7 @@ POST /v1.0/triggers/{functionName}/time
 | functionName | URL | String | Y | 함수 이름 |
 
 <a id="create-time-trigger-request-body"></a>
-
-### 요청 본문
+### 요청 본문 { #create-time-trigger-request-body }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -974,8 +907,7 @@ POST /v1.0/triggers/{functionName}/time
 | cron | String | Y | cron 표현식 |
 
 <a id="create-time-trigger-response"></a>
-
-### 응답
+### 응답 { #create-time-trigger-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -996,22 +928,19 @@ POST /v1.0/triggers/{functionName}/time
 ---
 
 <a id="modify-time-trigger"></a>
-
-## 타임 트리거 수정
+## 타임 트리거 수정 { #modify-time-trigger }
 
 타임 트리거의 cron 표현식을 수정합니다.
 
 <a id="modify-time-trigger-request"></a>
-
-### 요청
+### 요청 { #modify-time-trigger-request }
 
 ```
 PUT /v1.0/triggers/{functionName}/time
 ```
 
 <a id="modify-time-trigger-request-parameter"></a>
-
-### 요청 파라미터
+### 요청 파라미터 { #modify-time-trigger-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -1020,8 +949,7 @@ PUT /v1.0/triggers/{functionName}/time
 | functionName | URL | String | Y | 함수 이름 |
 
 <a id="modify-time-trigger-request-body"></a>
-
-### 요청 본문
+### 요청 본문 { #modify-time-trigger-request-body }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -1041,8 +969,7 @@ PUT /v1.0/triggers/{functionName}/time
 | cron | String | Y | cron 표현식 |
 
 <a id="modify-time-trigger-response"></a>
-
-### 응답
+### 응답 { #modify-time-trigger-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -1063,22 +990,19 @@ PUT /v1.0/triggers/{functionName}/time
 ---
 
 <a id="delete-time-triggers"></a>
-
-## 타임 트리거 삭제
+## 타임 트리거 삭제 { #delete-time-triggers }
 
 타임 트리거를 일괄 삭제합니다.
 
 <a id="delete-time-triggers-request"></a>
-
-### 요청
+### 요청 { #delete-time-triggers-request }
 
 ```
 DELETE /v1.0/triggers/{functionName}/time
 ```
 
 <a id="delete-time-triggers-request-parameter"></a>
-
-### 요청 파라미터
+### 요청 파라미터 { #delete-time-triggers-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -1087,8 +1011,7 @@ DELETE /v1.0/triggers/{functionName}/time
 | functionName | URL | String | Y | 함수 이름 |
 
 <a id="delete-time-triggers-request-body"></a>
-
-### 요청 본문
+### 요청 본문 { #delete-time-triggers-request-body }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -1106,8 +1029,7 @@ DELETE /v1.0/triggers/{functionName}/time
 | names | Array | Y | 삭제할 트리거 이름 목록 |
 
 <a id="delete-time-triggers-response"></a>
-
-### 응답
+### 응답 { #delete-time-triggers-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>

--- a/ko/code-template-dotnet-guide.md
+++ b/ko/code-template-dotnet-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=3c324618eb1e -->
 
-## Compute > Cloud Functions > 코드 템플릿 가이드 > .NET
+<a id="compute-cloud-functions-code-template-guide-net"></a>
+## Compute > Cloud Functions > 코드 템플릿 가이드 > .NET { #compute-cloud-functions-code-template-guide-net }
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 .NET을 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
 
 <a id="template-information"></a>
-
-## 템플릿 정보
+## 템플릿 정보 { #template-information }
 | 항목              | 값       |
 |-----------------|---------|
 | **지원 버전**       | 8       |
@@ -14,12 +14,10 @@
 | **Entry Point** | func    |
 
 <a id="basic-template"></a>
-
-## 기본 템플릿
+## 기본 템플릿 { #basic-template }
 
 <a id="hello-world-example"></a>
-
-### Hello World 예시
+### Hello World 예시 { #hello-world-example }
 가장 기본적인 함수 형태입니다. `Nhn.DotNetCore.Api` 네임스페이스의 `NhnContext`를 사용하여 로거 및 요청 정보에 접근합니다.
 
 ```csharp
@@ -59,8 +57,7 @@ public class NhnFunction
 ```
 
 <a id="context-object"></a>
-
-### Context 객체
+### Context 객체 { #context-object }
 `NhnContext` 객체를 통해 로거, 요청(Request), 응답(Response) 객체에 접근할 수 있습니다.
 
 ```csharp
@@ -106,19 +103,16 @@ public class NhnFunction
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## 템플릿 파일 다운로드 및 활용
+## 템플릿 파일 다운로드 및 활용 { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### 템플릿 다운로드
+### 템플릿 다운로드 { #template-download }
 Cloud Functions에서 제공하는 .NET 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 **템플릿 다운로드 링크**: [dotnet.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/dotnet/dotnet.zip)
 
 <a id="template-file-structure"></a>
-
-### 템플릿 파일 구조
+### 템플릿 파일 구조 { #template-file-structure }
 다운로드한 템플릿 파일의 구조는 다음과 같습니다.
 
 ```
@@ -129,11 +123,9 @@ dotnet.zip
 ```
 
 <a id="local-development-process"></a>
-
-### 로컬 개발 과정
+### 로컬 개발 과정 { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. 압축 해제
 ```bash
 # 압축 해제
@@ -144,7 +136,6 @@ cd my-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. 함수 코드 수정
 `func.cs` 파일을 원하는 로직으로 수정합니다.
 
@@ -201,7 +192,6 @@ public class NhnFunction
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. ZIP 파일로 압축
 수정된 소스 코드를 다시 ZIP 파일로 압축합니다. `func.cs`와 `nuget.txt`가 최상위에 포함되도록 압축해야 합니다.
 
@@ -210,18 +200,15 @@ zip my-function.zip func.cs nuget.txt
 ```
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Cloud Functions 콘솔에서 업로드
+### Cloud Functions 콘솔에서 업로드 { #upload-from-cloud-functions-console }
 - 함수 생성 또는 수정 시, **사용자 로컬 환경** 방식을 선택합니다.
 - **파일 선택**을 클릭하여 생성한 `my-function.zip` 파일을 업로드합니다.
 
 <a id="process-by-http-method"></a>
-
-## HTTP 메서드별 처리
+## HTTP 메서드별 처리 { #process-by-http-method }
 
 <a id="process-get-request"></a>
-
-### GET 요청 처리
+### GET 요청 처리 { #process-get-request }
 ```csharp
 using System;
 using Nhn.DotNetCore.Api;
@@ -251,8 +238,7 @@ public class NhnFunction
 ```
 
 <a id="process-post-request"></a>
-
-### POST 요청 처리
+### POST 요청 처리 { #process-post-request }
 ```csharp
 using System;
 using System.IO;
@@ -305,8 +291,7 @@ public class NhnFunction
 ```
 
 <a id="manage-package-nugettxt"></a>
-
-## 패키지 관리(`nuget.txt`)
+## 패키지 관리(`nuget.txt`) { #manage-package-nugettxt }
 
 의존성(NuGet 패키지) 관리를 위해 `nuget.txt` 파일을 사용합니다. 필요한 패키지를 한 줄에 하나씩 작성합니다.
 
@@ -316,8 +301,7 @@ Microsoft.Extensions.Configuration:8.0.0
 ```
 
 <a id="example-of-configuration-management"></a>
-
-### 설정 관리 예시
+### 설정 관리 예시 { #example-of-configuration-management }
 ```csharp
 using System;
 using System.Collections.Generic;
@@ -399,8 +383,7 @@ public class NhnFunction
 ```
 
 <a id="configure-entry-point"></a>
-
-## Entry Point 설정
+## Entry Point 설정 { #configure-entry-point }
 
 Entry Point는 **파일명**입니다. (확장자 제외)
 
@@ -410,7 +393,6 @@ Entry Point는 **파일명**입니다. (확장자 제외)
 **중요**: 클래스 이름은 `NhnFunction`이어야 하며, 함수 역할을 하는 메서드는 `public string Execute(NhnContext context)` 시그니처를 가져야 합니다.
 
 <a id="caution"></a>
-
-### 주의사항
+### 주의사항 { #caution }
 - **패키지 버전**: `nuget.txt`에서 패키지 버전을 명시할 수 있습니다. (예: `Newtonsoft.Json:9.0.1`)
 - **타입 충돌**: 의존성 추가 시 타입 충돌이 발생할 수 있으므로, 가능한 .NET 기본 라이브러리를 사용하거나 호환되는 버전의 패키지를 사용하는 것을 권장합니다.

--- a/ko/code-template-go-guide.md
+++ b/ko/code-template-go-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=9b45d499c0b7 -->
 
-## Compute > Cloud Functions > 코드 템플릿 가이드 > Go
+<a id="compute-cloud-functions-code-template-guide-go"></a>
+## Compute > Cloud Functions > 코드 템플릿 가이드 > Go { #compute-cloud-functions-code-template-guide-go }
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 Go를 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
 
 <a id="template-information"></a>
-
-## 템플릿 정보
+## 템플릿 정보 { #template-information }
 | 항목              | 값                                        |
 |-----------------|------------------------------------------|
 | **지원 버전**       | 1.22, 1.23, 1.24, 1.25 |
@@ -14,12 +14,10 @@
 | **Entry Point** | Handler                                  |
 
 <a id="basic-template"></a>
-
-## 기본 템플릿
+## 기본 템플릿 { #basic-template }
 
 <a id="hello-world-example"></a>
-
-### Hello World 예시
+### Hello World 예시 { #hello-world-example }
 가장 기본적인 함수 형태입니다.
 
 ```go
@@ -47,8 +45,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="context-object"></a>
-
-### Context 객체
+### Context 객체 { #context-object }
 Go 함수에서는 `http.ResponseWriter`와 `*http.Request`를 통해 HTTP 요청과 응답을 처리합니다.
 
 ```go
@@ -85,19 +82,16 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## 템플릿 파일 다운로드 및 활용
+## 템플릿 파일 다운로드 및 활용 { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### 템플릿 다운로드
+### 템플릿 다운로드 { #template-download }
 Cloud Functions에서 제공하는 Go 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 **템플릿 다운로드 링크**: [go.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/go/go.zip)
 
 <a id="template-file-structure"></a>
-
-### 템플릿 파일 구조
+### 템플릿 파일 구조 { #template-file-structure }
 다운로드한 템플릿 파일의 구조는 다음과 같습니다.
 
 ```
@@ -107,7 +101,6 @@ go.zip
 ```
 
 <a id="functionsgo"></a>
-
 #### functions.go
 기본 fake 데이터 생성 함수가 포함되어 있습니다.
 ```go
@@ -135,7 +128,6 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="gomod"></a>
-
 #### go.mod
 ```go
 module example.com/ncf
@@ -146,11 +138,9 @@ require github.com/brianvoe/gofakeit/v6 v6.28.0
 ```
 
 <a id="local-development-process"></a>
-
-### 로컬 개발 과정
+### 로컬 개발 과정 { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. 압축 해제
 ```bash
 # 압축 해제
@@ -161,7 +151,6 @@ cd my-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. 함수 코드 수정
 `functions.go` 파일을 원하는 로직으로 수정합니다.
 
@@ -212,7 +201,6 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. ZIP 파일로 압축
 수정된 코드를 다시 ZIP 파일로 압축합니다.
 
@@ -231,16 +219,13 @@ zip -r my-function.zip . -x "*.git*" "go.sum" "test.go"
 ```
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Cloud Functions 콘솔에서 업로드
+### Cloud Functions 콘솔에서 업로드 { #upload-from-cloud-functions-console }
 > 함수를 생성하거나 수정할 때 사용자 로컬 환경의 파일을 업로드 시 사용. (콘솔 사용 가이드 참고)
 
 <a id="cautions-for-upload"></a>
-
-### 업로드 시 주의사항
+### 업로드 시 주의사항 { #cautions-for-upload }
 
 <a id="zip-file-structure"></a>
-
 #### ZIP 파일 구조
 - ZIP 파일의 루트에 직접 `.go` 파일과 `go.mod`가 위치해야 합니다.
 - 불필요한 폴더 구조는 피할 것을 권장합니다.
@@ -262,13 +247,11 @@ my-function.zip
 ```
 
 <a id="file-size-limit"></a>
-
 #### 파일 크기 제한
 - ZIP 파일 크기는 100MiB 이하로 제한됩니다.
 - `go.sum` 파일은 포함하지 마세요.
 
 <a id="files-to-exclude"></a>
-
 #### 제외할 파일들
 ```bash
 # .gitignore와 유사하게 다음 파일들은 제외
@@ -282,12 +265,10 @@ zip -r my-function.zip . -x \
 ```
 
 <a id="process-by-http-method"></a>
-
-## HTTP 메서드별 처리
+## HTTP 메서드별 처리 { #process-by-http-method }
 
 <a id="process-get-request"></a>
-
-### GET 요청 처리
+### GET 요청 처리 { #process-get-request }
 ```go
 package main
 
@@ -326,8 +307,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="process-post-request"></a>
-
-### POST 요청 처리
+### POST 요청 처리 { #process-post-request }
 ```go
 package main
 
@@ -399,12 +379,10 @@ func getOrDefault(value, defaultValue string) string {
 ```
 
 <a id="manage-packages"></a>
-
-## 패키지 관리
+## 패키지 관리 { #manage-packages }
 
 <a id="write-gomod"></a>
-
-### go.mod 작성
+### go.mod 작성 { #write-gomod }
 의존성 관리를 위해 `go.mod` 파일을 작성합니다.
 
 ```go
@@ -419,8 +397,7 @@ require (
 ```
 
 <a id="example-of-external-api-call"></a>
-
-### 외부 API 호출 예시
+### 외부 API 호출 예시 { #example-of-external-api-call }
 ```go
 package main
 
@@ -474,8 +451,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 <a id="data-processing-example"></a>
-
-### 데이터 처리 예시
+### 데이터 처리 예시 { #data-processing-example }
 ```go
 package main
 
@@ -569,20 +545,17 @@ func normalizeName(name string) string {
 ```
 
 <a id="configure-entry-point"></a>
-
-## Entry Point 설정
+## Entry Point 설정 { #configure-entry-point }
 
 <a id="single-function"></a>
-
-### 단일 함수
+### 단일 함수 { #single-function }
 함수명을 Entry Point로 사용합니다.
 
 함수명: `Handler`
 Entry Point: `Handler`
 
 <a id="multiple-functions"></a>
-
-### 다중 함수
+### 다중 함수 { #multiple-functions }
 하나의 파일에서 여러 함수를 정의할 수 있습니다.
 
 ```go
@@ -623,12 +596,10 @@ Entry Point 설정:
 - `UpdateUser`
 
 <a id="caution"></a>
-
-## 주의사항
+## 주의사항 { #caution }
 
 <a id="go-version"></a>
-
-### Go 버전
+### Go 버전 { #go-version }
 | 버전 | 지원 중단일 | 사용 중단일 |
 |-----|-----------|-----------|
 | 1.25 | - | - |
@@ -637,7 +608,6 @@ Entry Point 설정:
 | 1.22 | 2026-01-28 | 2026-07-28 |
 
 <a id="go-version-support-policy"></a>
-
 #### Go 버전 지원 정책
 Cloud Functions는 Go의 공식 릴리즈 정책을 따릅니다. Go는 연 2회(1월, 7월) 새로운 메이저 버전을 릴리즈하며, 각 버전은 최신 2개 메이저 버전까지만 지원됩니다.
 

--- a/ko/code-template-java-guide.md
+++ b/ko/code-template-java-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=65e9891c8f54 -->
 
-## Compute > Cloud Functions > 코드 템플릿 가이드 > Java
+<a id="compute-cloud-functions-code-template-guide-java"></a>
+## Compute > Cloud Functions > 코드 템플릿 가이드 > Java { #compute-cloud-functions-code-template-guide-java }
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 Java를 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
 
 <a id="template-information"></a>
-
-## 템플릿 정보
+## 템플릿 정보 { #template-information }
 | 항목              | 값                  |
 |-----------------|--------------------|
 | **지원 버전**       | 17, 21             |
@@ -14,12 +14,10 @@
 | **Entry Point** | example.HelloWorld |
 
 <a id="basic-template"></a>
-
-## 기본 템플릿
+## 기본 템플릿 { #basic-template }
 
 <a id="hello-world-example"></a>
-
-### Hello World 예시
+### Hello World 예시 { #hello-world-example }
 가장 기본적인 함수 형태입니다.
 
 ```java
@@ -38,8 +36,7 @@ public class HelloWorld {
 ```
 
 <a id="context-object-requestentity"></a>
-
-### Context 객체(RequestEntity)
+### Context 객체(RequestEntity) { #context-object-requestentity }
 Java 함수에서는 Spring의 `RequestEntity`를 통해 HTTP 요청 정보에 접근할 수 있습니다.
 
 ```java
@@ -73,19 +70,16 @@ public class HelloWorld {
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## 템플릿 파일 다운로드 및 활용
+## 템플릿 파일 다운로드 및 활용 { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### 템플릿 다운로드
+### 템플릿 다운로드 { #template-download }
 Cloud Functions에서 제공하는 Java 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 **템플릿 다운로드 링크**: [java.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/java/java.zip)
 
 <a id="template-file-structure"></a>
-
-### 템플릿 파일 구조
+### 템플릿 파일 구조 { #template-file-structure }
 다운로드한 템플릿은 Maven 프로젝트 구조를 따릅니다.
 
 ```
@@ -99,11 +93,9 @@ java.zip
 ```
 
 <a id="local-development-process"></a>
-
-### 로컬 개발 과정
+### 로컬 개발 과정 { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. 압축 해제
 ```bash
 # 압축 해제
@@ -114,7 +106,6 @@ cd my-java-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. 함수 코드 수정
 `src/main/java/example/HelloWorld.java` 파일을 원하는 로직으로 수정합니다.
 
@@ -167,7 +158,6 @@ public class HelloWorld {
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. ZIP 파일로 압축
 수정된 소스 코드를 다시 ZIP 파일로 압축합니다. `pom.xml` 파일과 `src` 디렉터리가 최상위에 포함되도록 압축해야 합니다.
 
@@ -186,26 +176,22 @@ zip -r my-function.zip . -x "*.git*" "target/*" "*.log"
 ```
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Cloud Functions 콘솔에서 업로드
+### Cloud Functions 콘솔에서 업로드 { #upload-from-cloud-functions-console }
 - 함수 생성 또는 수정 시, **사용자 로컬 환경** 방식을 선택합니다.
 - **파일 선택**을 클릭하여 생성한 `my-function.zip` 파일을 업로드합니다.
 
 <a id="cautions-for-upload"></a>
-
-### 업로드 시 주의사항
+### 업로드 시 주의사항 { #cautions-for-upload }
 - **업로드 파일**: 소스 코드와 `pom.xml`이 포함된 **ZIP 파일**을 업로드해야 합니다.
 - **ZIP 파일 구조**: ZIP 파일의 루트에 `pom.xml`과 `src` 디렉터리가 위치해야 합니다.
 - **제외할 파일**: `target` 디렉터리, `.git` 디렉터리 등 불필요한 파일은 포함하지 마세요.
 - **파일 크기**: ZIP 파일 크기는 100MiB 이하로 제한됩니다.
 
 <a id="process-by-http-method"></a>
-
-## HTTP 메서드별 처리
+## HTTP 메서드별 처리 { #process-by-http-method }
 
 <a id="process-get-request"></a>
-
-### GET 요청 처리
+### GET 요청 처리 { #process-get-request }
 ```java
 package example;
 
@@ -242,8 +228,7 @@ public class GetHandler {
 ```
 
 <a id="process-post-request"></a>
-
-### POST 요청 처리
+### POST 요청 처리 { #process-post-request }
 ```java
 package example;
 
@@ -285,8 +270,7 @@ public class PostHandler {
 ```
 
 <a id="manage-package-pomxml"></a>
-
-## 패키지 관리(`pom.xml`)
+## 패키지 관리(`pom.xml`) { #manage-package-pomxml }
 
 의존성 관리를 위해 `pom.xml` 파일을 수정합니다. `dependencies` 섹션에 필요한 라이브러리를 추가하면, 함수 업로드 시 Cloud Functions가 자동으로 의존성을 다운로드하여 빌드에 포함합니다.
 
@@ -310,8 +294,7 @@ public class PostHandler {
 ```
 
 <a id="example-of-using-external-libraries"></a>
-
-### 외부 라이브러리 활용 예시
+### 외부 라이브러리 활용 예시 { #example-of-using-external-libraries }
 ```java
 package example;
 
@@ -346,12 +329,10 @@ public class StringUtilsHandler {
 ```
 
 <a id="entry-point-configuration"></a>
-
-## Entry Point 설정
+## Entry Point 설정 { #entry-point-configuration }
 
 <a id="single-class"></a>
-
-### 단일 클래스
+### 단일 클래스 { #single-class }
 `패키지명.클래스명`을 Entry Point로 사용합니다.
 
 - 패키지명: `example`
@@ -360,7 +341,6 @@ public class StringUtilsHandler {
 - **중요**: 함수 역할을 하는 메서드는 `public ResponseEntity<?> call(RequestEntity<?> req)` 시그니처를 가져야 합니다.
 
 <a id="caution"></a>
-
-### 주의사항
+### 주의사항 { #caution }
 - **프로젝트 구조**: `src/main/java` 디렉터리 구조를 유지해야 합니다.
 - **메모리 및 실행 시간**: 함수는 제한된 리소스 내에서 동작해야 하므로, 무거운 작업은 피하고 코드를 최적화하세요.

--- a/ko/code-template-node-guide.md
+++ b/ko/code-template-node-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=ce91cd7cb2f1 -->
 
-## Compute > Cloud Functions > 코드 템플릿 가이드 > Node.js
+<a id="compute-cloud-functions-code-template-guide-nodejs"></a>
+## Compute > Cloud Functions > 코드 템플릿 가이드 > Node.js { #compute-cloud-functions-code-template-guide-nodejs }
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 Node.js를 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
 
 <a id="template-information"></a>
-
-## 템플릿 정보
+## 템플릿 정보 { #template-information }
 | 항목              | 값               |
 |-----------------|-----------------|
 | **지원 버전**       | 20.16.0, 22.5.0 |
@@ -14,11 +14,9 @@
 | **Entry Point** | hello           |
 
 <a id="basic-template"></a>
-
-## 기본 템플릿
+## 기본 템플릿 { #basic-template }
 <a id="hello-world-example"></a>
-
-### Hello World 예시
+### Hello World 예시 { #hello-world-example }
 가장 기본적인 함수 형태입니다.
 
 ```javascript
@@ -31,8 +29,7 @@ module.exports = async (context) => {
 ```
 
 <a id="context-object"></a>
-
-### Context 객체
+### Context 객체 { #context-object }
 함수에 전달되는 `context` 객체는 다음과 같은 정보를 포함합니다.
 
 ```javascript
@@ -53,19 +50,16 @@ module.exports = async (context) => {
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## 템플릿 파일 다운로드 및 활용
+## 템플릿 파일 다운로드 및 활용 { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### 템플릿 다운로드
+### 템플릿 다운로드 { #template-download }
 Cloud Functions에서 제공하는 Node.js 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 **템플릿 다운로드 링크**: [nodejs.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/nodejs/nodejs.zip)
 
 <a id="template-file-structure"></a>
-
-### 템플릿 파일 구조
+### 템플릿 파일 구조 { #template-file-structure }
 다운로드한 템플릿 파일의 구조는 다음과 같습니다.
 
 ```
@@ -75,7 +69,6 @@ nodejs.zip
 ```
 
 <a id="hellojs"></a>
-
 #### hello.js
 기본 Hello World 함수가 포함되어 있습니다.
 ```javascript
@@ -88,18 +81,15 @@ module.exports = async (context) => {
 ```
 
 <a id="packagejson"></a>
-
 #### package.json
 ```json
 {}
 ```
 
 <a id="local-development-process"></a>
-
-### 로컬 개발 과정
+### 로컬 개발 과정 { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. 압축 해제
 ```bash
 # 압축 해제
@@ -110,7 +100,6 @@ cd my-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. 함수 코드 수정
 `hello.js` 파일을 원하는 로직으로 수정합니다.
 
@@ -154,7 +143,6 @@ module.exports = async (context) => {
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. ZIP 파일로 압축
 수정된 코드를 다시 ZIP 파일로 압축합니다.
 
@@ -173,16 +161,13 @@ zip -r my-function.zip . -x "*.git*" "node_modules/*" "test.js"
 ```
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Cloud Functions 콘솔에서 업로드
+### Cloud Functions 콘솔에서 업로드 { #upload-from-cloud-functions-console }
 > 함수를 생성하거나 수정할 때 사용자 로컬 환경의 파일을 업로드 시 사용. (콘솔 사용 가이드 참고)
 
 <a id="cautions-for-upload"></a>
-
-### 업로드 시 주의사항
+### 업로드 시 주의사항 { #cautions-for-upload }
 
 <a id="zip-file-structure"></a>
-
 #### ZIP 파일 구조
 - ZIP 파일의 루트에 직접 `.js` 파일과 `package.json`이 위치해야 합니다.
 - 불필요한 폴더 구조는 피할 것을 권장합니다.
@@ -204,13 +189,11 @@ my-function.zip
 ```
 
 <a id="file-size-limit"></a>
-
 #### 파일 크기 제한
 - ZIP 파일 크기는 100MiB 이하로 제한됩니다.
 - `node_modules` 폴더는 포함하지 마세요. (의존성은 `package.json`으로 관리)
 
 <a id="files-to-exclude"></a>
-
 #### 제외할 파일들
 ```bash
 # .gitignore와 유사하게 다음 파일들은 제외
@@ -224,12 +207,10 @@ zip -r my-function.zip . -x \
 ```
 
 <a id="process-by-http-method"></a>
-
-## HTTP 메서드별 처리
+## HTTP 메서드별 처리 { #process-by-http-method }
 
 <a id="process-get-request"></a>
-
-### GET 요청 처리
+### GET 요청 처리 { #process-get-request }
 ```javascript
 module.exports = async (context) => {
     if (context.request.method !== 'GET') {
@@ -256,8 +237,7 @@ module.exports = async (context) => {
 ```
 
 <a id="process-post-request"></a>
-
-### POST 요청 처리
+### POST 요청 처리 { #process-post-request }
 ```javascript
 module.exports = async (context) => {
     if (context.request.method !== 'POST') {
@@ -303,12 +283,10 @@ module.exports = async (context) => {
 ```
 
 <a id="manage-packages"></a>
-
-## 패키지 관리
+## 패키지 관리 { #manage-packages }
 
 <a id="write-packagejson"></a>
-
-### package.json 작성
+### package.json 작성 { #write-packagejson }
 의존성 관리를 위해 `package.json` 파일을 작성합니다.
 
 ```json
@@ -327,8 +305,7 @@ module.exports = async (context) => {
 ```
 
 <a id="example-of-external-api-call"></a>
-
-### 외부 API 호출 예시
+### 외부 API 호출 예시 { #example-of-external-api-call }
 ```javascript
 const axios = require('axios');
 
@@ -379,8 +356,7 @@ module.exports = async (context) => {
 ```
 
 <a id="data-processing-example"></a>
-
-### 데이터 처리 예시
+### 데이터 처리 예시 { #data-processing-example }
 ```javascript
 const _ = require('lodash');
 const moment = require('moment');
@@ -435,20 +411,17 @@ module.exports = async (context) => {
 ```
 
 <a id="configure-entry-point"></a>
-
-## Entry Point 설정
+## Entry Point 설정 { #configure-entry-point }
 
 <a id="single-function"></a>
-
-### 단일 함수
+### 단일 함수 { #single-function }
 파일명을 Entry Point로 사용합니다.
 
 파일명: `hello.js`
 Entry Point: `hello`
 
 <a id="multiple-functions"></a>
-
-### 다중 함수
+### 다중 함수 { #multiple-functions }
 하나의 파일에서 여러 함수를 내보낼 수 있습니다.
 
 ```javascript
@@ -484,8 +457,7 @@ Entry Point 설정:
 - `users.updateUser`
 
 <a id="entry-point-restriction"></a>
-
-### Entry Point 제한 사항
+### Entry Point 제한 사항 { #entry-point-restriction }
 - **하위 디렉터리 지정 불가**: 루트 디렉터리의 하위 디렉터리에 있는 파일은 Entry Point로 지정할 수 없습니다.
 
 **올바른 Entry Point:**
@@ -504,12 +476,10 @@ modules/auth.js → modules.auth ❌
 모든 함수 파일은 ZIP 파일의 루트 레벨에 위치해야 합니다.
 
 <a id="caution"></a>
-
-## 주의사항
+## 주의사항 { #caution }
 
 <a id="commonjs-vs-es-modules"></a>
-
-### CommonJS vs ES Modules
+### CommonJS vs ES Modules { #commonjs-vs-es-modules }
 현재 Cloud Functions는 CommonJS 방식만 지원합니다.
 
 **사용 가능(CommonJS):**
@@ -529,8 +499,7 @@ export default async (context) => {  // ❌ 지원하지 않음
 ```
 
 <a id="considerations-for-memory-and-execution-time"></a>
-
-### 메모리 및 실행 시간 고려사항
+### 메모리 및 실행 시간 고려사항 { #considerations-for-memory-and-execution-time }
 - 함수는 제한된 메모리와 실행 시간 내에서 동작해야 합니다.
 - 대용량 데이터 처리 시 스트림 처리를 고려하세요.
 - 장시간 실행되는 작업은 적절히 분할하세요.

--- a/ko/code-template-python-guide.md
+++ b/ko/code-template-python-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=577d9bcb43c9 -->
 
-## Compute > Cloud Functions > 코드 템플릿 가이드 > Python
+<a id="compute-cloud-functions-code-template-guide-python"></a>
+## Compute > Cloud Functions > 코드 템플릿 가이드 > Python { #compute-cloud-functions-code-template-guide-python }
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 Python을 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
 
 <a id="template-information"></a>
-
-## 템플릿 정보
+## 템플릿 정보 { #template-information }
 | 항목              | 값                |
 |-----------------|------------------|
 | **지원 버전**       | 3.11, 3.12, 3.13 |
@@ -14,12 +14,10 @@
 | **Entry Point** | user.main        |
 
 <a id="basic-template"></a>
-
-## 기본 템플릿
+## 기본 템플릿 { #basic-template }
 
 <a id="hello-world-example"></a>
-
-### Hello World 예시
+### Hello World 예시 { #hello-world-example }
 가장 기본적인 함수 형태입니다.
 
 ```python
@@ -38,8 +36,7 @@ def main():
 ```
 
 <a id="context-object"></a>
-
-### Context 객체
+### Context 객체 { #context-object }
 Python 함수에서는 Flask의 request 객체를 통해 HTTP 요청 정보에 접근할 수 있습니다.
 
 ```python
@@ -68,19 +65,16 @@ def main():
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## 템플릿 파일 다운로드 및 활용
+## 템플릿 파일 다운로드 및 활용 { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### 템플릿 다운로드
+### 템플릿 다운로드 { #template-download }
 Cloud Functions에서 제공하는 Python 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 **템플릿 다운로드 링크**: [python.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/python/python.zip)
 
 <a id="template-file-structure"></a>
-
-### 템플릿 파일 구조
+### 템플릿 파일 구조 { #template-file-structure }
 다운로드한 템플릿 파일의 구조는 다음과 같습니다.
 
 ```
@@ -90,7 +84,6 @@ python.zip
 ```
 
 <a id="userpy"></a>
-
 #### user.py
 기본 YAML 처리 함수가 포함되어 있습니다.
 ```python
@@ -109,18 +102,15 @@ def main():
 ```
 
 <a id="requirementstxt"></a>
-
 #### requirements.txt
 ```txt
 pyyaml
 ```
 
 <a id="local-development-process"></a>
-
-### 로컬 개발 과정
+### 로컬 개발 과정 { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. 압축 해제
 ```bash
 # 압축 해제
@@ -131,7 +121,6 @@ cd my-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. 함수 코드 수정
 `user.py` 파일을 원하는 로직으로 수정합니다.
 
@@ -174,7 +163,6 @@ def main():
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. ZIP 파일로 압축
 수정된 코드를 다시 ZIP 파일로 압축합니다.
 
@@ -193,16 +181,13 @@ zip -r my-function.zip . -x "*.git*" "__pycache__/*" "*.pyc" "test.py"
 ```
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Cloud Functions 콘솔에서 업로드
+### Cloud Functions 콘솔에서 업로드 { #upload-from-cloud-functions-console }
 > 함수를 생성하거나 수정할 때 사용자 로컬 환경의 파일을 업로드 시 사용. (콘솔 사용 가이드 참고)
 
 <a id="cautions-for-upload"></a>
-
-### 업로드 시 주의사항
+### 업로드 시 주의사항 { #cautions-for-upload }
 
 <a id="zip-file-structure"></a>
-
 #### ZIP 파일 구조
 - ZIP 파일의 루트에 직접 `.py` 파일과 `requirements.txt`가 위치해야 합니다.
 - 불필요한 폴더 구조는 피할 것을 권장합니다.
@@ -224,13 +209,11 @@ my-function.zip
 ```
 
 <a id="file-size-limit"></a>
-
 #### 파일 크기 제한
 - ZIP 파일 크기는 100MiB 이하로 제한됩니다.
 - `__pycache__` 폴더는 포함하지 마세요.
 
 <a id="files-to-exclude"></a>
-
 #### 제외할 파일들
 ```bash
 # .gitignore와 유사하게 다음 파일들은 제외
@@ -245,12 +228,10 @@ zip -r my-function.zip . -x \
 ```
 
 <a id="process-by-http-method"></a>
-
-## HTTP 메서드별 처리
+## HTTP 메서드별 처리 { #process-by-http-method }
 
 <a id="process-get-request"></a>
-
-### GET 요청 처리
+### GET 요청 처리 { #process-get-request }
 ```python
 from flask import request
 import json
@@ -274,8 +255,7 @@ def main():
 ```
 
 <a id="process-post-request"></a>
-
-### POST 요청 처리
+### POST 요청 처리 { #process-post-request }
 ```python
 from flask import request
 import json
@@ -319,12 +299,10 @@ def main():
 ```
 
 <a id="manage-packages"></a>
-
-## 패키지 관리
+## 패키지 관리 { #manage-packages }
 
 <a id="write-requirementstxt"></a>
-
-### requirements.txt 작성
+### requirements.txt 작성 { #write-requirementstxt }
 의존성 관리를 위해 `requirements.txt` 파일을 작성합니다.
 
 ```txt
@@ -334,8 +312,7 @@ python-dateutil>=2.8.0
 ```
 
 <a id="example-of-external-api-call"></a>
-
-### 외부 API 호출 예시
+### 외부 API 호출 예시 { #example-of-external-api-call }
 ```python
 from flask import request
 import json
@@ -378,8 +355,7 @@ def main():
 ```
 
 <a id="data-processing-example"></a>
-
-### 데이터 처리 예시
+### 데이터 처리 예시 { #data-processing-example }
 ```python
 from flask import request
 import json
@@ -434,12 +410,10 @@ def normalize_name(name):
 ```
 
 <a id="configure-entry-point"></a>
-
-## Entry Point 설정
+## Entry Point 설정 { #configure-entry-point }
 
 <a id="single-function"></a>
-
-### 단일 함수
+### 단일 함수 { #single-function }
 `파일명.함수명`을 Entry Point로 사용합니다.
 
 파일명: `user.py`
@@ -447,8 +421,7 @@ def normalize_name(name):
 Entry Point: `user.main`
 
 <a id="multiple-functions"></a>
-
-### 다중 함수
+### 다중 함수 { #multiple-functions }
 하나의 파일에서 여러 함수를 정의할 수 있습니다.
 
 ```python
@@ -475,12 +448,10 @@ Entry Point 설정:
 - `handlers.update_user`
 
 <a id="caution"></a>
-
-## 주의사항
+## 주의사항 { #caution }
 
 <a id="unsupported-packages"></a>
-
-### 지원하지 않는 패키지
+### 지원하지 않는 패키지 { #unsupported-packages }
 현재 아래 특징이 있는 복잡한 패키지는 지원하지 않습니다.
 
 **지원하지 않는 패키지 예시:**
@@ -495,8 +466,7 @@ Entry Point 설정:
 - `pillow` (이미지 처리 - 기본 기능)
 
 <a id="considerations-for-memory-and-execution-time"></a>
-
-### 메모리 및 실행 시간 고려사항
+### 메모리 및 실행 시간 고려사항 { #considerations-for-memory-and-execution-time }
 - 함수는 제한된 메모리와 실행 시간 내에서 동작해야 합니다.
 - 대용량 데이터 처리 시 제너레이터나 스트림 처리를 고려하세요.
 - 장시간 실행되는 작업은 적절히 분할하세요.

--- a/ko/code-template-ruby-guide.md
+++ b/ko/code-template-ruby-guide.md
@@ -1,12 +1,12 @@
 <!-- pre-align:aligned sig=1d5361d8d187 -->
 
-## Compute > Cloud Functions > 코드 템플릿 가이드 > Ruby
+<a id="compute-cloud-functions-code-template-guide-ruby"></a>
+## Compute > Cloud Functions > 코드 템플릿 가이드 > Ruby { #compute-cloud-functions-code-template-guide-ruby }
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 Ruby를 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
 
 <a id="template-information"></a>
-
-## 템플릿 정보
+## 템플릿 정보 { #template-information }
 | 항목              | 값        |
 |-----------------|----------|
 | **지원 버전**       | 3.4.5    |
@@ -14,12 +14,10 @@
 | **Entry Point** | handler  |
 
 <a id="basic-template"></a>
-
-## 기본 템플릿
+## 기본 템플릿 { #basic-template }
 
 <a id="hello-world-example"></a>
-
-### Hello World 예시
+### Hello World 예시 { #hello-world-example }
 가장 기본적인 함수 형태입니다.
 
 ```ruby
@@ -39,8 +37,7 @@ end
 ```
 
 <a id="context-object"></a>
-
-### Context 객체
+### Context 객체 { #context-object }
 함수에 전달되는 `context` 객체를 통해 로거와 요청 정보에 접근할 수 있습니다.
 
 ```ruby
@@ -75,19 +72,16 @@ end
 ```
 
 <a id="download-and-use-template-file"></a>
-
-## 템플릿 파일 다운로드 및 활용
+## 템플릿 파일 다운로드 및 활용 { #download-and-use-template-file }
 
 <a id="template-download"></a>
-
-### 템플릿 다운로드
+### 템플릿 다운로드 { #template-download }
 Cloud Functions에서 제공하는 Ruby 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 **템플릿 다운로드 링크**: [ruby.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/ruby/ruby.zip)
 
 <a id="template-file-structure"></a>
-
-### 템플릿 파일 구조
+### 템플릿 파일 구조 { #template-file-structure }
 다운로드한 템플릿 파일의 구조는 다음과 같습니다.
 
 ```
@@ -97,11 +91,9 @@ ruby.zip
 ```
 
 <a id="local-development-process"></a>
-
-### 로컬 개발 과정
+### 로컬 개발 과정 { #local-development-process }
 
 <a id="unzip"></a>
-
 #### 1. 압축 해제
 ```bash
 # 압축 해제
@@ -112,7 +104,6 @@ cd my-function
 ```
 
 <a id="modify-function-codes"></a>
-
 #### 2. 함수 코드 수정
 `parse.rb` 파일을 원하는 로직으로 수정합니다.
 
@@ -158,7 +149,6 @@ end
 ```
 
 <a id="compress-into-a-zip-file"></a>
-
 #### 3. ZIP 파일로 압축
 수정된 소스 코드를 다시 ZIP 파일로 압축합니다. `parse.rb`와 `Gemfile`이 최상위에 포함되도록 압축해야 합니다.
 
@@ -168,26 +158,22 @@ zip my-function.zip parse.rb Gemfile Gemfile.lock
 **참고**: `Gemfile.lock` 파일은 배포 단계에서 자동으로 생성되지만, 의존성의 정확한 버전을 미리 확인하거나 고정하고 싶은 경우 로컬에서 `bundle install`을 실행하여 직접 생성한 후 함께 압축할 수 있습니다. `Gemfile.lock` 파일이 포함된 경우 해당 파일에 명시된 버전을 사용하여 빌드됩니다.
 
 <a id="upload-from-cloud-functions-console"></a>
-
-### Cloud Functions 콘솔에서 업로드
+### Cloud Functions 콘솔에서 업로드 { #upload-from-cloud-functions-console }
 - 함수 생성 또는 수정 시, **사용자 로컬 환경** 방식을 선택합니다.
 - **파일 선택**을 클릭하여 생성한 `my-function.zip` 파일을 업로드합니다.
 
 <a id="cautions-for-upload"></a>
-
-### 업로드 시 주의사항
+### 업로드 시 주의사항 { #cautions-for-upload }
 - **업로드 파일**: `*.rb`, `Gemfile`이 포함된 **ZIP 파일**을 업로드해야 합니다.
   - `Gemfile.lock` 파일은 선택 사항입니다. 포함된 경우 해당 파일에 명시된 버전으로 빌드되며, 없을 경우 배포 단계에서 자동으로 생성됩니다.
 - **ZIP 파일 구조**: ZIP 파일의 루트에 파일들이 위치해야 합니다.
 - **파일 크기**: ZIP 파일 크기는 100MiB 이하로 제한됩니다.
 
 <a id="process-post-request"></a>
-
-## HTTP 메서드별 처리
+## HTTP 메서드별 처리 { #process-post-request }
 
 <a id="process-get-request"></a>
-
-### GET 요청 처리
+### GET 요청 처리 { #process-get-request }
 ```ruby
 # frozen_string_literal: true
 
@@ -212,8 +198,7 @@ end
 ```
 
 <a id="process-post-request-2"></a>
-
-### POST 요청 처리
+### POST 요청 처리 { #process-post-request-2 }
 ```ruby
 # frozen_string_literal: true
 
@@ -249,8 +234,7 @@ end
 ```
 
 <a id="manage-package-gemfile"></a>
-
-## 패키지 관리(`Gemfile`)
+## 패키지 관리(`Gemfile`) { #manage-package-gemfile }
 
 의존성(Gem) 관리를 위해 `Gemfile`을 사용합니다. 필요한 Gem을 추가하고 `bundle install`을 실행하여 `Gemfile.lock`을 생성합니다.
 
@@ -265,8 +249,7 @@ gem "httparty", "~> 0.23" # HTTP 클라이언트
 ```
 
 <a id="example-of-external-api-call"></a>
-
-### 외부 API 호출 예시
+### 외부 API 호출 예시 { #example-of-external-api-call }
 ```ruby
 # frozen_string_literal: true
 
@@ -307,8 +290,7 @@ end
 ```
 
 <a id="configure-entry-point"></a>
-
-## Entry Point 설정
+## Entry Point 설정 { #configure-entry-point }
 
 Entry Point는 함수명을 사용합니다.
 
@@ -317,7 +299,6 @@ Entry Point는 함수명을 사용합니다.
 - Entry Point: `handler`
 
 <a id="caution"></a>
-
-### 주의사항
+### 주의사항 { #caution }
 - **Bundler 버전**: `Gemfile.lock` 생성 시 Bundler 2.6.2 이상 버전 사용을 권장합니다.
 - **ActiveSupport 등 일부 Gem 호환성**: `ActiveSupport`와 같이 C 확장(C extension)에 의존하거나 내부 구조가 복잡한 일부 Gem은 현재 Cloud Functions 환경과 호환성 문제가 발생할 수 있습니다. `activesupport` Gem은 내부적으로 `zeitwerk` Gem에 의존하며, 이 Gem이 파일 시스템을 탐색하는 방식이 실행 환경과 충돌하여 정상적으로 동작하지 않을 수 있습니다. 따라서 가급적 표준 라이브러리나 외부 의존성이 적은 Gem을 사용하는 것을 권장합니다.

--- a/ko/console-guide.md
+++ b/ko/console-guide.md
@@ -1,23 +1,21 @@
 <!-- pre-align:aligned sig=fda183656939 -->
 
-## Compute > Cloud Functions > 콘솔 사용 가이드
+<a id="compute-cloud-functions-console-user-guide"></a>
+## Compute > Cloud Functions > 콘솔 사용 가이드 { #compute-cloud-functions-console-user-guide }
 이 문서는 Cloud Functions 콘솔에서 함수를 생성하고 관리하는 방법을 설명합니다.
 
 <a id="manage-functions"></a>
-
-## 함수 관리
+## 함수 관리 { #manage-functions }
 함수를 생성, 수정, 삭제, 복사할 수 있습니다.
 
 <a id="create-functions"></a>
-
-### 함수 생성
+### 함수 생성 { #create-functions }
 함수 설정을 하고 코드를 작성하여 빌드한 뒤 **생성** 버튼을 클릭하면 마지막 빌드한 패키지로 함수가 생성됩니다.
 
 ![console-guide-07](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-07.png)
 ![console-guide-08](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-08.png)
 
 <a id="function-settings"></a>
-
 #### 함수 설정
 <table class="it">
     <tr>
@@ -96,7 +94,6 @@
 
 
 <a id="code-writing"></a>
-
 #### 코드 작성
 
 ![console-guide-09](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-09.png)
@@ -161,59 +158,49 @@
 > **[참고]** <br> 빌드 버튼을 통해 생성된 패키지는 함수 생성/수정 시 마지막 빌드한 패키지가 함수 버전으로 연동됩니다. 함수 생성 전 최소 1회 이상 빌드를 수행해야 합니다.
 
 <a id="modify-functions"></a>
-
-### 함수 수정
+### 함수 수정 { #modify-functions }
 기존 함수의 함수 설정 및 코드를 수정하기 위해 **수정** 버튼을 클릭해 함수를 수정합니다.
 <a id="non-modifiable-item"></a>
-
 #### 수정 불가 항목
 - 이름, 런타임 환경
     - 해당 항목을 제외한 모든 항목을 수정할 수 있습니다.
 <a id="source-code"></a>
-
 #### 소스 코드
 - 코드 에디터를 사용하는 경우 기존 코드가 로드됩니다.
 - 사용자 로컬 환경의 ZIP 파일을 업로드하여 함수를 생성했을 경우, 코드 에디터로 변경하면 ZIP 파일을 보여주지 않고 기본 템플릿 코드를 로드합니다.
 
 <a id="delete-a-function"></a>
-
-### 함수 삭제
+### 함수 삭제 { #delete-a-function }
 ![console-guide-14](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-14.png)
 기존 함수를 선택하여 삭제합니다. 한 번에 여러 함수 삭제가 가능합니다.
 
 <a id="copy-a-function"></a>
-
-### 함수 복사
+### 함수 복사 { #copy-a-function }
 ![console-guide-13](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-13.png)
 기존 함수와 동일한 함수를 복사합니다. 이름은 중복이 불가능하여 복사 전에 이름을 새롭게 작성할 수 있습니다.
 - 트리거는 복사되지 않습니다. (HTTP 트리거는 기본 제공)
 - 버전은 현재 적용된 버전만 복사됩니다.
 
 <a id="about-functions"></a>
-
-## 함수 정보
+## 함수 정보 { #about-functions }
 <a id="list-of-functions"></a>
-
-### 함수 목록
+### 함수 목록 { #list-of-functions }
 ![console-guide-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-01.png)
 - 사용자가 생성한 함수 목록을 확인할 수 있습니다.
 - 빌드 상태는 현재 버전의 빌드 상태를 표시합니다.
 <a id="basic-information-of-functions"></a>
-
-### 함수 기본 정보
+### 함수 기본 정보 { #basic-information-of-functions }
 ![console-guide-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-02.png)
 - 함수의 기본 정보를 확인할 수 있습니다.
 - 로그 관리 항목에서 **Log & Crash Search** 버튼을 클릭해 Log & Crash Search 서비스로 이동하여 로그를 확인할 수 있습니다.
 
 <a id="function-versioning"></a>
-
-### 함수 버전 관리
+### 함수 버전 관리 { #function-versioning }
 ![console-guide-15](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2026-01-27/console-guide-15.png)
 - 함수의 버전을 관리할 수 있습니다.
 - 생성된 모든 버전의 이력을 확인하고, 이전 버전으로 롤백할 수 있습니다.
 
 <a id="versioning-overview"></a>
-
 #### 버전 관리 개요
 함수 생성/수정 화면에서 **빌드** 버튼을 클릭해 코드를 빌드하면 패키지가 생성됩니다.
 - 함수 생성/수정 시 마지막 빌드한 패키지가 함수 버전으로 연동됩니다.
@@ -221,7 +208,6 @@
 - 함수 생성 시 최소 1회 이상 빌드를 진행해야 함수 생성이 가능합니다.
 
 <a id="version-information"></a>
-
 #### 버전 정보
 <table class="it">
     <tr>
@@ -252,7 +238,6 @@
 </table>
 
 <a id="deploy-versions"></a>
-
 #### 버전 배포
 - 버전 목록에서 배포할 버전을 선택하고 **버전 배포** 버튼을 클릭하면 해당 버전으로 함수가 업데이트됩니다.
 - 현재 적용된 버전은 선택할 수 없습니다.
@@ -263,7 +248,6 @@
 > <br>버전 배포 시 확인 팝업이 표시되며, 성공 시 버전 목록이 자동으로 갱신됩니다.
 
 <a id="delete-versions"></a>
-
 #### 버전 삭제
 - 버전 목록에서 삭제할 버전을 선택하고 **버전 삭제** 버튼을 클릭하면 해당 버전이 삭제됩니다.
 - 현재 적용된 버전은 삭제할 수 없습니다.
@@ -274,7 +258,6 @@
 > <br>버전 삭제 시 확인 팝업이 표시되며, 삭제된 버전은 복구할 수 없습니다.
 
 <a id="constraints"></a>
-
 #### 제약 사항
 - 함수 생성/수정 화면에서 빌드한 패키지는 함수 생성/수정을 취소하면 함수 버전으로 연동되지 않습니다.
 - 함수 삭제 시 해당 함수와 연동된 모든 버전도 함께 삭제됩니다.
@@ -282,8 +265,7 @@
 - 함수 생성 시 여러 런타임으로 빌드할 수 있으나, 함수 수정 시에는 생성 당시 선택한 런타임으로만 빌드할 수 있습니다.
 
 <a id="manage-function-triggers"></a>
-
-### 함수 트리거 관리
+### 함수 트리거 관리 { #manage-function-triggers }
 - 함수를 실행할 수 있는 트리거를 관리할 수 있습니다.
 - HTTP 트리거는 함수 생성 시 기본으로 제공됩니다.
     - 활성화/비활성화를 통해 사용 여부를 설정할 수 있습니다.
@@ -295,7 +277,6 @@
     - Method : GET, POST
 
 <a id="createedit-triggers"></a>
-
 #### 트리거 생성/수정
 - Timer
     - Value: Cron 문자열로 주기를 입력합니다.
@@ -303,13 +284,11 @@
     - API Gateway 서비스를 이용하여 HTTP Endpoint를 추가할 수 있습니다.
 
 <a id="delete-triggers"></a>
-
 #### 트리거 삭제
 - 여러 건의 트리거를 선택하여 삭제할 수 있습니다. 기본 트리거인 HTTP 트리거는 삭제할 수 없습니다.
 
 <a id="monitor-functions"></a>
-
-### 함수 모니터링
+### 함수 모니터링 { #monitor-functions }
 ![console-guide-06](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-06.png)
 - 함수의 사용량을 확인할 수 있습니다.
 - 함수 호출 횟수, 호출 거부 수, 오류 발생 횟수, 성공률, 함수 실행 시간 지표를 제공합니다.

--- a/ko/overview.md
+++ b/ko/overview.md
@@ -1,11 +1,11 @@
 <!-- pre-align:aligned sig=92acb111e0a0 -->
 
-## Compute > Cloud Functions > 개요
+<a id="compute-cloud-functions-overview"></a>
+## Compute > Cloud Functions > 개요 { #compute-cloud-functions-overview }
 사용자는 함수 단위로 코드를 작성할 수 있으며, 특정 이벤트 발생 시 정의된 함수가 자동으로 실행되어 필요한 작업을 처리합니다. 서버 관리나 인프라 설정 없이 애플리케이션 로직에만 집중할 수 있습니다.
 
 <a id="features"></a>
-
-### 특징
+### 특징 { #features }
 - 비용 효율성
     - 사용한 만큼만 과금하여 비용을 절감합니다.
     - 필요할 때만 리소스를 할당하므로 관리 비용을 감소할 수 있습니다.
@@ -18,20 +18,17 @@
     - 이벤트 기반 아키텍처로 다양한 활용이 가능합니다.
 
 <a id="main-features"></a>
-
-### 주요 기능
+### 주요 기능 { #main-features }
 - 다양한 언어(환경)를 제공합니다.
 - **코드 에디터**를 통해 간단한 함수 단위 코드를 작성할 수 있습니다.
 - 함수를 수행할 수 있는 HTTPS Endpoint를 기본 제공합니다.
 - 함수를 일정 주기로 반복 수행할 수 있습니다.
 
 <a id="two-modes-available"></a>
-
-### 두 가지 모드 제공
+### 두 가지 모드 제공 { #two-modes-available }
 - Pool Manager
 - New Deployment
 <a id="pool-manager"></a>
-
 #### Pool Manager
 - 함수가 수행될 때만 인스턴스가 생성되어 리소스를 사용합니다.
 - 일정 기간 함수가 수행되지 않으면 인스턴스는 사라지고 리소스 사용량은 0이 됩니다.
@@ -40,7 +37,6 @@
 ![overview-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_1_ko.png)
 
 <a id="new-deployment"></a>
-
 #### New Deployment
 - 함수를 생성하면 바로 인스턴스가 생성되어 일정량의 리소스를 계속 사용합니다.
 - 빠른 응답을 위해 인스턴스 생성을 유지합니다.
@@ -49,8 +45,7 @@
 ![overview-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_2_ko.png)
 
 <a id="supported-languages"></a>
-
-### 지원 언어
+### 지원 언어 { #supported-languages }
 
 | 언어     | 버전                | 지원 중단일   | 사용 중단일   |
 |--------|-------------------|------------|------------|
@@ -72,8 +67,7 @@
 |        | 7(사용 중단)         | 2024-05-14 | 2025-05-14 |
 
 <a id="trigger"></a>
-
-### Trigger
+### Trigger { #trigger }
 - HTTP Trigger
     - 기본 제공(GET, POST 지원)
 - Timer Trigger

--- a/ko/release-notes.md
+++ b/ko/release-notes.md
@@ -1,39 +1,33 @@
 <!-- pre-align:aligned sig=06519d7ca905 -->
 
-## Compute > Cloud Functions > 릴리스 노트
+<a id="compute-cloud-functions-release-notes"></a>
+## Compute > Cloud Functions > 릴리스 노트 { #compute-cloud-functions-release-notes }
 
 <a id="april-14-2026"></a>
-
-### 2026. 04. 14.
+### 2026. 04. 14. { #april-14-2026 }
 
 <a id="added-features"></a>
-
 #### 기능 추가
 - Public API v1.0 추가
   - API로 Cloud Functions를 이용할 수 있습니다.
 
 <a id="january-27-2026"></a>
-
-### 2026. 01. 27.
+### 2026. 01. 27. { #january-27-2026 }
 
 <a id="january-27-2026-added-features"></a>
-
 #### 기능 추가
 - 함수 버전 관리 기능 추가
   - 빌드한 패키지를 버전으로 관리하고 이전 버전으로 롤백할 수 있습니다.
 
 <a id="november-25-2025"></a>
-
-### 2025. 11. 25.
+### 2025. 11. 25. { #november-25-2025 }
 
 <a id="november-25-2025-added-features"></a>
-
 #### 기능 추가
 - API Gateway 트리거 추가
   - 동일 프로젝트의 API Gateway 서비스를 활용하여 API Gateway 트리거를 생성할 수 있습니다.
 
 <a id="feature-updates"></a>
-
 #### 기능 개선
 - 런타임 환경 최신 버전 추가 및 일부 버전 사용 중단
   - Go 1.24, 1.25 추가
@@ -43,10 +37,8 @@
   - .NET 7 사용 중단, .NET 8 추가
 
 <a id="july-29-2025"></a>
-
-### 2025. 07. 29.
+### 2025. 07. 29. { #july-29-2025 }
 
 <a id="launch-cloud-functions-service"></a>
-
 #### Cloud Functions 서비스 출시
 - 사용자는 함수 단위로 코드를 작성할 수 있으며, 특정 이벤트 발생 시 정의된 함수가 자동으로 실행되어 필요한 작업을 처리합니다. 서버 관리나 인프라 설정 없이 애플리케이션 로직에만 집중할 수 있습니다.

--- a/ko/trigger-guide.md
+++ b/ko/trigger-guide.md
@@ -1,18 +1,17 @@
 <!-- pre-align:aligned sig=02be28f736c7 -->
 
-## Compute > Cloud Functions > 트리거 가이드
+<a id="compute-cloud-functions-trigger-guide"></a>
+## Compute > Cloud Functions > 트리거 가이드 { #compute-cloud-functions-trigger-guide }
 
 이 문서는 Cloud Functions에서 제공하는 트리거 유형과 설정 방법을 설명합니다.
 
 <a id="trigger-overview"></a>
-
-## 트리거 개요
+## 트리거 개요 { #trigger-overview }
 
 트리거는 함수를 실행시키는 이벤트 소스입니다. Cloud Functions는 다양한 유형의 트리거를 제공하여 여러 방식으로 함수를 호출할 수 있습니다.
 
 <a id="supported-triggers"></a>
-
-### 지원 트리거 유형
+### 지원 트리거 유형 { #supported-triggers }
 
 | 트리거 유형      | 설명                     | 기본 제공 |
 |-------------|------------------------|-------|
@@ -21,33 +20,28 @@
 | API Gateway | API Gateway를 통해 함수 실행  | X     |
 
 <a id="http-trigger"></a>
-
-## HTTP 트리거
+## HTTP 트리거 { #http-trigger }
 
 HTTP 트리거는 함수 생성 시 기본으로 제공되며, HTTP 요청을 통해 함수를 실행할 수 있습니다.
 
 <a id="features"></a>
-
-### 특징
+### 특징 { #features }
 
 - 함수 생성 시 자동으로 생성됩니다.
 - 삭제할 수 없으며, 활성화/비활성화만 가능합니다.
 - GET, POST 메서드를 지원합니다.
 
 <a id="url-format-of-http-trigger"></a>
-
-### HTTP 트리거 URL 형식
+### HTTP 트리거 URL 형식 { #url-format-of-http-trigger }
 
 ```
 https://{userdomain}/{함수명}
 ```
 
 <a id="examples"></a>
-
-### 사용 예시
+### 사용 예시 { #examples }
 
 <a id="request-get"></a>
-
 #### GET 요청
 
 ```bash
@@ -55,7 +49,6 @@ curl -X GET "https://{userdomain}/{함수명}?param1=value1&param2=value2"
 ```
 
 <a id="request-post"></a>
-
 #### POST 요청
 
 ```bash
@@ -65,8 +58,7 @@ curl -X POST "https://{userdomain}/{함수명}" \
 ```
 
 <a id="enabledisable-http-trigger"></a>
-
-### HTTP 트리거 활성화/비활성화
+### HTTP 트리거 활성화/비활성화 { #enabledisable-http-trigger }
 
 1. Cloud Functions 콘솔에서 함수를 선택합니다.
 2. **트리거** 탭으로 이동합니다.
@@ -76,14 +68,12 @@ curl -X POST "https://{userdomain}/{함수명}" \
 > <br>비활성화된 HTTP 트리거로 요청을 보내면 함수가 실행되지 않습니다.
 
 <a id="timer-trigger"></a>
-
-## Timer 트리거
+## Timer 트리거 { #timer-trigger }
 
 Timer 트리거는 지정된 시간 또는 주기에 따라 자동으로 함수를 실행합니다. Cron 표현식을 사용하여 실행 주기를 설정할 수 있습니다.
 
 <a id="create-timer-trigger"></a>
-
-### Timer 트리거 생성
+### Timer 트리거 생성 { #create-timer-trigger }
 
 ![trigger-guide-05](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-01.png)
 
@@ -95,8 +85,7 @@ Timer 트리거는 지정된 시간 또는 주기에 따라 자동으로 함수�
 6. **생성**을 클릭합니다.
 
 <a id="cron-expression-format"></a>
-
-### Cron 표현식 형식
+### Cron 표현식 형식 { #cron-expression-format }
 
 Cron 표현식은 다음과 같은 형식을 따릅니다.
 
@@ -112,7 +101,6 @@ Cron 표현식은 다음과 같은 형식을 따릅니다.
 ```
 
 <a id="cron-expression-field"></a>
-
 #### Cron 표현식 필드
 
 | 필드              | 필수  | 허용 값            | 허용 특수 문자  |
@@ -125,7 +113,6 @@ Cron 표현식은 다음과 같은 형식을 따릅니다.
 | 요일(Day of week) | Yes | 0-6 또는 SUN-SAT  | * / , - ? |
 
 <a id="special-characters-details"></a>
-
 #### 특수 문자 설명
 
 `*`
@@ -149,8 +136,7 @@ Cron 표현식은 다음과 같은 형식을 따릅니다.
 일(Day of month) 또는 요일(Day of week) 필드를 비워두기 위해 `*` 대신 사용할 수 있습니다.
 
 <a id="example-of-cron-expression"></a>
-
-### Cron 표현식 예시
+### Cron 표현식 예시 { #example-of-cron-expression }
 
 | Cron 표현식               | 설명                              |
 |------------------------|---------------------------------|
@@ -165,8 +151,7 @@ Cron 표현식은 다음과 같은 형식을 따릅니다.
 | `0 0 0 1 JAN *`        | 매년 1월 1일 자정에 실행                 |
 
 <a id="modify-timer-trigger"></a>
-
-### Timer 트리거 수정
+### Timer 트리거 수정 { #modify-timer-trigger }
 
 ![trigger-guide-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-02.png)
 
@@ -181,21 +166,18 @@ Cron 표현식은 다음과 같은 형식을 따릅니다.
 > <br>월(Month)과 요일(Day of week) 필드 값은 대소문자를 구분하지 않습니다. "SUN", "Sun", "sun"은 모두 동일하게 인식됩니다.
 
 <a id="api-gateway-trigger"></a>
-
-## API Gateway 트리거
+## API Gateway 트리거 { #api-gateway-trigger }
 
 API Gateway 트리거는 동일 프로젝트의 API Gateway 서비스를 활용하여 함수를 실행할 수 있습니다. API Gateway를 통해 더욱 세밀한 API 관리와 제어가 가능합니다.
 
 <a id="prerequisites"></a>
-
-### 사전 요구사항
+### 사전 요구사항 { #prerequisites }
 
 - 동일 프로젝트에 API Gateway 서비스가 활성화되어 있어야 합니다.
   - 활성화되어 있지 않는 경우 트리거 생성 시 활성화 가능합니다.
 
 <a id="create-api-gateway-trigger"></a>
-
-### API Gateway 트리거 생성
+### API Gateway 트리거 생성 { #create-api-gateway-trigger }
 
 ![trigger-guide-04](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-04.png)
 
@@ -208,19 +190,16 @@ API Gateway 트리거는 동일 프로젝트의 API Gateway 서비스를 활용�
 6. **생성**을 클릭합니다.
 
 <a id="api-gateway-trigger-url-format"></a>
-
-### API Gateway 트리거 URL 형식
+### API Gateway 트리거 URL 형식 { #api-gateway-trigger-url-format }
 
 ```
 https://{stageurl}/{경로}
 ```
 
 <a id="api-gateway-trigger-examples"></a>
-
-### 사용 예시
+### 사용 예시 { #api-gateway-trigger-examples }
 
 <a id="api-gateway-trigger-examples-request-get"></a>
-
 #### GET 요청
 
 ```bash
@@ -228,7 +207,6 @@ curl -X GET "https://{stageurl}/{경로}?param1=value1&param2=value2"
 ```
 
 <a id="api-gateway-trigger-examples-request-post"></a>
-
 #### POST 요청
 
 ```bash
@@ -238,8 +216,7 @@ curl -X POST "https://{stageurl}/{경로}" \
 ```
 
 <a id="features-of-api-gateway-trigger"></a>
-
-### API Gateway 트리거 특징
+### API Gateway 트리거 특징 { #features-of-api-gateway-trigger }
 
 - API Gateway의 다양한 기능을 활용할 수 있습니다.
   - 인증 및 권한 관리
@@ -251,8 +228,7 @@ curl -X POST "https://{stageurl}/{경로}" \
 - HTTP 트리거와 동일하게 GET, POST 메서드를 지원합니다.
 
 <a id="modify-api-gateway-trigger"></a>
-
-### API Gateway 트리거 수정
+### API Gateway 트리거 수정 { #modify-api-gateway-trigger }
 
 ![trigger-guide-05](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-05.png)
 
@@ -269,20 +245,17 @@ curl -X POST "https://{stageurl}/{경로}" \
 > <br>플러그인이 적용된 리소스 경로를 변경하려면 수정 대신 새로운 트리거를 추가하는 것을 권장합니다.
 
 <a id="use-with-api-gateway"></a>
-
-### API Gateway와 함께 사용하기
+### API Gateway와 함께 사용하기 { #use-with-api-gateway }
 
 API Gateway 트리거를 생성하면 API Gateway 콘솔에서 추가 설정을 할 수 있습니다.
 
 자세한 내용은 [API Gateway 가이드](https://docs.nhncloud.com/ko/Application%20Service/API%20Gateway/ko/overview/)를 참고하세요.
 
 <a id="delete-trigger"></a>
-
-## 트리거 삭제
+## 트리거 삭제 { #delete-trigger }
 
 <a id="how-to-delete-trigger"></a>
-
-### 트리거 삭제 방법
+### 트리거 삭제 방법 { #how-to-delete-trigger }
 
 ![trigger-guide-03](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-03.png)
 
@@ -293,20 +266,17 @@ API Gateway 트리거를 생성하면 API Gateway 콘솔에서 추가 설정을 
 5. **트리거 삭제** 모달 창에서 **삭제**를 클릭합니다.
 
 <a id="cautions"></a>
-
-### 주의사항
+### 주의사항 { #cautions }
 
 - HTTP 트리거는 삭제할 수 없습니다. HTTP 트리거는 기본 트리거로 제공되며, 활성화/비활성화만 가능합니다.
 - 트리거를 삭제하면 해당 이벤트를 통해 함수를 실행할 수 없습니다.
 - 삭제된 트리거는 복구할 수 없습니다.
 
 <a id="restrictions"></a>
-
-## 트리거 제한사항
+## 트리거 제한사항 { #restrictions }
 
 <a id="restrictions-for-api-gateway-trigger"></a>
-
-### API Gateway 트리거 제한사항
+### API Gateway 트리거 제한사항 { #restrictions-for-api-gateway-trigger }
 
 - 동일 프로젝트 내의 API Gateway만 연결할 수 있습니다.
 - 하나의 API Gateway Resource는 하나의 함수만 연결할 수 있습니다.


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `alpha` |
| Scope | 11 doc(s) scanned · 33 file(s) changed |
| Self-verify | ✅ all aligned |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/main/52/ |
| Generated | 2026-07-08T08:09:10 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`alpha`): [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FCloud-Functions%2Ftree%2Falpha&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FCloud-Functions%2Fpull%2F59&source=ko&langs=en%2Cja)

## Link check

이 PR 의 링크 상태: [Link Check ↗](http://content-agent.cloud.toastoven.net:7700/link-check?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FCloud-Functions%2Fpull%2F59&ref=alpha&langs=en%2Cja)

<!-- LINK_CHECK_SUMMARY -->

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ko/api-guide-v1-0.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/api-guide-v1-0.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/api-guide-v1-0.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-dotnet-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-dotnet-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-dotnet-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-go-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-go-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-go-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-java-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-java-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-java-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-node-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-node-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-node-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-python-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-python-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-python-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-ruby-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-ruby-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-ruby-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/trigger-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/trigger-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/trigger-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Cloud-Functions`