### PR TITLE
chore(pre-align): align heading structure (11 docs) with ko

### DIFF
--- a/en/api-guide-v1-0.md
+++ b/en/api-guide-v1-0.md
@@ -1,10 +1,15 @@
-## Cloud Functions API v1.0 Guide
+<!-- pre-align:aligned sig=fb47c311eeaa -->
+
+<a id="cloud-functions-api-v10-guide"></a>
+## Cloud Functions API v1.0 Guide { #cloud-functions-api-v10-guide }
 
 **Compute > Cloud Functions > API Guide > API v1.0 Guide**
 
-## Cloud Functions API v1.0 Common Information
+<a id="cloud-functions-api-v10-common-information"></a>
+## Cloud Functions API v1.0 Common Information { #cloud-functions-api-v10-common-information }
 
-### API Endpoint
+<a id="api-endpoint"></a>
+### API Endpoint { #api-endpoint }
 
 The endpoints by region for calling the Cloud Functions API are as follows:
 
@@ -12,13 +17,15 @@ The endpoints by region for calling the Cloud Functions API are as follows:
 | --- |-----------------------------------------------------|
 | Korea (Pangyo) Region | https://kr1-cloud-functions.api.nhncloudservice.com |
 
-### Authentication and Authorization
+<a id="authentication-and-authorization"></a>
+### Authentication and Authorization { #authentication-and-authorization }
 
 Cloud Functions uses User Access Key tokens for authentication and authorization when making API calls.
 The User Access Key token is a temporary, Bearer-type access token issued from a User Access Key.
 For more information on issuing and using User Access Key tokens, refer to the [User Access Key Token](/nhncloud/en/public-api/user-access-key-token).
 
-### Response Common Information
+<a id="response-common-information"></a>
+### Response Common Information { #response-common-information }
 
 Every API response follows the common format as below:
 
@@ -64,7 +71,8 @@ Every API response follows the common format as below:
 | header.resultMessage | String | Result message |
 | data | Object | Response data (varies by API) |
 
-### Runtime EOL Status Common Fields
+<a id="runtime-eol-status-common-fields"></a>
+### Runtime EOL Status Common Fields { #runtime-eol-status-common-fields }
 
 The response for function and environment list retrieval includes EOL (end of life) status information for the runtime.
 
@@ -79,28 +87,33 @@ The response for function and environment list retrieval includes EOL (end of li
 
 ---
 
-## List Environments
+<a id="list-environments"></a>
+## List Environments { #list-environments }
 
 Retrieves a list of available runtime environments.
 
-### Request
+<a id="request"></a>
+### Request { #request }
 
 ```
 GET /v1.0/env/list
 ```
 
-### Request Parameter
+<a id="request-parameter"></a>
+### Request Parameter { #request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 
-### Request Body
+<a id="request-body"></a>
+### Request Body { #request-body }
 
 This API does not require a request body.
 
-### Response
+<a id="response"></a>
+### Response { #response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -150,17 +163,20 @@ This API does not require a request body.
 
 ---
 
-## List Functions
+<a id="list-functions"></a>
+## List Functions { #list-functions }
 
 Retrieves a list of functions.
 
-### Request
+<a id="list-functions-request"></a>
+### Request { #list-functions-request }
 
 ```
 GET /v1.0/functions
 ```
 
-### Request Parameter
+<a id="list-functions-request-parameter"></a>
+### Request Parameter { #list-functions-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -169,11 +185,13 @@ GET /v1.0/functions
 | page | Query | Integer | N | Current page (default: 0) |
 | pageSize | Query | Integer | N | Number of items to display per page (default: 5,000) |
 
-### Request Body
+<a id="list-functions-request-body"></a>
+### Request Body { #list-functions-request-body }
 
 This API does not require a request body.
 
-### Response
+<a id="list-functions-response"></a>
+### Response { #list-functions-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -228,17 +246,20 @@ This API does not require a request body.
 
 ---
 
-## Get Function
+<a id="get-function"></a>
+## Get Function { #get-function }
 
 Retrieves detailed information and build logs for a function.
 
-### Request
+<a id="get-function-request"></a>
+### Request { #get-function-request }
 
 ```
 GET /v1.0/functions/{functionName}
 ```
 
-### Request Parameter
+<a id="get-function-request-parameter"></a>
+### Request Parameter { #get-function-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -246,11 +267,13 @@ GET /v1.0/functions/{functionName}
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name |
 
-### Request Body
+<a id="get-function-request-body"></a>
+### Request Body { #get-function-request-body }
 
 This API does not require a request body.
 
-### Response
+<a id="get-function-response"></a>
+### Response { #get-function-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -319,7 +342,8 @@ This API does not require a request body.
 
 ---
 
-## Create Function
+<a id="create-function"></a>
+## Create Function { #create-function }
 
 Creates a new function. Upload the source file as multipart/form-data.
 The runtime must be entered in the `{environment}-{version}` format (e.g., NodeJS-22.5.0). Available runtimes can be checked using the List Environments API.
@@ -328,20 +352,23 @@ Required parameters vary depending on the executorType. When using poolManager, 
 
 Environment variables are passed as a JSON string in the `envVars` field. Up to 100 variables are allowed per function, keys must match `^[A-Za-z_][A-Za-z0-9_]*$` (maximum 128 characters, no duplicates), values can be up to 4,096 characters, and reserved keys cannot be registered for security reasons. An invalid JSON will return a failure response.
 
-### Request
+<a id="create-function-request"></a>
+### Request { #create-function-request }
 
 ```
 POST /v1.0/functions
 ```
 
-### Request Parameter
+<a id="create-function-request-parameter"></a>
+### Request Parameter { #create-function-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 
-### Request Body
+<a id="create-function-request-body"></a>
+### Request Body { #create-function-request-body }
 
 Content-Type: multipart/form-data
 
@@ -361,7 +388,8 @@ Content-Type: multipart/form-data
 | envVars | String | N          | Environment variables (JSON string, e.g., `{"DB_HOST":"10.0.0.1"}`). If not specified, no environment variables are set. An invalid JSON will return a failure response. |
 | sourceFile | Binary | Y | Source code file (ZIP) |
 
-### Response
+<a id="create-function-response"></a>
+### Response { #create-function-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -381,7 +409,8 @@ Content-Type: multipart/form-data
 
 ---
 
-## Modify Function
+<a id="modify-function"></a>
+## Modify Function { #modify-function }
 
 Modifies a function. The source file can be uploaded as multipart/form-data.
 
@@ -391,13 +420,15 @@ Environment variables are passed as a JSON string in the `envVars` field. If not
 
 Functions using a discontinued (`DISCONTINUED`) runtime cannot be modified. When requested, a failure response is returned with `header.isSuccessful` set to `false`, along with the message "Functions cannot be modified using a discontinued runtime. Please create a new function with the latest runtime."
 
-### Request
+<a id="modify-function-request"></a>
+### Request { #modify-function-request }
 
 ```
 PUT /v1.0/functions/{functionName}
 ```
 
-### Request Parameter
+<a id="modify-function-request-parameter"></a>
+### Request Parameter { #modify-function-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -405,7 +436,8 @@ PUT /v1.0/functions/{functionName}
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Name of the function to modify |
 
-### Request Body
+<a id="modify-function-request-body"></a>
+### Request Body { #modify-function-request-body }
 
 Content-Type: multipart/form-data
 
@@ -424,7 +456,8 @@ Content-Type: multipart/form-data
 | envVars | String | N          | Environment variables (JSON string). If not specified, the existing environment variables are retained. If set to `"{}"`, all environment variables are deleted. If a value is provided, all environment variables are replaced. An invalid JSON will return a failure response. |
 | sourceFile | Binary | N | Source code file (ZIP) |
 
-### Response
+<a id="modify-function-response"></a>
+### Response { #modify-function-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -444,24 +477,28 @@ Content-Type: multipart/form-data
 
 ---
 
-## Delete Functions
+<a id="delete-functions"></a>
+## Delete Functions { #delete-functions }
 
 Deletes functions in bulk.
 
-### Request
+<a id="delete-functions-request"></a>
+### Request { #delete-functions-request }
 
 ```
 DELETE /v1.0/functions
 ```
 
-### Request Parameter
+<a id="delete-functions-request-parameter"></a>
+### Request Parameter { #delete-functions-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 
-### Request Body
+<a id="delete-functions-request-body"></a>
+### Request Body { #delete-functions-request-body }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -478,7 +515,8 @@ DELETE /v1.0/functions
 | --- | --- | --- | --- |
 | names | Array | Y | Function name list to delete |
 
-### Response
+<a id="delete-functions-response"></a>
+### Response { #delete-functions-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -498,17 +536,20 @@ DELETE /v1.0/functions
 
 ---
 
-## Execute Function (GET)
+<a id="execute-function-get"></a>
+## Execute Function (GET) { #execute-function-get }
 
 Executes a function using the GET method.
 
-### Request
+<a id="execute-function-get-request"></a>
+### Request { #execute-function-get-request }
 
 ```
 GET /v1.0/functions/{functionName}/invoke
 ```
 
-### Request Parameter
+<a id="execute-function-get-request-parameter"></a>
+### Request Parameter { #execute-function-get-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -516,11 +557,13 @@ GET /v1.0/functions/{functionName}/invoke
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name to execute |
 
-### Request Body
+<a id="execute-function-get-request-body"></a>
+### Request Body { #execute-function-get-request-body }
 
 This API does not require a request body.
 
-### Response
+<a id="execute-function-get-response"></a>
+### Response { #execute-function-get-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -544,17 +587,20 @@ This API does not require a request body.
 
 ---
 
-## Execute Function (POST)
+<a id="execute-function-post"></a>
+## Execute Function (POST) { #execute-function-post }
 
 Executes a function using the POST method. A request body can be included.
 
-### Request
+<a id="execute-function-post-request"></a>
+### Request { #execute-function-post-request }
 
 ```
 POST /v1.0/functions/{functionName}/invoke
 ```
 
-### Request Parameter
+<a id="execute-function-post-request-parameter"></a>
+### Request Parameter { #execute-function-post-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -562,7 +608,8 @@ POST /v1.0/functions/{functionName}/invoke
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name to execute |
 
-### Request Body
+<a id="execute-function-post-request-body"></a>
+### Request Body { #execute-function-post-request-body }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -579,7 +626,8 @@ POST /v1.0/functions/{functionName}/invoke
 | --- |------| --- | --- |
 | body | JSON | N | Body to send to the function |
 
-### Response
+<a id="execute-function-post-response"></a>
+### Response { #execute-function-post-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -603,17 +651,20 @@ POST /v1.0/functions/{functionName}/invoke
 
 ---
 
-## List Versions
+<a id="list-versions"></a>
+## List Versions { #list-versions }
 
 Retrieves a list of versions (packages) for a function.
 
-### Request
+<a id="list-versions-request"></a>
+### Request { #list-versions-request }
 
 ```
 GET /v1.0/functions/{functionName}/versions
 ```
 
-### Request Parameter
+<a id="list-versions-request-parameter"></a>
+### Request Parameter { #list-versions-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -621,11 +672,13 @@ GET /v1.0/functions/{functionName}/versions
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name |
 
-### Request Body
+<a id="list-versions-request-body"></a>
+### Request Body { #list-versions-request-body }
 
 This API does not require a request body.
 
-### Response
+<a id="list-versions-response"></a>
+### Response { #list-versions-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -672,17 +725,20 @@ This API does not require a request body.
 
 ---
 
-## Switch Version
+<a id="switch-version"></a>
+## Switch Version { #switch-version }
 
 Changes the currently active version of a function.
 
-### Request
+<a id="switch-version-request"></a>
+### Request { #switch-version-request }
 
 ```
 PUT /v1.0/functions/{functionName}/versions
 ```
 
-### Request Parameter
+<a id="switch-version-request-parameter"></a>
+### Request Parameter { #switch-version-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -690,7 +746,8 @@ PUT /v1.0/functions/{functionName}/versions
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name |
 
-### Request Body
+<a id="switch-version-request-body"></a>
+### Request Body { #switch-version-request-body }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -707,7 +764,8 @@ PUT /v1.0/functions/{functionName}/versions
 | --- | --- | --- | --- |
 | versionId | Integer | Y | Version ID to convert |
 
-### Response
+<a id="switch-version-response"></a>
+### Response { #switch-version-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -727,19 +785,22 @@ PUT /v1.0/functions/{functionName}/versions
 
 ---
 
-## Delete Versions
+<a id="delete-versions"></a>
+## Delete Versions { #delete-versions }
 
 Deletes versions of a function in bulk.
 
 The currently active version cannot be deleted.
 
-### Request
+<a id="delete-versions-request"></a>
+### Request { #delete-versions-request }
 
 ```
 DELETE /v1.0/functions/{functionName}/versions
 ```
 
-### Request Parameter
+<a id="delete-versions-request-parameter"></a>
+### Request Parameter { #delete-versions-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -747,7 +808,8 @@ DELETE /v1.0/functions/{functionName}/versions
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name |
 
-### Request Body
+<a id="delete-versions-request-body"></a>
+### Request Body { #delete-versions-request-body }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -764,7 +826,8 @@ DELETE /v1.0/functions/{functionName}/versions
 | --- | --- | --- | --- |
 | versionIds | Array | Y | Version ID list to delete |
 
-### Response
+<a id="delete-versions-response"></a>
+### Response { #delete-versions-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -784,17 +847,20 @@ DELETE /v1.0/functions/{functionName}/versions
 
 ---
 
-## List Triggers
+<a id="list-triggers"></a>
+## List Triggers { #list-triggers }
 
 Retrieves a list of triggers for a function.
 
-### Request
+<a id="list-triggers-request"></a>
+### Request { #list-triggers-request }
 
 ```
 GET /v1.0/triggers/{functionName}
 ```
 
-### Request Parameter
+<a id="list-triggers-request-parameter"></a>
+### Request Parameter { #list-triggers-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -802,11 +868,13 @@ GET /v1.0/triggers/{functionName}
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name |
 
-### Request Body
+<a id="list-triggers-request-body"></a>
+### Request Body { #list-triggers-request-body }
 
 This API does not require a request body.
 
-### Response
+<a id="list-triggers-response"></a>
+### Response { #list-triggers-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -847,17 +915,20 @@ This API does not require a request body.
 
 ---
 
-## Create Time Trigger
+<a id="create-time-trigger"></a>
+## Create Time Trigger { #create-time-trigger }
 
 Creates a time trigger for a function.
 
-### Request
+<a id="create-time-trigger-request"></a>
+### Request { #create-time-trigger-request }
 
 ```
 POST /v1.0/triggers/{functionName}/time
 ```
 
-### Request Parameter
+<a id="create-time-trigger-request-parameter"></a>
+### Request Parameter { #create-time-trigger-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -865,7 +936,8 @@ POST /v1.0/triggers/{functionName}/time
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name |
 
-### Request Body
+<a id="create-time-trigger-request-body"></a>
+### Request Body { #create-time-trigger-request-body }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -882,7 +954,8 @@ POST /v1.0/triggers/{functionName}/time
 | --- | --- | --- | --- |
 | cron | String | Y | cron expression |
 
-### Response
+<a id="create-time-trigger-response"></a>
+### Response { #create-time-trigger-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -902,17 +975,20 @@ POST /v1.0/triggers/{functionName}/time
 
 ---
 
-## Modify Time Trigger
+<a id="modify-time-trigger"></a>
+## Modify Time Trigger { #modify-time-trigger }
 
 Modifies the cron expression of a time trigger.
 
-### Request
+<a id="modify-time-trigger-request"></a>
+### Request { #modify-time-trigger-request }
 
 ```
 PUT /v1.0/triggers/{functionName}/time
 ```
 
-### Request Parameter
+<a id="modify-time-trigger-request-parameter"></a>
+### Request Parameter { #modify-time-trigger-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -920,7 +996,8 @@ PUT /v1.0/triggers/{functionName}/time
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name |
 
-### Request Body
+<a id="modify-time-trigger-request-body"></a>
+### Request Body { #modify-time-trigger-request-body }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -939,7 +1016,8 @@ PUT /v1.0/triggers/{functionName}/time
 | name | String | Y | Trigger name |
 | cron | String | Y | cron expression |
 
-### Response
+<a id="modify-time-trigger-response"></a>
+### Response { #modify-time-trigger-response }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -959,17 +1037,20 @@ PUT /v1.0/triggers/{functionName}/time
 
 ---
 
-## Delete Time Triggers
+<a id="delete-time-triggers"></a>
+## Delete Time Triggers { #delete-time-triggers }
 
 Deletes time triggers in bulk.
 
-### Request
+<a id="delete-time-triggers-request"></a>
+### Request { #delete-time-triggers-request }
 
 ```
 DELETE /v1.0/triggers/{functionName}/time
 ```
 
-### Request Parameter
+<a id="delete-time-triggers-request-parameter"></a>
+### Request Parameter { #delete-time-triggers-request-parameter }
 
 | Name | Category | Type | Required | Description |
 | --- | --- | --- | --- | --- |
@@ -977,7 +1058,8 @@ DELETE /v1.0/triggers/{functionName}/time
 | X-NHN-authorization | Header | String | Y | User token (Bearer {token}) |
 | functionName | URL | String | Y | Function name |
 
-### Request Body
+<a id="delete-time-triggers-request-body"></a>
+### Request Body { #delete-time-triggers-request-body }
 
 <details>
   <summary><strong>Example code</strong></summary>
@@ -994,7 +1076,8 @@ DELETE /v1.0/triggers/{functionName}/time
 | --- | --- | --- | --- |
 | names | Array | Y | List of trigger names to delete |
 
-### Response
+<a id="delete-time-triggers-response"></a>
+### Response { #delete-time-triggers-response }
 
 <details>
   <summary><strong>Example code</strong></summary>

--- a/en/code-template-dotnet-guide.md
+++ b/en/code-template-dotnet-guide.md
@@ -1,17 +1,23 @@
-## Compute > Cloud Functions > Code Template Guide > .NET
+<!-- pre-align:aligned sig=12935a7ff892 -->
+
+<a id="compute-cloud-functions-code-template-guide-net"></a>
+## Compute > Cloud Functions > Code Template Guide > .NET { #compute-cloud-functions-code-template-guide-net }
 
 This document details how to develop functions by using .NET from NHN Cloud's Cloud Functions service.
 
-## Template information
+<a id="template-information"></a>
+## Template information { #template-information }
 | Item              | Value                  |
 |-----------------|---------|
 | **Supported version**       | 8       |
 | **File name**         | func.cs |
 | **Entry point** | func             |
 
-## Basic template
+<a id="basic-template"></a>
+## Basic template { #basic-template }
 
-### Hello World example
+<a id="hello-world-example"></a>
+### Hello World example { #hello-world-example }
 A basic form of function. Use `NhnContext` of `Nhn.DotNetCore.Api` namespace to access the logger and request information.
 
 ```csharp
@@ -50,7 +56,8 @@ public class NhnFunction
 }
 ```
 
-### Context object
+<a id="context-object"></a>
+### Context object { #context-object }
 With the `NhnContext` object, you can access the logger, request, and response.
 
 ```csharp
@@ -95,14 +102,17 @@ public class NhnFunction
 }
 ```
 
-## Download and use template file
+<a id="download-and-use-template-file"></a>
+## Download and use template file { #download-and-use-template-file }
 
-### Template download
+<a id="template-download"></a>
+### Template download { #template-download }
 You can download the .NET template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [dotnet.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/dotnet/dotnet.zip)
 
-### Template file structure
+<a id="template-file-structure"></a>
+### Template file structure { #template-file-structure }
 The structure of the downloaded template file is as follows:
 
 ```
@@ -112,8 +122,10 @@ dotnet.zip
 └── nuget.txt     # Dependency management file
 ```
 
-### Local development process
+<a id="local-development-process"></a>
+### Local development process { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. Unzip
 ```bash
 # Unzip
@@ -123,6 +135,7 @@ unzip dotnet.zip -d my-function
 cd my-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. Modify function codes
 Modify `func.cs` file with the logic you want.
 
@@ -178,6 +191,7 @@ public class NhnFunction
 }
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file. You must compress it so that `func.cs` and `nuget.txt` are included at the top level.
 
@@ -185,13 +199,16 @@ Compress the modified source code into ZIP file. You must compress it so that `f
 zip my-function.zip func.cs nuget.txt
 ```
 
-### Upload from Cloud Functions console
+<a id="upload-from-cloud-functions-console"></a>
+### Upload from Cloud Functions console { #upload-from-cloud-functions-console }
 - When creating or modifying a function, select the **User Local Environment** method.
 - Click **Select File** to upload the `my-function.zip` file you created.
 
-## Process by HTTP method
+<a id="process-by-http-method"></a>
+## Process by HTTP method { #process-by-http-method }
 
-### Process GET request
+<a id="process-get-request"></a>
+### Process GET request { #process-get-request }
 ```csharp
 using System;
 using Nhn.DotNetCore.Api;
@@ -220,7 +237,8 @@ public class NhnFunction
 }
 ```
 
-### Process POST request
+<a id="process-post-request"></a>
+### Process POST request { #process-post-request }
 ```csharp
 using System;
 using System.IO;
@@ -272,7 +290,8 @@ public class NhnFunction
 }
 ```
 
-## Manage package (`nuget.txt`)
+<a id="manage-package-nugettxt"></a>
+## Manage package (`nuget.txt`) { #manage-package-nugettxt }
 
 Use the `nuget.txt` file to manage dependencies (NuGet packages). Write the required packages one per line.
 
@@ -281,7 +300,8 @@ Use the `nuget.txt` file to manage dependencies (NuGet packages). Write the requ
 Microsoft.Extensions.Configuration:8.0.0
 ```
 
-### Example of configuration management
+<a id="example-of-configuration-management"></a>
+### Example of configuration management { #example-of-configuration-management }
 ```csharp
 using System;
 using System.Collections.Generic;
@@ -362,7 +382,8 @@ public class NhnFunction
 }
 ```
 
-## Use Environment Variables
+<a id="use-environment-variables"></a>
+## Use Environment Variables { #use-environment-variables }
 Environment variables registered for a function can be accessed via `Environment.GetEnvironmentVariable`. Environment variables are registered during the code writing step of function creation and modification. For more information, see the console user guide.
 
 ```csharp
@@ -412,7 +433,8 @@ public class NhnFunction
     - `DOTNET_STARTUP_HOOKS`, `DOTNET_ADDITIONAL_DEPS`, `ASPNETCORE_HOSTINGSTARTUPASSEMBLIES`
     - Prefixes `CORECLR_`, `COMPLUS_`, `DOTNET_`, `ASPNETCORE_`
 
-## Configure Entry Point
+<a id="configure-entry-point"></a>
+## Configure Entry Point { #configure-entry-point }
 
 Entry Point is **file name**. (excluding extention)
 
@@ -421,6 +443,7 @@ Entry Point is **file name**. (excluding extention)
 
 **Important**: The class name must be `NhnFunction`, and the method acting as a function must have the signature `public string Execute(NhnContext context)`.
 
-### Caution
+<a id="caution"></a>
+### Caution { #caution }
 - **Package version**: You can specify the package version in `nuget.txt`. (example: `Newtonsoft.Json:9.0.1`)
 - **Type conflict**: Since type conflicts can occur when adding dependencies, we recommend using the .NET native library whenever possible or using a compatible version of the package.

--- a/en/code-template-go-guide.md
+++ b/en/code-template-go-guide.md
@@ -1,17 +1,23 @@
-## Compute > Cloud Functions > Code Template Guide > Go
+<!-- pre-align:aligned sig=03a04e4bdda0 -->
+
+<a id="compute-cloud-functions-code-template-guide-go"></a>
+## Compute > Cloud Functions > Code Template Guide > Go { #compute-cloud-functions-code-template-guide-go }
 
 This document details how to develop functions by using Go from NHN Cloud's Cloud Functions service.
 
-## Template information
+<a id="template-information"></a>
+## Template information { #template-information }
 | Item              | Value                                        |
 |-----------------|------------------------------------------|
 | **Supported version**       | 1.22, 1.23, 1.24, 1.25 |
 | **File name**    | functions.go                               |
 | **Entry Point** | Handler                                  |
 
-## Basic template
+<a id="basic-template"></a>
+## Basic template { #basic-template }
 
-### Hello World example
+<a id="hello-world-example"></a>
+### Hello World example { #hello-world-example }
 A basic form of function.
 
 ```go
@@ -38,7 +44,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
-### Context object
+<a id="context-object"></a>
+### Context object { #context-object }
 In Go functions, HTTP requests and responses are processed via `http.ResponseWriter` and `*http.Request`.
 
 ```go
@@ -74,14 +81,17 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
-## Download and use template file
+<a id="download-and-use-template-file"></a>
+## Download and use template file { #download-and-use-template-file }
 
-### Template download
+<a id="template-download"></a>
+### Template download { #template-download }
 You can download the Go template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [go.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/go/go.zip)
 
-### Template file structure
+<a id="template-file-structure"></a>
+### Template file structure { #template-file-structure }
 The structure of the downloaded template file is as follows:
 
 ```
@@ -90,6 +100,7 @@ go.zip
 └── go.mod          # Dependency management file
 ```
 
+<a id="template-file-structure-functionsgo"></a>
 #### functions.go
 Include basic fake data generation functions.
 ```go
@@ -116,6 +127,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+<a id="template-file-structure-gomod"></a>
 #### go.mod
 ```go
 module example.com/ncf
@@ -125,8 +137,10 @@ go 1.22
 require github.com/brianvoe/gofakeit/v6 v6.28.0
 ```
 
-### Local development process
+<a id="local-development-process"></a>
+### Local development process { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. Unzip
 ```bash
 # Unzip
@@ -136,6 +150,7 @@ unzip go.zip -d my-function
 cd my-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. Modify function codes
 Modify `functions.go` file with the logic you want.
 
@@ -185,6 +200,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file.
 
@@ -202,11 +218,14 @@ zip my-function.zip functions.go go.mod
 zip -r my-function.zip . -x "*.git*" "go.sum" "test.go"
 ```
 
-### Upload from Cloud Functions console
+<a id="upload-from-cloud-functions-console"></a>
+### Upload from Cloud Functions console { #upload-from-cloud-functions-console }
 > Used when uploading files from the user's local environment when creating or modifying a function. (refer to Console Guide)
 
-### Cautions for upload
+<a id="cautions-for-upload"></a>
+### Cautions for upload { #cautions-for-upload }
 
+<a id="cautions-for-upload-zip-file-structure"></a>
 #### ZIP file structure
 - The `.go` file and `go.mod` must be located directly in the root of the ZIP file.
 - We recommend avoiding unnecessary folder structures.
@@ -227,10 +246,12 @@ my-function.zip
     └── go.mod
 ```
 
+<a id="cautions-for-upload-file-size-limit"></a>
 #### File size limit
 - ZIP file size is limited to 100MiB.
 - `go.sum` file should not be included.
 
+<a id="cautions-for-upload-files-to-exclude"></a>
 #### Files to exclude
 ```bash
 # Similar to .gitignore, exclude the following files:
@@ -243,9 +264,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
-## Process by HTTP method
+<a id="process-by-http-method"></a>
+## Process by HTTP method { #process-by-http-method }
 
-### Process GET request
+<a id="process-get-request"></a>
+### Process GET request { #process-get-request }
 ```go
 package main
 
@@ -283,7 +306,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
-### Process POST request
+<a id="process-post-request"></a>
+### Process POST request { #process-post-request }
 ```go
 package main
 
@@ -354,9 +378,11 @@ func getOrDefault(value, defaultValue string) string {
 }
 ```
 
-## Manage packages
+<a id="manage-packages"></a>
+## Manage packages { #manage-packages }
 
-### Write go.mod
+<a id="write-gomod"></a>
+### Write go.mod { #write-gomod }
 Write `go.mod` to manage dependencies.
 
 ```go
@@ -370,7 +396,8 @@ require (
 )
 ```
 
-### Example of external API call
+<a id="example-of-external-api-call"></a>
+### Example of external API call { #example-of-external-api-call }
 ```go
 package main
 
@@ -423,7 +450,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
-### Data processing example
+<a id="data-processing-example"></a>
+### Data processing example { #data-processing-example }
 ```go
 package main
 
@@ -516,7 +544,8 @@ func normalizeName(name string) string {
 }
 ```
 
-## Use Environment Variables
+<a id="use-environment-variables"></a>
+## Use Environment Variables { #use-environment-variables }
 Environment variables registered for a function can be accessed via `os.Getenv`. Environment variables are registered during the code writing step of function creation and modification. For more information, see the console user guide.
 
 ```go
@@ -565,15 +594,18 @@ func Handler(w http.ResponseWriter, r *http.Request) {
     - `GODEBUG`
     - Go has no prefix restrictions to avoid conflicts with general user variables.
 
-## Configure Entry Point
+<a id="configure-entry-point"></a>
+## Configure Entry Point { #configure-entry-point }
 
-### Single function
+<a id="single-function"></a>
+### Single function { #single-function }
 Use the function name as the Entry Point.
 
 Function name: `Handler`
 Entry Point: `Handler`
 
-### Multiple functions
+<a id="multiple-functions"></a>
+### Multiple functions { #multiple-functions }
 You can define multiple functions in a single file.
 
 ```go
@@ -613,9 +645,11 @@ Entry Point configuration:
 - `CreateUser`
 - `UpdateUser`
 
-## Caution
+<a id="caution"></a>
+## Caution { #caution }
 
-### Go version
+<a id="go-version"></a>
+### Go version { #go-version }
 | Version | End of Support | End of Service |
 |-----|-----------|-----------|
 | 1.25 | - | - |
@@ -623,6 +657,7 @@ Entry Point configuration:
 | 1.23 | 2026-02-21 | 2026-08-21 |
 | 1.22 | 2026-01-28 | 2026-07-28 |
 
+<a id="go-version-support-policy"></a>
 #### Go Version Support Policy
 Cloud Functions follows Go's official release policy. Go releases new major versions twice a year (January and July), and each version is supported only up to the latest two major versions.
 

--- a/en/code-template-java-guide.md
+++ b/en/code-template-java-guide.md
@@ -1,17 +1,23 @@
-## Compute > Cloud Functions > Code Template Guide > Java
+<!-- pre-align:aligned sig=fe65e841fbc2 -->
+
+<a id="compute-cloud-functions-code-template-guide-java"></a>
+## Compute > Cloud Functions > Code Template Guide > Java { #compute-cloud-functions-code-template-guide-java }
 
 This document details how to develop functions by using Java from NHN Cloud's Cloud Functions service.
 
-## Template information
+<a id="template-information"></a>
+## Template information { #template-information }
 | Item               | Value                  |
 |-----------------|---------------------|
 | **Supported version**       | 17, 21             |
 | **File name**          | HelloWorld.java    |
 | **Entry Point** | example.HelloWorld |
 
-## Basic template
+<a id="basic-template"></a>
+## Basic template { #basic-template }
 
-### Hello World example
+<a id="hello-world-example"></a>
+### Hello World example { #hello-world-example }
 A basic form of function.
 
 ```java
@@ -29,7 +35,8 @@ public class HelloWorld {
 }
 ```
 
-### Context object (RequestEntity)
+<a id="context-object-requestentity"></a>
+### Context object (RequestEntity) { #context-object-requestentity }
 In a Java function, you can access HTTP request information through `RequestEntity`.
 
 ```java
@@ -62,14 +69,17 @@ public class HelloWorld {
 }
 ```
 
-## Download and use template file
+<a id="download-and-use-template-file"></a>
+## Download and use template file { #download-and-use-template-file }
 
-### Template download
+<a id="template-download"></a>
+### Template download { #template-download }
 You can download the Java template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [java.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/java/java.zip)
 
-### Template file structure
+<a id="template-file-structure"></a>
+### Template file structure { #template-file-structure }
 The structure of the downloaded template file is as follows:
 
 ```
@@ -82,8 +92,10 @@ java.zip
                 └── HelloWorld.java
 ```
 
-### Local development process
+<a id="local-development-process"></a>
+### Local development process { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. Unzip
 ```bash
 # Unzip
@@ -93,6 +105,7 @@ unzip java.zip -d my-java-function
 cd my-java-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. Modify function codes
 Modify `src/main/java/example/HelloWorld.java` file with the logic you want.
 
@@ -144,6 +157,7 @@ public class HelloWorld {
 }
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file. You must compress it so that `pom.xml` and `src` are included at the top level.
 
@@ -161,19 +175,23 @@ zip -r my-function.zip pom.xml src
 zip -r my-function.zip . -x "*.git*" "target/*" "*.log"
 ```
 
-### Upload from Cloud Functions console
+<a id="upload-from-cloud-functions-console"></a>
+### Upload from Cloud Functions console { #upload-from-cloud-functions-console }
 - When creating or modifying a function, select the **User Local Environment** method.
 - Click **Select File** to upload the `my-function.zip` file you created.
 
-### Cautions for upload
+<a id="cautions-for-upload"></a>
+### Cautions for upload { #cautions-for-upload }
 - **Upload File**: Upload **ZIP file** which includes source code and `pom.xml`.
 - **ZIP File Structure**: The `pom.xml` and `src` directory must be located directly in the root of the ZIP file.
 - **File to Exclude**: Do not include unnecessary files such as the `target` directory, `.git` directory, etc.
 - **File Size**: ZIP file size is limited to 100 MiB.
 
-## Process by HTTP method
+<a id="process-by-http-method"></a>
+## Process by HTTP method { #process-by-http-method }
 
-### Process GET request
+<a id="process-get-request"></a>
+### Process GET request { #process-get-request }
 ```java
 package example;
 
@@ -209,7 +227,8 @@ public class GetHandler {
 }
 ```
 
-### Process POST request
+<a id="process-post-request"></a>
+### Process POST request { #process-post-request }
 ```java
 package example;
 
@@ -250,7 +269,8 @@ public class PostHandler {
 }
 ```
 
-## Manage package (`pom.xml`)
+<a id="manage-package-pomxml"></a>
+## Manage package (`pom.xml`) { #manage-package-pomxml }
 
 Use the `pom.xml` file to manage dependencies. When you add required libraries to the `dependencies` section, Cloud Functions automatically downloads the dependencies and includes them in the build when you upload your function.
 
@@ -273,7 +293,8 @@ Use the `pom.xml` file to manage dependencies. When you add required libraries t
 </dependencies>
 ```
 
-### Example of using external libraries
+<a id="example-of-using-external-libraries"></a>
+### Example of using external libraries { #example-of-using-external-libraries }
 ```java
 package example;
 
@@ -307,7 +328,8 @@ public class StringUtilsHandler {
 }
 ```
 
-## Use Environment Variables
+<a id="use-environment-variables"></a>
+## Use Environment Variables { #use-environment-variables }
 Environment variables registered for a function can be accessed via `System.getProperty`. Environment variables are registered during the code writing step of function creation and modification. For more information, see the console user guide.
 
 !!! tip "Note"
@@ -358,9 +380,11 @@ public class HelloWorld {
 
     - `JAVA_TOOL_OPTIONS`, `_JAVA_OPTIONS`, `JDK_JAVA_OPTIONS`, `CLASSPATH`
 
-## Entry Point configuration
+<a id="entry-point-configuration"></a>
+## Entry Point configuration { #entry-point-configuration }
 
-### Single class
+<a id="single-class"></a>
+### Single class { #single-class }
 Use `packagename.classname` as an Entry Point.
 
 - Package name: `example`
@@ -368,6 +392,7 @@ Use `packagename.classname` as an Entry Point.
 - Entry Point: `example.HelloWorld`
 - **Important**: Methods that act as functions must have the signature `public ResponseEntity<?> call(RequestEntity<?> req)`.
 
-### Caution
+<a id="caution"></a>
+### Caution { #caution }
 - **Project structure**: You must maintain the `src/main/java` directory structure.
 - **Memory and execution time**: Functions must operate within limited resources, so avoid heavy workloads and optimize the code.

--- a/en/code-template-node-guide.md
+++ b/en/code-template-node-guide.md
@@ -1,16 +1,22 @@
-## Compute > Cloud Functions > Code Template Guide > Node.js
+<!-- pre-align:aligned sig=9f2d38073162 -->
+
+<a id="compute-cloud-functions-code-template-guide-nodejs"></a>
+## Compute > Cloud Functions > Code Template Guide > Node.js { #compute-cloud-functions-code-template-guide-nodejs }
 
 This document details how to develop functions by using Node.js from NHN Cloud's Cloud Functions service.
 
-## Template information
+<a id="template-information"></a>
+## Template information { #template-information }
 | Item           | Value                  |
 |-----------------|-----------------|
 | **Supported version**       | 20.16.0, 22.5.0 |
 | **File name**         | hello.js        |
 | **Entry Point** | hello           |
 
-## Basic template
-### Hello World example
+<a id="basic-template"></a>
+## Basic template { #basic-template }
+<a id="hello-world-example"></a>
+### Hello World example { #hello-world-example }
 A basic form of function.
 
 ```javascript
@@ -22,7 +28,8 @@ module.exports = async (context) => {
 }
 ```
 
-### Context object
+<a id="context-object"></a>
+### Context object { #context-object }
 'context' object sent to functions include:
 
 ```javascript
@@ -42,14 +49,17 @@ module.exports = async (context) => {
 }
 ```
 
-## Download and use template file
+<a id="download-and-use-template-file"></a>
+## Download and use template file { #download-and-use-template-file }
 
-### Template download
+<a id="template-download"></a>
+### Template download { #template-download }
 You can download the Node.js template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [nodejs.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/nodejs/nodejs.zip)
 
-### Template file structure
+<a id="template-file-structure"></a>
+### Template file structure { #template-file-structure }
 The structure of the downloaded template file is as follows:
 
 ```
@@ -58,6 +68,7 @@ nodejs.zip
 └── package.json      # Dependency management file
 ```
 
+<a id="template-file-structure-hellojs"></a>
 #### hello.js
 Basic Hello World function is included.
 ```javascript
@@ -69,13 +80,16 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="template-file-structure-packagejson"></a>
 #### package.json
 ```json
 {}
 ```
 
-### Local development process
+<a id="local-development-process"></a>
+### Local development process { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. Unzip
 ```bash
 # Unzip
@@ -85,6 +99,7 @@ unzip nodejs.zip -d my-function
 cd my-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. Modify function codes
 Modify `hello.js` file with the logic you want.
 
@@ -127,6 +142,7 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file.
 
@@ -144,11 +160,14 @@ zip my-function.zip hello.js package.json
 zip -r my-function.zip . -x "*.git*" "node_modules/*" "test.js"
 ```
 
-### Upload from Cloud Functions console
+<a id="upload-from-cloud-functions-console"></a>
+### Upload from Cloud Functions console { #upload-from-cloud-functions-console }
 > Used when uploading files from the user's local environment when creating or modifying a function. (refer to Console Guide)
 
-### Cautions for upload
+<a id="cautions-for-upload"></a>
+### Cautions for upload { #cautions-for-upload }
 
+<a id="cautions-for-upload-zip-file-structure"></a>
 #### ZIP file structure
 - The `.js` file and `package.json` must be located directly in the root of the ZIP file.
 - We recommend avoiding unnecessary folder structures.
@@ -169,10 +188,12 @@ my-function.zip
     └── package.json
 ```
 
+<a id="cautions-for-upload-file-size-limit"></a>
 #### File size limit
 - ZIP file size is limited to 100MiB.
 - `node_modules` file should not be included. (for dependencies, manageed as `package.json`)
 
+<a id="cautions-for-upload-files-to-exclude"></a>
 #### Files to exclude
 ```bash
 # Similar to .gitignore, exclude the following files:
@@ -185,9 +206,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
-## Process by HTTP method
+<a id="process-by-http-method"></a>
+## Process by HTTP method { #process-by-http-method }
 
-### Process GET request
+<a id="process-get-request"></a>
+### Process GET request { #process-get-request }
 ```javascript
 module.exports = async (context) => {
     if (context.request.method !== 'GET') {
@@ -213,7 +236,8 @@ module.exports = async (context) => {
 }
 ```
 
-### Process POST request
+<a id="process-post-request"></a>
+### Process POST request { #process-post-request }
 ```javascript
 module.exports = async (context) => {
     if (context.request.method !== 'POST') {
@@ -258,9 +282,11 @@ module.exports = async (context) => {
 }
 ```
 
-## Manage packages
+<a id="manage-packages"></a>
+## Manage packages { #manage-packages }
 
-### Write package.json
+<a id="write-packagejson"></a>
+### Write package.json { #write-packagejson }
 Write `package.json` to manage dependencies.
 
 ```json
@@ -278,7 +304,8 @@ Write `package.json` to manage dependencies.
 }
 ```
 
-### Example of external API call
+<a id="example-of-external-api-call"></a>
+### Example of external API call { #example-of-external-api-call }
 ```javascript
 const axios = require('axios');
 
@@ -328,7 +355,8 @@ module.exports = async (context) => {
 }
 ```
 
-### Data processing example
+<a id="data-processing-example"></a>
+### Data processing example { #data-processing-example }
 ```javascript
 const _ = require('lodash');
 const moment = require('moment');
@@ -382,7 +410,8 @@ module.exports = async (context) => {
 }
 ```
 
-## Use Environment Variables
+<a id="use-environment-variables"></a>
+## Use Environment Variables { #use-environment-variables }
 Environment variables registered for a function can be accessed via `process.env`. Environment variables are registered during the code writing step of function creation and modification. For more information, see the console user guide.
 
 ```javascript
@@ -424,15 +453,18 @@ module.exports = async (context) => {
     - `NODE_PATH`, `NODE_OPTIONS`, `NODE_EXTRA_CA_CERTS`
     - Prefix `NODE_`
 
-## Configure Entry Point
+<a id="configure-entry-point"></a>
+## Configure Entry Point { #configure-entry-point }
 
-### Single function
+<a id="single-function"></a>
+### Single function { #single-function }
 Use the function name as the Entry Point.
 
 File name: `hello.js`
 Entry Point: `hello`
 
-### Multiple functions
+<a id="multiple-functions"></a>
+### Multiple functions { #multiple-functions }
 You can define multiple functions in a single file.
 
 ```javascript
@@ -467,7 +499,8 @@ Entry Point Configuration:
 - `users.createUser`
 - `users.updateUser`
 
-### Entry Point restriction
+<a id="entry-point-restriction"></a>
+### Entry Point restriction { #entry-point-restriction }
 - **Subdirectory specification unavailable**: Files in subdirectories of the root directory cannot be specified as Entry Points.
 
 **Right Entry Point:**
@@ -485,9 +518,11 @@ modules/auth.js → modules.auth ❌
 
 All function files must be located at the root level of the ZIP file.
 
-## Caution
+<a id="caution"></a>
+## Caution { #caution }
 
-### CommonJS vs ES Modules
+<a id="commonjs-vs-es-modules"></a>
+### CommonJS vs ES Modules { #commonjs-vs-es-modules }
 Cloud Functions currently only supports CommonJS method.
 
 **Available (CommonJS):**
@@ -506,7 +541,8 @@ export default async (context) => {  // ❌ Not supported
 };
 ```
 
-### Considerations for Memory and execution time
+<a id="considerations-for-memory-and-execution-time"></a>
+### Considerations for Memory and execution time { #considerations-for-memory-and-execution-time }
 - Functions must operate within limited memory and execution time.
 - Consider stream processing when handling large-scale data.
 - Split long-running tasks appropriately.

--- a/en/code-template-python-guide.md
+++ b/en/code-template-python-guide.md
@@ -1,17 +1,23 @@
-## Compute > Cloud Functions > Code Template Guide > Python
+<!-- pre-align:aligned sig=253528824169 -->
+
+<a id="compute-cloud-functions-code-template-guide-python"></a>
+## Compute > Cloud Functions > Code Template Guide > Python { #compute-cloud-functions-code-template-guide-python }
 
 This document details how to develop functions by using Python from NHN Cloud's Cloud Functions service.
 
-## Template information
+<a id="template-information"></a>
+## Template information { #template-information }
 | Item              | Value                  |
 |-----------------|------------------|
 | **Supported version**       | 3.11, 3.12, 3.13 |
 | **File name**         | user.py            |
 | **Entry Point** | user.main        |
 
-## Basic template
+<a id="basic-template"></a>
+## Basic template { #basic-template }
 
-### Hello World example
+<a id="hello-world-example"></a>
+### Hello World example { #hello-world-example }
 A basic form of function.
 
 ```python
@@ -29,7 +35,8 @@ def main():
     return yaml.dump(yaml.safe_load(document))
 ```
 
-### Context object
+<a id="context-object"></a>
+### Context object { #context-object }
 Python functions can access HTTP request information through Flask's request object.
 
 ```python
@@ -57,14 +64,17 @@ def main():
     }
 ```
 
-## Download and use template file
+<a id="download-and-use-template-file"></a>
+## Download and use template file { #download-and-use-template-file }
 
-### Template download
+<a id="template-download"></a>
+### Template download { #template-download }
 You can download the Python template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [python.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/python/python.zip)
 
-### Template file structure
+<a id="template-file-structure"></a>
+### Template file structure { #template-file-structure }
 The structure of the downloaded template file is as follows:
 
 ```
@@ -73,6 +83,7 @@ python.zip
 └── requirements.txt # Dependency management file
 ```
 
+<a id="template-file-structure-userpy"></a>
 #### user.py
 Include basic YAML processing functions.
 ```python
@@ -90,13 +101,16 @@ def main():
     return yaml.dump(yaml.safe_load(document))
 ```
 
+<a id="template-file-structure-requirementstxt"></a>
 #### requirements.txt
 ```txt
 pyyaml
 ```
 
-### Local development process
+<a id="local-development-process"></a>
+### Local development process { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. Unzip
 ```bash
 # Unzip
@@ -106,6 +120,7 @@ unzip python.zip -d my-function
 cd my-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. Modify function codes
 Modify `user.py` file with the logic you want.
 
@@ -147,6 +162,7 @@ def main():
         }, ensure_ascii=False)
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file.
 
@@ -164,11 +180,14 @@ zip my-function.zip user.py requirements.txt
 zip -r my-function.zip . -x "*.git*" "__pycache__/*" "*.pyc" "test.py"
 ```
 
-### Upload from Cloud Functions console
+<a id="upload-from-cloud-functions-console"></a>
+### Upload from Cloud Functions console { #upload-from-cloud-functions-console }
 > Used when uploading files from the user's local environment when creating or modifying a function. (refer to Console Guide)
 
-### Cautions for upload
+<a id="cautions-for-upload"></a>
+### Cautions for upload { #cautions-for-upload }
 
+<a id="cautions-for-upload-zip-file-structure"></a>
 #### ZIP file structure
 - The `.py` file and `requirements.txt` must be located directly in the root of the ZIP file.
 - We recommend avoiding unnecessary folder structures.
@@ -189,10 +208,12 @@ my-function.zip
     └── requirements.txt
 ```
 
+<a id="cautions-for-upload-file-size-limit"></a>
 #### File size limit
 - ZIP file size is limited to 100MiB.
 - `__pycache__` file should not be included.
 
+<a id="cautions-for-upload-files-to-exclude"></a>
 #### Files to exclude
 ```bash
 # Similar to .gitignore, exclude the following files:
@@ -206,9 +227,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
-## Process by HTTP method
+<a id="process-by-http-method"></a>
+## Process by HTTP method { #process-by-http-method }
 
-### Process GET request
+<a id="process-get-request"></a>
+### Process GET request { #process-get-request }
 ```python
 from flask import request
 import json
@@ -231,7 +254,8 @@ def main():
     return json.dumps(result, ensure_ascii=False)
 ```
 
-### Process POST request
+<a id="process-post-request"></a>
+### Process POST request { #process-post-request }
 ```python
 from flask import request
 import json
@@ -274,9 +298,11 @@ def main():
         }, ensure_ascii=False), 400
 ```
 
-## Manage packages
+<a id="manage-packages"></a>
+## Manage packages { #manage-packages }
 
-### Write requirements.txt
+<a id="write-requirementstxt"></a>
+### Write requirements.txt { #write-requirementstxt }
 Write `requirements.txt` to manage dependencies.
 
 ```txt
@@ -285,7 +311,8 @@ requests>=2.28.0
 python-dateutil>=2.8.0
 ```
 
-### Example of external API call
+<a id="example-of-external-api-call"></a>
+### Example of external API call { #example-of-external-api-call }
 ```python
 from flask import request
 import json
@@ -327,7 +354,8 @@ def main():
         }, ensure_ascii=False), 500
 ```
 
-### Data processing example
+<a id="data-processing-example"></a>
+### Data processing example { #data-processing-example }
 ```python
 from flask import request
 import json
@@ -381,7 +409,8 @@ def normalize_name(name):
     return name.strip().title()
 ```
 
-## Use Environment Variables
+<a id="use-environment-variables"></a>
+## Use Environment Variables { #use-environment-variables }
 Environment variables registered for a function can be accessed via `os.environ` (or `os.getenv`). Environment variables are registered during the code writing step of function creation and modification. For more information, see the console user guide.
 
 ```python
@@ -418,16 +447,19 @@ def main():
     - `PYTHONPATH`, `PYTHONSTARTUP`, `PYTHONHOME`, `PYTHONEXECUTABLE`
     - Prefix `PYTHON`
 
-## Configure Entry Point
+<a id="configure-entry-point"></a>
+## Configure Entry Point { #configure-entry-point }
 
-### Single function
+<a id="single-function"></a>
+### Single function { #single-function }
 Use `filename.functionname` as the Entry Point.
 
 File name: `user.py`
 Function name: `main`
 Entry Point: `user.main`
 
-### Multiple functions
+<a id="multiple-functions"></a>
+### Multiple functions { #multiple-functions }
 You can define multiple functions in a single file.
 
 ```python
@@ -453,9 +485,11 @@ Entry Point Configuration:
 - `handlers.create_user`
 - `handlers.update_user`
 
-## Caution
+<a id="caution"></a>
+## Caution { #caution }
 
-### Unsupported packages
+<a id="unsupported-packages"></a>
+### Unsupported packages { #unsupported-packages }
 Complex packages with the following features are not currently supported:
 
 **Examples of unsupported packages:**
@@ -469,7 +503,8 @@ Complex packages with the following features are not currently supported:
 - `python-dateutil` (date/time processing)
 - `pillow` (image processing - basic feature)
 
-### Considerations for Memory and execution time
+<a id="considerations-for-memory-and-execution-time"></a>
+### Considerations for Memory and execution time { #considerations-for-memory-and-execution-time }
 - Functions must operate within limited memory and execution time.
 - Consider generator and stream processing when handling large-scale data.
 - Split long-running tasks appropriately.

--- a/en/code-template-ruby-guide.md
+++ b/en/code-template-ruby-guide.md
@@ -1,17 +1,23 @@
-## Compute > Cloud Functions > Code Template Guide   > Ruby
+<!-- pre-align:aligned sig=015e63f62c78 -->
+
+<a id="compute-cloud-functions-code-template-guide-ruby"></a>
+## Compute > Cloud Functions > Code Template Guide   > Ruby { #compute-cloud-functions-code-template-guide-ruby }
 
 This document details how to develop functions by using Ruby from NHN Cloud's Cloud Functions service.
 
-## Template information
+<a id="template-information"></a>
+## Template information { #template-information }
 | Item         | Value        |
 |-----------------|----------|
 | **Supported version**      | 3.4.5    |
 | **File name**         | parse.rb |
 | **Entry Point** | handler |
 
-## Basic template
+<a id="basic-template"></a>
+## Basic template { #basic-template }
 
-### Hello World example
+<a id="hello-world-example"></a>
+### Hello World example { #hello-world-example }
 A basic form of function.
 
 ```ruby
@@ -30,7 +36,8 @@ def handler(context)
 end
 ```
 
-### Context object
+<a id="context-object"></a>
+### Context object { #context-object }
 You can access logger and request information through the `context` object passed to the function.
 
 ```ruby
@@ -64,14 +71,17 @@ def handler(context)
 end
 ```
 
-## Download and use template file
+<a id="download-and-use-template-file"></a>
+## Download and use template file { #download-and-use-template-file }
 
-### Template download
+<a id="template-download"></a>
+### Template download { #template-download }
 You can download the Ruby template provided by Cloud Functions to develop a local environment.
 
 **Template download link**: [ruby.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/ruby/ruby.zip)
 
-### Template file structure
+<a id="template-file-structure"></a>
+### Template file structure { #template-file-structure }
 The structure of the downloaded template file is as follows:
 
 ```
@@ -80,8 +90,10 @@ ruby.zip
 └── Gemfile
 ```
 
-### Local development process
+<a id="local-development-process"></a>
+### Local development process { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. Unzip
 ```bash
 # Unzip
@@ -91,6 +103,7 @@ unzip ruby.zip -d my-function
 cd my-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. Modify function codes
 Modify `parse.rb` file with the logic you want.
 
@@ -135,6 +148,7 @@ def handler(context)
 end
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. Compress into a ZIP file
 Compress the modified source code into ZIP file. You must compress it so that `parse.rb` and `Gemfile` are included at the top level.
 
@@ -143,19 +157,23 @@ zip my-function.zip parse.rb Gemfile Gemfile.lock
 ```
 **Note**: The `Gemfile.lock` file is automatically created during the deployment phase, but if you want to check or lock the exact versions of your dependencies in advance, you can create one yourself by running `bundle install` locally and then compress it together. If a `Gemfile.lock` file is included, the build will use the versions specified in it.
 
-### Upload from Cloud Functions console
+<a id="upload-from-cloud-functions-console"></a>
+### Upload from Cloud Functions console { #upload-from-cloud-functions-console }
 - When creating or modifying a function, select the **User Local Environment** method.
 - Click **Select File** to upload the `my-function.zip` file you created.
 
-### Cautions for upload
+<a id="cautions-for-upload"></a>
+### Cautions for upload { #cautions-for-upload }
 - **Upload File**: Upload **ZIP file** which includes `*.rb`, `Gemfile`.
   - `Gemfile.lock` file is optional. If included, it will be built with the version specified in the file, and if not present, it will be automatically created during the deployment phase.
 - **ZIP Files Structure**: Files must be located directly in the root of the ZIP file.
 - **File Size**: ZIP file size is limited to 100 MiB.
 
-## Process POST request
+<a id="process-post-request"></a>
+## Process POST request { #process-post-request }
 
-### Process GET request
+<a id="process-get-request"></a>
+### Process GET request { #process-get-request }
 ```ruby
 # frozen_string_literal: true
 
@@ -179,7 +197,8 @@ def handler(context)
 end
 ```
 
-### Process POST request
+<a id="process-post-request-2"></a>
+### Process POST request { #process-post-request-2 }
 ```ruby
 # frozen_string_literal: true
 
@@ -214,7 +233,8 @@ def handler(context)
 end
 ```
 
-## Manage package (`Gemfile`)
+<a id="manage-package-gemfile"></a>
+## Manage package (`Gemfile`) { #manage-package-gemfile }
 
 Use `Gemfile` to manage dependencies (gems). Add the required gems and run `bundle install` to generate `Gemfile.lock`.
 
@@ -228,7 +248,8 @@ gem "nokogiri", "~> 1.18" # XML/HTML parser
 gem "httparty", "~> 0.23" # HTTP client
 ```
 
-### Example of external API call
+<a id="example-of-external-api-call"></a>
+### Example of external API call { #example-of-external-api-call }
 ```ruby
 # frozen_string_literal: true
 
@@ -268,7 +289,8 @@ def handler(context)
 end
 ```
 
-## Use Environment Variables
+<a id="use-environment-variables"></a>
+## Use Environment Variables { #use-environment-variables }
 Environment variables registered for a function can be accessed via `ENV`. Environment variables are registered during the code writing step of function creation and modification. For more information, see the console user guide.
 
 ```ruby
@@ -309,7 +331,8 @@ end
     - `RUBYOPT`, `RUBYLIB`, `GEM_HOME`, `GEM_PATH`
     - Prefix `RUBY`
 
-## Configure Entry Point
+<a id="configure-entry-point"></a>
+## Configure Entry Point { #configure-entry-point }
 
 Entry Point uses the function name.
 
@@ -317,6 +340,7 @@ Entry Point uses the function name.
 - Function name: `handler`
 - Entry Point: `handler`
 
-### Caution
+<a id="caution"></a>
+### Caution { #caution }
 - **Bundler version**: We recommend using Bundler 2.6.2 or later when generating `Gemfile.lock`.
 - **Some Gem compatibility such as ActiveSupport**: Some gems that rely on C extensions, such as `ActiveSupport`, or have complex internal structures may have compatibility issues with the current Cloud Functions environment. The `activesupport` Gem internally depends on the `zeitwerk` Gem, and the way this Gem navigates the filesystem may conflict with the execution environment, causing it to malfunction. Therefore, we recommend using standard libraries or Gems with fewer external dependencies as much as possible.

--- a/en/console-guide.md
+++ b/en/console-guide.md
@@ -1,15 +1,21 @@
-## Compute > Cloud Functions > Console User Guide
+<!-- pre-align:aligned sig=1dc54302160b -->
+
+<a id="compute-cloud-functions-console-user-guide"></a>
+## Compute > Cloud Functions > Console User Guide { #compute-cloud-functions-console-user-guide }
 This document describes how to create and manage functions in Cloud Functions console.
 
-## Manage functions
+<a id="manage-functions"></a>
+## Manage functions { #manage-functions }
 You can create, edit, delete, and copy functions.
 
-### Create functions
+<a id="create-functions"></a>
+### Create functions { #create-functions }
 Configure the function, write your code, and build it. Then, click **Create** to deploy the function using the latest built package.
 
 ![console-guide-07](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-01.png)
 ![console-guide-08](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-02.png)
 
+<a id="create-functions-function-settings"></a>
 #### Function settings
 <table class="it">
     <tr>
@@ -87,6 +93,7 @@ Configure the function, write your code, and build it. Then, click **Create** to
 <br>
 
 
+<a id="create-functions-code-writing"></a>
 #### Code writing
 
 ![console-guide-16](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn-origin/prod_cloud_functions/2026-07-14/console-guide-en-16.png)
@@ -159,6 +166,7 @@ Configure the function, write your code, and build it. Then, click **Create** to
 > "This runtime was deprecated on April 30, 2026, and is scheduled to be discontinued on October 31, 2026. Modification of existing functions will not be possible after discontinuation, so the use of the latest runtime is recommended for stable operation."<br>
 > Discontinued runtimes are excluded from the list and cannot be selected when creating a new function. For more information on runtime status, see "Runtime Support Status" in the overview.
 
+<a id="create-functions-environment-variable"></a>
 #### Environment Variable
 Credentials required for integration with external services (API keys, DB connection information, etc.) can be managed separately as environment variables without hardcoding them in the code.
 
@@ -194,15 +202,19 @@ Credentials required for integration with external services (API keys, DB connec
 > - Language/runtime: `PYTHONPATH` (Python), `NODE_OPTIONS` (Node.js), `JAVA_TOOL_OPTIONS`·`CLASSPATH` (Java)<br>
 > - Keys starting with the prefixes `LD_`, `DYLD_`, `KUBERNETES_`, `FISSION_` are all blocked.
 
-### Modify functions
+<a id="modify-functions"></a>
+### Modify functions { #modify-functions }
 To modify the function settings and code of an existing function, click **Modify** button to modify the function.
+<a id="modify-functions-non-modifiable-item"></a>
 #### Non-modifiable item
 - Name, runtime environment
     - You can edit everything except the item.
+<a id="modify-functions-source-code"></a>
 #### Source code
 - If you're using the code editor, the existing code is loaded.
 - If you created a function by uploading a ZIP file from the local environment, when you switch to the code editor, it loads the default template code without showing the ZIP file.
 
+<a id="modify-functions-modify-function-restrictions-for-discontinued-runtimes"></a>
 #### Modify Function Restrictions for Discontinued Runtimes
 - Functions using a discontinued runtime cannot be modified.
 - When a single function using a discontinued runtime is selected in the function list, the **Modify** button is disabled and the function modification screen cannot be accessed.
@@ -210,30 +222,36 @@ To modify the function settings and code of an existing function, click **Modify
     - "Functions cannot be modified using a discontinued runtime. Please create a new function with the latest runtime."
 - Functions using a deprecated (pre-discontinuation) runtime can be modified, and a guidance callout is displayed in the same way as when creating a function.
 
-### Delete a function
+<a id="delete-a-function"></a>
+### Delete a function { #delete-a-function }
 ![console-guide-14](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-06.png)
 Select an existing function to delete it. You can delete multiple functions at once.
 
-### Copy a function
+<a id="copy-a-function"></a>
+### Copy a function { #copy-a-function }
 ![console-guide-13](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-07.png)
 Copy a function that is identical to an existing function. The name cannot be duplicated, so you can rewrite the name before copying.
 - Triggers are not copied. (HTTP triggers are provided by default).
 - Only the currently applied version will be copied.
 - Environment variables registered in the original function are copied as-is.
 
-## About functions
-### List of functions
+<a id="about-functions"></a>
+## About functions { #about-functions }
+<a id="list-of-functions"></a>
+### List of functions { #list-of-functions }
 ![console-guide-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-08.png)
 - You can see a list of functions that users have created.
 - Build status shows the build status of the current version.
 - A runtime support status badge (deprecated/discontinued) is displayed to the right of the runtime information.
 
-### Basic information of functions
+<a id="basic-information-of-functions"></a>
+### Basic information of functions { #basic-information-of-functions }
 ![console-guide-19](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn-origin/prod_cloud_functions/2026-07-14/console-guide-en-19.png)
 - You can see basic information about the function.
 - Click Log & Crash Search in the Log Management section to view your logs in the Log & Crash Search service.
 
-### Function Environment Variables
+<a id="function-environment-variables"></a>
+### Function Environment Variables { #function-environment-variables }
 You can check the list of environment variables registered for a function in the environment variable tab of the function details.
 
 ![console-guide-20](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn-origin/prod_cloud_functions/2026-07-14/console-guide-en-20.png)
@@ -258,17 +276,20 @@ You can check the list of environment variables registered for a function in the
 
 - Environment variables can be registered, modified, or deleted during the code writing step of function creation and modification. For more information, see Function Creation > Environment Variable.
 
-### Function versioning
+<a id="function-versioning"></a>
+### Function versioning { #function-versioning }
 ![console-guide-15](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2026-01-27/console-guide-en-15.png)
 - You can manage function versions.
 - You can view version history and rollback to any previous version.
 
+<a id="function-versioning-versioning-overview"></a>
 #### Versioning overview
 Build your code by clicking **Build** in the function creation or modification screen to generate a package.
 - When you create or update a function, the latest built package is integrated into the function version.
 - Each version is managed independently, allowing you to apply a tested version directly to your function.
 - At least one build is required to enable function creation.
 
+<a id="function-versioning-version-information"></a>
 #### Version information
 <table class="it">
     <tr>
@@ -298,6 +319,7 @@ Build your code by clicking **Build** in the function creation or modification s
     </tr>
 </table>
 
+<a id="function-versioning-deploy-versions"></a>
 #### Deploy versions
 - Select a version from the list and click **Deploy Version** to update the function to the version.
 - The currently applied version cannot be selected for deployment.
@@ -307,6 +329,7 @@ Build your code by clicking **Build** in the function creation or modification s
 > **[Note]**
 > <br>A confirmation popup will appear upon deployment. Once the deployment is successful, the version list will refresh automatically.
 
+<a id="function-versioning-delete-versions"></a>
 #### Delete versions
 - To delete a version, select it from the list and click **Delete Version**.
 - The currently applied version cannot be deleted.
@@ -316,13 +339,15 @@ Build your code by clicking **Build** in the function creation or modification s
 > **[Note]**
 > <br>A confirmation popup will appear when deleting a version. Please note that deleted versions cannot be recovered.
 
+<a id="function-versioning-constraints"></a>
 #### Constraints
 - Canceling function creation or modification will prevent the built package from being integrated into a function version.
 - Deleting a function will permanently remove all integrated versions.
 - When copying a function, only the currently active version is copied. The full version history will not be copied.
 - While multiple runtimes are available during function creation, you can only build using the initially selected runtime when modifying the function.
 
-### Manage function triggers
+<a id="manage-function-triggers"></a>
+### Manage function triggers { #manage-function-triggers }
 You can manage triggers that can perform functions.
 - HTTP triggers are built-in when creating a function.
     - You can set whether to use through the Enable/Disable features.
@@ -333,16 +358,19 @@ You can manage triggers that can perform functions.
     - Example: `https://{userdomain}/{function name}`
     - Method : GET, POST
 
+<a id="manage-function-triggers-createedit-triggers"></a>
 #### Create/edit triggers
 - Timer
     - Value: Enter the cycle as a Cron string.
     - API Gateway
     - You can add HTTP Endpoint by using the API Gateway service.
 
+<a id="manage-function-triggers-delete-triggers"></a>
 #### Delete triggers
 - You can select multiple triggers to delete. You can't delete the HTTP trigger, which is the default trigger.
 
-### Monitor functions
+<a id="monitor-functions"></a>
+### Monitor functions { #monitor-functions }
 ![console-guide-06](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-en-11.png)
 - You can check the usage of a function.
 - Provide metrics for the number of function calls, number of call rejections, number of errors, success rate, and function execution time.

--- a/en/overview.md
+++ b/en/overview.md
@@ -1,7 +1,11 @@
-## Compute > Cloud Functions > Overview
+<!-- pre-align:aligned sig=1cb57d0b02b5 -->
+
+<a id="compute-cloud-functions-overview"></a>
+## Compute > Cloud Functions > Overview { #compute-cloud-functions-overview }
 Users can write codes by function unit. Functions defined on a specific event are automatically executed, processing the required tasks. Without server management or infrastructure configuration, you can focus only on application logic.
 
-### Features
+<a id="features"></a>
+### Features { #features }
 - Cost-effectiveness
     - Save money with pay-as-you-go pricing.
     - You can reduce management cost as it allocates resources only when necessary.
@@ -13,15 +17,18 @@ Users can write codes by function unit. Functions defined on a specific event ar
     - Support for multiple languages and runtimes.
     - The event-based architecture is versatile.
 
-### Main Features
+<a id="main-features"></a>
+### Main Features { #main-features }
 - We offer multiple languages (environments).
 - The **code editor** makes you write simple function unit code.
 - Provide an HTTPS Endpoint as standard to perform the function.
 - Iterate the function at regular cycles.
 
-### Two Modes Available
+<a id="two-modes-available"></a>
+### Two Modes Available { #two-modes-available }
 - Pool Manager
 - New Deployment
+<a id="two-modes-available-pool-manager"></a>
 #### Pool Manager
 - Instances are created and use resources only when the function is performed.
 - If the function is not performed for a certain period, instances disappear, and the resource usage becomes 0.
@@ -29,6 +36,7 @@ Users can write codes by function unit. Functions defined on a specific event ar
 
 ![overview-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_1_en.png)
 
+<a id="two-modes-available-new-deployment"></a>
 #### New Deployment
 - Once functions are created, instances are created, keeping a certain amount of resources being used.
 - Instances are kept to reduce response latency.
@@ -36,7 +44,8 @@ Users can write codes by function unit. Functions defined on a specific event ar
 
 ![overview-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_2_en.png)
 
-### Supported Languages
+<a id="supported-languages"></a>
+### Supported Languages { #supported-languages }
 | Language     | Version                | End of Support   | End of Service   |
 |--------|-------------------|------------|------------|
 | NodeJS | 22.5.0            | 2027-04-30 | 2027-10-30 |
@@ -56,6 +65,7 @@ Users can write codes by function unit. Functions defined on a specific event ar
 | .NET   | 8                 | 2026-11-10 | 2027-11-10 |
 |        | 7 (end of service)         | 2024-05-14 | 2025-05-14 |
 
+<a id="supported-languages-runtime-support-status"></a>
 #### Runtime Support Status
 Each runtime is categorized into one of the following three statuses based on the EOL (end of life) policy.
 
@@ -70,7 +80,8 @@ Each runtime is categorized into one of the following three statuses based on th
 
 The status of a runtime can be checked in the function list, function details, and the function creation/modification screen. For details on behavior, see the console user guide.
 
-### Trigger
+<a id="trigger"></a>
+### Trigger { #trigger }
 - HTTP Trigger
     - Basic (support GET, POST)
 - Timer Trigger

--- a/en/release-notes.md
+++ b/en/release-notes.md
@@ -1,7 +1,12 @@
-## Compute > Cloud Functions > Release Notes
+<!-- pre-align:aligned sig=a0129d78150c -->
 
-### July 14, 2026
+<a id="compute-cloud-functions-release-notes"></a>
+## Compute > Cloud Functions > Release Notes { #compute-cloud-functions-release-notes }
 
+<a id="july-14-2026"></a>
+### July 14, 2026 { #july-14-2026 }
+
+<a id="july-14-2026-added-features"></a>
 #### Added Features
 - Added environment variable feature
   - Allows separation of code and configuration by setting environment variables for functions.
@@ -10,24 +15,31 @@
   - Displays the deprecated/discontinued status of runtimes in the function list and details.
   - Provides guidance on deprecated runtimes when creating or modifying functions, and restricts the selection and modification of discontinued runtimes.
 
-### April 14, 2026
+<a id="april-14-2026"></a>
+### April 14, 2026 { #april-14-2026 }
 
+<a id="april-14-2026-added-features"></a>
 #### Added Features
 - Added Public API v1.0
   - Added support for using Cloud Functions via API.
 
-### January 27, 2026
+<a id="january-27-2026"></a>
+### January 27, 2026 { #january-27-2026 }
 
+<a id="january-27-2026-added-features"></a>
 #### Added Features
 - Added function versioning
   - Manage build packages by version and rollback to previous versions.
 
-### November 25, 2025
+<a id="november-25-2025"></a>
+### November 25, 2025 { #november-25-2025 }
 
+<a id="november-25-2025-added-features"></a>
 #### Added Features
 - Added API Gateway trigger
   - Added the feature to create API Gateway triggers by utilizing the API Gateway service in the same project.
 
+<a id="november-25-2025-feature-updates"></a>
 #### Feature Updates
 - Added the latest runtime environment and deprecated some versions
   - Added Go 1.24, 1.25
@@ -36,7 +48,9 @@
   - Deprecated Ruby 2.6.1, added Ruby 3.4.5
   - Deprecated .NET 7, added .NET 8
 
-### July 29. 2025
+<a id="july-29-2025"></a>
+### July 29. 2025 { #july-29-2025 }
 
+<a id="july-29-2025-launch-cloud-functions-service"></a>
 #### Launch Cloud Functions Service
 - Users can write codes by function unit. Functions defined on a specific event are automatically executed, processing the required tasks. Without server management or infrastructure configuration, you can focus only on application logic.

--- a/en/trigger-guide.md
+++ b/en/trigger-guide.md
@@ -1,12 +1,17 @@
-## Compute > Cloud Functions > Trigger Guide
+<!-- pre-align:aligned sig=1dfb7cf11d02 -->
+
+<a id="compute-cloud-functions-trigger-guide"></a>
+## Compute > Cloud Functions > Trigger Guide { #compute-cloud-functions-trigger-guide }
 
 This document describes the trigger types available in Cloud Functions and how to set them up.
 
-## Trigger Overview
+<a id="trigger-overview"></a>
+## Trigger Overview { #trigger-overview }
 
 Trigger is an event source to execute functions. Cloud Functions provide various triggers to allow you to call functions in multiple ways.
 
-### Supported Triggers
+<a id="supported-triggers"></a>
+### Supported Triggers { #supported-triggers }
 
 | Types | Descriptions | Built-in |
 |-------------|------------------------|-------|
@@ -14,30 +19,36 @@ Trigger is an event source to execute functions. Cloud Functions provide various
 | Timer | Execute a function at a specified time or interval | No |
 | API Gateway | Execute a function via API Gateway | No |
 
-## HTTP Trigger
+<a id="http-trigger"></a>
+## HTTP Trigger { #http-trigger }
 
 HTTP trigger is built-in when creating a function, and you can execute the function with an HTTP request.
 
-### Features
+<a id="features"></a>
+### Features { #features }
 
 - When creating a function, it will be automatically created.
 - It cannot be deleted but only enabled or disabled.
 - GET, POST methods are supported.
 
-### URL Format of HTTP Trigger
+<a id="url-format-of-http-trigger"></a>
+### URL Format of HTTP Trigger { #url-format-of-http-trigger }
 
 ```
 https://{userdomain}/{function name}
 ```
 
-### Examples
+<a id="examples"></a>
+### Examples { #examples }
 
+<a id="examples-request-get"></a>
 #### Request GET
 
 ```bash
 curl -X GET "https://{userdomain}/{function name}?param1=value1&param2=value2"
 ```
 
+<a id="examples-request-post"></a>
 #### Request POST
 
 ```bash
@@ -46,7 +57,8 @@ curl -X POST "https://{userdomain}/{function name}" \
   -d '{"key": "value"}'
 ```
 
-### Enable/disable HTTP Trigger
+<a id="enabledisable-http-trigger"></a>
+### Enable/disable HTTP Trigger { #enabledisable-http-trigger }
 
 1. Select a function from the Cloud Functions console.
 2. Go to **Trigger** tab.
@@ -55,11 +67,13 @@ curl -X POST "https://{userdomain}/{function name}" \
 > **[Note]**
 > <br>If you send a request with a disabled HTTP trigger, the function will not execute.
 
-## Timer Trigger
+<a id="timer-trigger"></a>
+## Timer Trigger { #timer-trigger }
 
 Timer trigger executes a function automatically at the specified time or cycle. You can set up the cycle by using the Cron expression.
 
-### Create Timer Trigger
+<a id="create-timer-trigger"></a>
+### Create Timer Trigger { #create-timer-trigger }
 
 ![trigger-guide-05](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-01.png)
 
@@ -70,7 +84,8 @@ Timer trigger executes a function automatically at the specified time or cycle. 
 5. Enter Cron expression in **Value**.
 6. Click **Create**.
 
-### Cron Expression Format
+<a id="cron-expression-format"></a>
+### Cron Expression Format { #cron-expression-format }
 
 Cron expression follows the format as below:
 
@@ -85,6 +100,7 @@ Cron expression follows the format as below:
 └─────────── second (0-59)
 ```
 
+<a id="cron-expression-format-cron-expression-field"></a>
 #### Cron Expression Field
 
 | Field | Required | Allowed vale | Allowed special character |
@@ -96,6 +112,7 @@ Cron expression follows the format as below:
 | Month | Yes | 1-12 or JAN-DEC | * / , - |
 | Day of week | Yes | 0-6 or SUN-SAT | * / , - ? |
 
+<a id="cron-expression-format-special-characters-details"></a>
 #### Special Characters Details
 
 `*`
@@ -118,7 +135,8 @@ Used to define scope. For example, using `9-17` in the third field (hours) means
 
 You can use * instead of leaving the Day of month or Day of week field blank.
 
-### Example of Cron Expression
+<a id="example-of-cron-expression"></a>
+### Example of Cron Expression { #example-of-cron-expression }
 
 | Cron Expression | Description |
 |------------------------|---------------------------------|
@@ -132,7 +150,8 @@ You can use * instead of leaving the Day of month or Day of week field blank.
 | `30 0 12 * * *` | Execute every day at 12:00:30 PM |
 | `0 0 0 1 JAN *` | Execute every January 1st at midnight |
 
-### Modify Timer Trigger
+<a id="modify-timer-trigger"></a>
+### Modify Timer Trigger { #modify-timer-trigger }
 
 ![trigger-guide-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-02.png)
 
@@ -146,16 +165,19 @@ You can use * instead of leaving the Day of month or Day of week field blank.
 > **[Note]**
 > <br>The Month and Day of week field values ​​are case-insensitive. "SUN", "Sun", "sun" are all recognized equally.
 
-## API Gateway Trigger
+<a id="api-gateway-trigger"></a>
+## API Gateway Trigger { #api-gateway-trigger }
 
 API Gateway triggers can execute functions by leveraging the API Gateway service in the same project. API Gateway enables more detailed API management and control.
 
-### Prerequisites
+<a id="prerequisites"></a>
+### Prerequisites { #prerequisites }
 
 - The API Gateway service must be enabled in the same project.
   - If it isn't enabled, you can enable it when creating a trigger.
 
-### Create API Gateway Trigger
+<a id="create-api-gateway-trigger"></a>
+### Create API Gateway Trigger { #create-api-gateway-trigger }
 
 ![trigger-guide-04](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-04.png)
 
@@ -167,20 +189,24 @@ API Gateway triggers can execute functions by leveraging the API Gateway service
    * Duplicate path is unavailable.
 6. Click **Create**.
 
-### API Gateway Trigger URL Format
+<a id="api-gateway-trigger-url-format"></a>
+### API Gateway Trigger URL Format { #api-gateway-trigger-url-format }
 
 ```
 https://{stageurl}/{path}
 ```
 
-### Examples
+<a id="api-gateway-trigger-examples"></a>
+### Examples { #api-gateway-trigger-examples }
 
+<a id="api-gateway-trigger-examples-request-get"></a>
 #### Request GET
 
 ```bash
 curl -X GET "https://{stageurl}/{path}?param1=value1&param2=value2"
 ```
 
+<a id="api-gateway-trigger-examples-request-post"></a>
 #### Request POST
 
 ```bash
@@ -189,7 +215,8 @@ curl -X POST "https://{stageurl}/{path}" \
   -d '{"key": "value"}'
 ```
 
-### Features of API Gateway Trigger
+<a id="features-of-api-gateway-trigger"></a>
+### Features of API Gateway Trigger { #features-of-api-gateway-trigger }
 
 - You can leverage various features of API Gateway.
   - Manage authentication and permission
@@ -200,7 +227,8 @@ curl -X POST "https://{stageurl}/{path}" \
 - Integrating functions is available only in a single automatically generated service.
 - The service supports GET and POST methods, same as HTTP triggers.
 
-### Modify API Gateway Trigger
+<a id="modify-api-gateway-trigger"></a>
+### Modify API Gateway Trigger { #modify-api-gateway-trigger }
 
 ![trigger-guide-05](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-05.png)
 
@@ -216,15 +244,18 @@ curl -X POST "https://{stageurl}/{path}" \
 > <br>It results in deleting all plugins applied to the corresponding resource.
 > <br>If you want to change the resource path to which the plugin is applied, we recommend adding a new trigger instead of modifying it.
 
-### Use with API Gateway
+<a id="use-with-api-gateway"></a>
+### Use with API Gateway { #use-with-api-gateway }
 
 Once you create an API Gateway trigger, you can configure additional settings in the API Gateway console.
 
 For more details, please refer to the [API Gateway Guide](https://docs.nhncloud.com/ko/Application%20Service/API%20Gateway/ko/overview/).
 
-## Delete Trigger
+<a id="delete-trigger"></a>
+## Delete Trigger { #delete-trigger }
 
-### How to Delete Trigger
+<a id="how-to-delete-trigger"></a>
+### How to Delete Trigger { #how-to-delete-trigger }
 
 ![trigger-guide-03](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-03.png)
 
@@ -234,15 +265,18 @@ For more details, please refer to the [API Gateway Guide](https://docs.nhncloud.
 4. Click **Delete Trigger**.
 5. Click **Delete** from the modal window of **Delete Trigger**.
 
-### Cautions
+<a id="cautions"></a>
+### Cautions { #cautions }
 
 - You cannot delete HTTP trigger. HTTP trigger is built-in, only being enabled or disabled.
 - If deleting the trigger, you cannot execute the function through the event.
 - Deleted triggers cannot be recovered.
 
-## Restrictions
+<a id="restrictions"></a>
+## Restrictions { #restrictions }
 
-### Restrictions for API Gateway Trigger
+<a id="restrictions-for-api-gateway-trigger"></a>
+### Restrictions for API Gateway Trigger { #restrictions-for-api-gateway-trigger }
 
 - You can only connect API Gateways within the same project.
 - A single API Gateway resource can only be connected with one function. A single function can register multiple API Gateway triggers.

--- a/ja/api-guide-v1-0.md
+++ b/ja/api-guide-v1-0.md
@@ -1,10 +1,15 @@
-## Cloud Functions API v1.0 ガイド
+<!-- pre-align:aligned sig=fb47c311eeaa -->
+
+<a id="cloud-functions-api-v10-guide"></a>
+## Cloud Functions API v1.0 ガイド { #cloud-functions-api-v10-guide }
 
 **Compute > Cloud Functions > API ガイド > API v1.0 ガイド**
 
-## Cloud Functions API v1.0 共通情報
+<a id="cloud-functions-api-v10-common-information"></a>
+## Cloud Functions API v1.0 共通情報 { #cloud-functions-api-v10-common-information }
 
-### API エンドポイント
+<a id="api-endpoint"></a>
+### API エンドポイント { #api-endpoint }
 
 Cloud Functions APIを呼び出すためのリージョン別エンドポイントは以下のとおりです。
 
@@ -12,13 +17,15 @@ Cloud Functions APIを呼び出すためのリージョン別エンドポイン�
 | --- |-----------------------------------------------------|
 | 韓国(パンギョ)リージョン | https://kr1-cloud-functions.api.nhncloudservice.com |
 
-### 認証及び権限
+<a id="authentication-and-authorization"></a>
+### 認証及び権限 { #authentication-and-authorization }
 
 Cloud Functionsは、API呼び出し時の認証/認可にUser Access Keyトークンを使用します。
 User Access Keyトークンは、User Access Keyをもとに発行されるBearerタイプの一時的なアクセストークンです。
 User Access Keyトークンの発行手順や使用方法の詳細は、[User Access Keyトークン](/nhncloud/ko/public-api/user-access-key-token)をご参照ください。
 
-### レスポンス共通情報
+<a id="response-common-information"></a>
+### レスポンス共通情報 { #response-common-information }
 
 全てのAPIレスポンスは以下の共通形式に従います。
 
@@ -64,7 +71,8 @@ User Access Keyトークンの発行手順や使用方法の詳細は、[User Ac
 | header.resultMessage | String | 結果メッセージ |
 | data | Object | レスポンスデータ(APIごとに異なる) |
 
-### ランタイムEOL状態共通フィールド
+<a id="runtime-eol-status-common-fields"></a>
+### ランタイムEOL状態共通フィールド { #runtime-eol-status-common-fields }
 
 関数および環境一覧照会のレスポンスには、ランタイムのEOL(end of life)状態情報が含まれます。
 
@@ -79,28 +87,33 @@ User Access Keyトークンの発行手順や使用方法の詳細は、[User Ac
 
 ---
 
-## 環境一覧
+<a id="list-environments"></a>
+## 環境一覧 { #list-environments }
 
 使用可能なランタイム環境一覧を照会します。
 
-### リクエスト
+<a id="request"></a>
+### リクエスト { #request }
 
 ```
 GET /v1.0/env/list
 ```
 
-### リクエストパラメータ
+<a id="request-parameter"></a>
+### リクエストパラメータ { #request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 
-### リクエストボディ
+<a id="request-body"></a>
+### リクエストボディ { #request-body }
 
 このAPIはリクエストボディを必要としません。
 
-### レスポンス
+<a id="response"></a>
+### レスポンス { #response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -150,17 +163,20 @@ GET /v1.0/env/list
 
 ---
 
-## 関数一覧
+<a id="list-functions"></a>
+## 関数一覧 { #list-functions }
 
 関数一覧を照会します。
 
-### リクエスト
+<a id="list-functions-request"></a>
+### リクエスト { #list-functions-request }
 
 ```
 GET /v1.0/functions
 ```
 
-### リクエストパラメータ
+<a id="list-functions-request-parameter"></a>
+### リクエストパラメータ { #list-functions-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -169,11 +185,13 @@ GET /v1.0/functions
 | page | Query | Integer | N | 現在のページ(デフォルト値: 0) |
 | pageSize | Query | Integer | N | 1ページに表示する件数(デフォルト値: 5000) |
 
-### リクエストボディ
+<a id="list-functions-request-body"></a>
+### リクエストボディ { #list-functions-request-body }
 
 このAPIはリクエストボディを必要としません。
 
-### レスポンス
+<a id="list-functions-response"></a>
+### レスポンス { #list-functions-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -228,17 +246,20 @@ GET /v1.0/functions
 
 ---
 
-## 関数詳細照会
+<a id="get-function"></a>
+## 関数詳細照会 { #get-function }
 
 関数の詳細情報とビルドログを同時に照会します。
 
-### リクエスト
+<a id="get-function-request"></a>
+### リクエスト { #get-function-request }
 
 ```
 GET /v1.0/functions/{functionName}
 ```
 
-### リクエストパラメータ
+<a id="get-function-request-parameter"></a>
+### リクエストパラメータ { #get-function-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -246,11 +267,13 @@ GET /v1.0/functions/{functionName}
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 関数名 |
 
-### リクエストボディ
+<a id="get-function-request-body"></a>
+### リクエストボディ { #get-function-request-body }
 
 このAPIはリクエストボディを必要としません。
 
-### レスポンス
+<a id="get-function-response"></a>
+### レスポンス { #get-function-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -319,7 +342,8 @@ GET /v1.0/functions/{functionName}
 
 ---
 
-## 関数作成
+<a id="create-function"></a>
+## 関数作成 { #create-function }
 
 新しい関数を作成します。multipart/form-dataでソースファイルをアップロードします。
 runtimeは`{environment}-{version}`形式で入力する必要があります(例: NodeJS-22.5.0)。使用可能なランタイムは環境一覧照会APIで確認できます。
@@ -328,20 +352,23 @@ executorTypeによって必須パラメータが異なります。poolManagerの
 
 環境変数は`envVars`フィールドにJSON文字列で渡します。関数につき最大100個、キーは`^[A-Za-z_][A-Za-z0-9_]*$`(最大128文字、重複不可)、値は最大4,096文字であり、セキュリティ上の理由から予約済みのキーは登録できません。無効なJSONの場合はエラーレスポンスを返します。
 
-### リクエスト
+<a id="create-function-request"></a>
+### リクエスト { #create-function-request }
 
 ```
 POST /v1.0/functions
 ```
 
-### リクエストパラメータ
+<a id="create-function-request-parameter"></a>
+### リクエストパラメータ { #create-function-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 
-### リクエストボディ
+<a id="create-function-request-body"></a>
+### リクエストボディ { #create-function-request-body }
 
 Content-Type: multipart/form-data
 
@@ -361,7 +388,8 @@ Content-Type: multipart/form-data
 | envVars | String | N          | 環境変数(JSON文字列、例: `{"DB_HOST":"10.0.0.1"}`)。未指定時は環境変数なし。無効なJSONの場合はエラーレスポンス |
 | sourceFile | Binary | Y | ソースコードファイル(ZIP) |
 
-### レスポンス
+<a id="create-function-response"></a>
+### レスポンス { #create-function-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -381,7 +409,8 @@ Content-Type: multipart/form-data
 
 ---
 
-## 関数修正
+<a id="modify-function"></a>
+## 関数修正 { #modify-function }
 
 関数を修正します。multipart/form-dataでソースファイルをアップロードできます。
 
@@ -391,13 +420,15 @@ Content-Type: multipart/form-data
 
 使用中止(`DISCONTINUED`)となったランタイムを使用する関数は修正できません。リクエスト時、エラーレスポンス(`header.isSuccessful`が`false`)とともに「使用中止されたランタイムで関数を修正することはできません。最新のランタイムで関数を新しく作成してください。」というメッセージが返されます。
 
-### リクエスト
+<a id="modify-function-request"></a>
+### リクエスト { #modify-function-request }
 
 ```
 PUT /v1.0/functions/{functionName}
 ```
 
-### リクエストパラメータ
+<a id="modify-function-request-parameter"></a>
+### リクエストパラメータ { #modify-function-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -405,7 +436,8 @@ PUT /v1.0/functions/{functionName}
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 修正する関数名 |
 
-### リクエストボディ
+<a id="modify-function-request-body"></a>
+### リクエストボディ { #modify-function-request-body }
 
 Content-Type: multipart/form-data
 
@@ -424,7 +456,8 @@ Content-Type: multipart/form-data
 | envVars | String | N          | 環境変数(JSON文字列)。未指定時は既存維持、`"{}"`の場合はすべて削除、値がある場合はすべて置換。無効なJSONの場合はエラーレスポンス |
 | sourceFile | Binary | N | ソースコードファイル(ZIP) |
 
-### レスポンス
+<a id="modify-function-response"></a>
+### レスポンス { #modify-function-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -444,24 +477,28 @@ Content-Type: multipart/form-data
 
 ---
 
-## 関数削除
+<a id="delete-functions"></a>
+## 関数削除 { #delete-functions }
 
 関数を一括削除します。
 
-### リクエスト
+<a id="delete-functions-request"></a>
+### リクエスト { #delete-functions-request }
 
 ```
 DELETE /v1.0/functions
 ```
 
-### リクエストパラメータ
+<a id="delete-functions-request-parameter"></a>
+### リクエストパラメータ { #delete-functions-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
 | X-NHN-appkey | Header | String | Y | Appkey |
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 
-### リクエストボディ
+<a id="delete-functions-request-body"></a>
+### リクエストボディ { #delete-functions-request-body }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -478,7 +515,8 @@ DELETE /v1.0/functions
 | --- | --- | --- | --- |
 | names | Array | Y | 削除する関数名一覧 |
 
-### レスポンス
+<a id="delete-functions-response"></a>
+### レスポンス { #delete-functions-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -498,17 +536,20 @@ DELETE /v1.0/functions
 
 ---
 
-## 関数実行(GET)
+<a id="execute-function-get"></a>
+## 関数実行(GET) { #execute-function-get }
 
 GETメソッドで関数を実行します。
 
-### リクエスト
+<a id="execute-function-get-request"></a>
+### リクエスト { #execute-function-get-request }
 
 ```
 GET /v1.0/functions/{functionName}/invoke
 ```
 
-### リクエストパラメータ
+<a id="execute-function-get-request-parameter"></a>
+### リクエストパラメータ { #execute-function-get-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -516,11 +557,13 @@ GET /v1.0/functions/{functionName}/invoke
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 実行する関数名 |
 
-### リクエストボディ
+<a id="execute-function-get-request-body"></a>
+### リクエストボディ { #execute-function-get-request-body }
 
 このAPIはリクエストボディを必要としません。
 
-### レスポンス
+<a id="execute-function-get-response"></a>
+### レスポンス { #execute-function-get-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -544,17 +587,20 @@ GET /v1.0/functions/{functionName}/invoke
 
 ---
 
-## 関数実行(POST)
+<a id="execute-function-post"></a>
+## 関数実行(POST) { #execute-function-post }
 
 POSTメソッドで関数を実行します。bodyを送信できます。
 
-### リクエスト
+<a id="execute-function-post-request"></a>
+### リクエスト { #execute-function-post-request }
 
 ```
 POST /v1.0/functions/{functionName}/invoke
 ```
 
-### リクエストパラメータ
+<a id="execute-function-post-request-parameter"></a>
+### リクエストパラメータ { #execute-function-post-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -562,7 +608,8 @@ POST /v1.0/functions/{functionName}/invoke
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 実行する関数名 |
 
-### リクエストボディ
+<a id="execute-function-post-request-body"></a>
+### リクエストボディ { #execute-function-post-request-body }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -579,7 +626,8 @@ POST /v1.0/functions/{functionName}/invoke
 | --- |------| --- | --- |
 | body | JSON | N | 関数に渡すbody |
 
-### レスポンス
+<a id="execute-function-post-response"></a>
+### レスポンス { #execute-function-post-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -603,17 +651,20 @@ POST /v1.0/functions/{functionName}/invoke
 
 ---
 
-## バージョン一覧
+<a id="list-versions"></a>
+## バージョン一覧 { #list-versions }
 
 関数のバージョン(パッケージ)一覧を照会します。
 
-### リクエスト
+<a id="list-versions-request"></a>
+### リクエスト { #list-versions-request }
 
 ```
 GET /v1.0/functions/{functionName}/versions
 ```
 
-### リクエストパラメータ
+<a id="list-versions-request-parameter"></a>
+### リクエストパラメータ { #list-versions-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -621,11 +672,13 @@ GET /v1.0/functions/{functionName}/versions
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 関数名 |
 
-### リクエストボディ
+<a id="list-versions-request-body"></a>
+### リクエストボディ { #list-versions-request-body }
 
 このAPIはリクエストボディを必要としません。
 
-### レスポンス
+<a id="list-versions-response"></a>
+### レスポンス { #list-versions-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -672,17 +725,20 @@ GET /v1.0/functions/{functionName}/versions
 
 ---
 
-## バージョン切り替え
+<a id="switch-version"></a>
+## バージョン切り替え { #switch-version }
 
 関数の現在のアクティブバージョンを変更します。
 
-### リクエスト
+<a id="switch-version-request"></a>
+### リクエスト { #switch-version-request }
 
 ```
 PUT /v1.0/functions/{functionName}/versions
 ```
 
-### リクエストパラメータ
+<a id="switch-version-request-parameter"></a>
+### リクエストパラメータ { #switch-version-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -690,7 +746,8 @@ PUT /v1.0/functions/{functionName}/versions
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 関数名 |
 
-### リクエストボディ
+<a id="switch-version-request-body"></a>
+### リクエストボディ { #switch-version-request-body }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -707,7 +764,8 @@ PUT /v1.0/functions/{functionName}/versions
 | --- | --- | --- | --- |
 | versionId | Integer | Y | 切り替えるバージョンID |
 
-### レスポンス
+<a id="switch-version-response"></a>
+### レスポンス { #switch-version-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -727,19 +785,22 @@ PUT /v1.0/functions/{functionName}/versions
 
 ---
 
-## バージョン削除
+<a id="delete-versions"></a>
+## バージョン削除 { #delete-versions }
 
 関数のバージョンを一括削除します。
 
 現在のアクティブバージョンは削除できません。
 
-### リクエスト
+<a id="delete-versions-request"></a>
+### リクエスト { #delete-versions-request }
 
 ```
 DELETE /v1.0/functions/{functionName}/versions
 ```
 
-### リクエストパラメータ
+<a id="delete-versions-request-parameter"></a>
+### リクエストパラメータ { #delete-versions-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -747,7 +808,8 @@ DELETE /v1.0/functions/{functionName}/versions
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 関数名 |
 
-### リクエストボディ
+<a id="delete-versions-request-body"></a>
+### リクエストボディ { #delete-versions-request-body }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -764,7 +826,8 @@ DELETE /v1.0/functions/{functionName}/versions
 | --- | --- | --- | --- |
 | versionIds | Array | Y | 削除するバージョンID一覧 |
 
-### レスポンス
+<a id="delete-versions-response"></a>
+### レスポンス { #delete-versions-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -784,17 +847,20 @@ DELETE /v1.0/functions/{functionName}/versions
 
 ---
 
-## トリガー一覧
+<a id="list-triggers"></a>
+## トリガー一覧 { #list-triggers }
 
 関数のトリガー一覧を照会します。
 
-### リクエスト
+<a id="list-triggers-request"></a>
+### リクエスト { #list-triggers-request }
 
 ```
 GET /v1.0/triggers/{functionName}
 ```
 
-### リクエストパラメータ
+<a id="list-triggers-request-parameter"></a>
+### リクエストパラメータ { #list-triggers-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -802,11 +868,13 @@ GET /v1.0/triggers/{functionName}
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 関数名 |
 
-### リクエストボディ
+<a id="list-triggers-request-body"></a>
+### リクエストボディ { #list-triggers-request-body }
 
 このAPIはリクエストボディを必要としません。
 
-### レスポンス
+<a id="list-triggers-response"></a>
+### レスポンス { #list-triggers-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -847,17 +915,20 @@ GET /v1.0/triggers/{functionName}
 
 ---
 
-## タイムトリガー作成
+<a id="create-time-trigger"></a>
+## タイムトリガー作成 { #create-time-trigger }
 
 関数にタイムトリガーを作成します。
 
-### リクエスト
+<a id="create-time-trigger-request"></a>
+### リクエスト { #create-time-trigger-request }
 
 ```
 POST /v1.0/triggers/{functionName}/time
 ```
 
-### リクエストパラメータ
+<a id="create-time-trigger-request-parameter"></a>
+### リクエストパラメータ { #create-time-trigger-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -865,7 +936,8 @@ POST /v1.0/triggers/{functionName}/time
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 関数名 |
 
-### リクエストボディ
+<a id="create-time-trigger-request-body"></a>
+### リクエストボディ { #create-time-trigger-request-body }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -882,7 +954,8 @@ POST /v1.0/triggers/{functionName}/time
 | --- | --- | --- | --- |
 | cron | String | Y | cron式 |
 
-### レスポンス
+<a id="create-time-trigger-response"></a>
+### レスポンス { #create-time-trigger-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -902,17 +975,20 @@ POST /v1.0/triggers/{functionName}/time
 
 ---
 
-## タイムトリガー修正
+<a id="modify-time-trigger"></a>
+## タイムトリガー修正 { #modify-time-trigger }
 
 タイムトリガーのcron式を修正します。
 
-### リクエスト
+<a id="modify-time-trigger-request"></a>
+### リクエスト { #modify-time-trigger-request }
 
 ```
 PUT /v1.0/triggers/{functionName}/time
 ```
 
-### リクエストパラメータ
+<a id="modify-time-trigger-request-parameter"></a>
+### リクエストパラメータ { #modify-time-trigger-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -920,7 +996,8 @@ PUT /v1.0/triggers/{functionName}/time
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 関数名 |
 
-### リクエストボディ
+<a id="modify-time-trigger-request-body"></a>
+### リクエストボディ { #modify-time-trigger-request-body }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -939,7 +1016,8 @@ PUT /v1.0/triggers/{functionName}/time
 | name | String | Y | トリガー名 |
 | cron | String | Y | cron式 |
 
-### レスポンス
+<a id="modify-time-trigger-response"></a>
+### レスポンス { #modify-time-trigger-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -959,17 +1037,20 @@ PUT /v1.0/triggers/{functionName}/time
 
 ---
 
-## タイムトリガー削除
+<a id="delete-time-triggers"></a>
+## タイムトリガー削除 { #delete-time-triggers }
 
 タイムトリガーを一括削除します。
 
-### リクエスト
+<a id="delete-time-triggers-request"></a>
+### リクエスト { #delete-time-triggers-request }
 
 ```
 DELETE /v1.0/triggers/{functionName}/time
 ```
 
-### リクエストパラメータ
+<a id="delete-time-triggers-request-parameter"></a>
+### リクエストパラメータ { #delete-time-triggers-request-parameter }
 
 | 名前 | 区分 | タイプ | 必須 | 説明 |
 | --- | --- | --- | --- | --- |
@@ -977,7 +1058,8 @@ DELETE /v1.0/triggers/{functionName}/time
 | X-NHN-authorization | Header | String | Y | ユーザートークン(Bearer {token}) |
 | functionName | URL | String | Y | 関数名 |
 
-### リクエストボディ
+<a id="delete-time-triggers-request-body"></a>
+### リクエストボディ { #delete-time-triggers-request-body }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>
@@ -994,7 +1076,8 @@ DELETE /v1.0/triggers/{functionName}/time
 | --- | --- | --- | --- |
 | names | Array | Y | 削除するトリガー名一覧 |
 
-### レスポンス
+<a id="delete-time-triggers-response"></a>
+### レスポンス { #delete-time-triggers-response }
 
 <details>
   <summary><strong>サンプルコード</strong></summary>

--- a/ja/code-template-dotnet-guide.md
+++ b/ja/code-template-dotnet-guide.md
@@ -1,17 +1,23 @@
-## Compute > Cloud Functions > コードテンプレートガイド > .NET
+<!-- pre-align:aligned sig=12935a7ff892 -->
+
+<a id="compute-cloud-functions-code-template-guide-net"></a>
+## Compute > Cloud Functions > コードテンプレートガイド > .NET { #compute-cloud-functions-code-template-guide-net }
 
 このドキュメントでは、NHN CloudのCloud Functionsサービスで.NETを使用して関数を開発する方法を詳しく説明します。
 
-## テンプレート情報
+<a id="template-information"></a>
+## テンプレート情報 { #template-information }
 | 項目       | 値                |
 |-----------------|---------|
 | **サポートバージョン** | 8                  |
 | **ファイル名**    | func.cs            |
 | **Entry Point** | func             |
 
-## 基本テンプレート
+<a id="basic-template"></a>
+## 基本テンプレート { #basic-template }
 
-### Hello Worldの例
+<a id="hello-world-example"></a>
+### Hello Worldの例 { #hello-world-example }
 最も基本的な関数の形式です。`Nhn.DotNetCore.Api`名前空間の`NhnContext`を使用して、ロガーやリクエスト情報にアクセスします。
 
 ```csharp
@@ -50,7 +56,8 @@ public class NhnFunction
 }
 ```
 
-### Contextオブジェクト
+<a id="context-object"></a>
+### Contextオブジェクト { #context-object }
 `NhnContext`オブジェクトを通じて、ロガー、リクエスト(Request)、レスポンス(Response)オブジェクトにアクセスできます。
 
 ```csharp
@@ -95,14 +102,17 @@ public class NhnFunction
 }
 ```
 
-## テンプレートファイルのダウンロードと活用
+<a id="download-and-use-template-file"></a>
+## テンプレートファイルのダウンロードと活用 { #download-and-use-template-file }
 
-### テンプレートのダウンロード
+<a id="template-download"></a>
+### テンプレートのダウンロード { #template-download }
 Cloud Functionsが提供する.NETテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [dotnet.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/dotnet/dotnet.zip)
 
-### テンプレートのファイル構造
+<a id="template-file-structure"></a>
+### テンプレートのファイル構造 { #template-file-structure }
 ダウンロードしたテンプレートファイルの構造は次のとおりです。
 
 ```
@@ -112,8 +122,10 @@ dotnet.zip
 └── nuget.txt     # 依存関係管理ファイル
 ```
 
-### ローカルでの開発プロセス
+<a id="local-development-process"></a>
+### ローカルでの開発プロセス { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. 解凍
 ```bash
 # 解凍
@@ -123,6 +135,7 @@ unzip dotnet.zip -d my-function
 cd my-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. 関数コードの修正
 `func.cs`ファイルを、目的のロジックに合わせて修正します。
 
@@ -178,6 +191,7 @@ public class NhnFunction
 }
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. ZIPファイルへ圧縮
 修正したソースコードを、再度ZIPファイルへ圧縮します。`func.cs`と`nuget.txt`がルートディレクトリに含まれるように圧縮する必要があります。
 
@@ -185,13 +199,16 @@ public class NhnFunction
 zip my-function.zip func.cs nuget.txt
 ```
 
-### Cloud Functionsコンソールでのアップロード
+<a id="upload-from-cloud-functions-console"></a>
+### Cloud Functionsコンソールでのアップロード { #upload-from-cloud-functions-console }
 - 関数を作成または修正する際に、**ユーザーローカル環境**方式を選択します。
 - **ファイルを選択**をクリックし、作成した`my-function.zip`ファイルをアップロードします。
 
-## HTTPメソッド別の処理
+<a id="process-by-http-method"></a>
+## HTTPメソッド別の処理 { #process-by-http-method }
 
-### GETリクエストの処理
+<a id="process-get-request"></a>
+### GETリクエストの処理 { #process-get-request }
 ```csharp
 using System;
 using Nhn.DotNetCore.Api;
@@ -220,7 +237,8 @@ public class NhnFunction
 }
 ```
 
-### POSTリクエストの処理
+<a id="process-post-request"></a>
+### POSTリクエストの処理 { #process-post-request }
 ```csharp
 using System;
 using System.IO;
@@ -272,7 +290,8 @@ public class NhnFunction
 }
 ```
 
-## パッケージ管理(`nuget.txt`)
+<a id="manage-package-nugettxt"></a>
+## パッケージ管理(`nuget.txt`) { #manage-package-nugettxt }
 
 依存関係(NuGetパッケージ)の管理には、`nuget.txt`ファイルを使用します。必要なパッケージを1行に1つずつ記述してください。
 
@@ -281,7 +300,8 @@ public class NhnFunction
 Microsoft.Extensions.Configuration:8.0.0
 ```
 
-### 設定管理の例
+<a id="example-of-configuration-management"></a>
+### 設定管理の例 { #example-of-configuration-management }
 ```csharp
 using System;
 using System.Collections.Generic;
@@ -362,7 +382,8 @@ public class NhnFunction
 }
 ```
 
-## 環境変数の使用
+<a id="use-environment-variables"></a>
+## 環境変数の使用 { #use-environment-variables }
 関数に登録した環境変数は、`Environment.GetEnvironmentVariable`でアクセスできます。環境変数は、関数の作成及び修正のコード作成段階で登録します。詳細については、コンソール使用ガイドをご参照ください。
 
 ```csharp
@@ -412,7 +433,8 @@ public class NhnFunction
     - `DOTNET_STARTUP_HOOKS`, `DOTNET_ADDITIONAL_DEPS`, `ASPNETCORE_HOSTINGSTARTUPASSEMBLIES`
     - プレフィックス `CORECLR_`、`COMPLUS_`、`DOTNET_`、`ASPNETCORE_`
 
-## エントリーポイントの設定
+<a id="configure-entry-point"></a>
+## エントリーポイントの設定 { #configure-entry-point }
 
 エントリーポイントは**ファイル名**です。(拡張子を除く)
 
@@ -421,6 +443,7 @@ public class NhnFunction
 
 **重要**:クラス名は`NhnFunction`である必要があり、関数として機能するメソッドは`public string Execute(NhnContext context)`というシグネチャを持つ必要があります。
 
-### 注意事項
+<a id="caution"></a>
+### 注意事項 { #caution }
 - **パッケージバージョン**: `nuget.txt`でパッケージのバージョンを明記できます。(例: `Newtonsoft.Json:9.0.1`)
 - **タイプの競合**:依存関係を追加する際にタイプの競合が発生する可能性があるため、可能な限り.NETの基本ライブラリを使用するか、互換性のあるバージョンのパッケージを使用することを推奨します。

--- a/ja/code-template-go-guide.md
+++ b/ja/code-template-go-guide.md
@@ -1,17 +1,23 @@
-## Compute > Cloud Functions > コードテンプレートガイド > Go
+<!-- pre-align:aligned sig=03a04e4bdda0 -->
+
+<a id="compute-cloud-functions-code-template-guide-go"></a>
+## Compute > Cloud Functions > コードテンプレートガイド > Go { #compute-cloud-functions-code-template-guide-go }
 
 このドキュメントでは、NHN CloudのCloud FunctionsサービスでGoを使用して関数を開発する方法を詳しく説明します。
 
-## テンプレート情報
+<a id="template-information"></a>
+## テンプレート情報 { #template-information }
 | 項目             | 値                                       |
 |-----------------|------------------------------------------|
 | **サポートバージョン**       | 1.22, 1.23, 1.24, 1.25 |
 | **ファイル名**         | functions.go                             |
 | **Entry Point** | Handler                                  |
 
-## 基本テンプレート
+<a id="basic-template"></a>
+## 基本テンプレート { #basic-template }
 
-### Hello Worldの例
+<a id="hello-world-example"></a>
+### Hello Worldの例 { #hello-world-example }
 最も基本的な関数の形式です。
 
 ```go
@@ -38,7 +44,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
-### Contextオブジェクト
+<a id="context-object"></a>
+### Contextオブジェクト { #context-object }
 Goの関数では、`http.ResponseWriter`と`*http.Request`を通じてHTTPのリクエストとレスポンスを処理します。
 
 ```go
@@ -74,14 +81,17 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
-## テンプレートファイルのダウンロードと活用
+<a id="download-and-use-template-file"></a>
+## テンプレートファイルのダウンロードと活用 { #download-and-use-template-file }
 
-### テンプレートのダウンロード
+<a id="template-download"></a>
+### テンプレートのダウンロード { #template-download }
 Cloud Functionsが提供するGoテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [go.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/go/go.zip)
 
-### テンプレートのファイル構造
+<a id="template-file-structure"></a>
+### テンプレートのファイル構造 { #template-file-structure }
 ダウンロードしたテンプレートファイルの構造は次のとおりです。
 
 ```
@@ -90,6 +100,7 @@ go.zip
 └── go.mod          # 依存関係管理ファイル
 ```
 
+<a id="template-file-structure-functionsgo"></a>
 #### functions.go
 基本的なfakeデータ生成関数が含まれています。
 ```go
@@ -116,6 +127,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+<a id="template-file-structure-gomod"></a>
 #### go.mod
 ```go
 module example.com/ncf
@@ -125,8 +137,10 @@ go 1.22
 require github.com/brianvoe/gofakeit/v6 v6.28.0
 ```
 
-### ローカルでの開発プロセス
+<a id="local-development-process"></a>
+### ローカルでの開発プロセス { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. 解凍
 ```bash
 # 解凍
@@ -136,6 +150,7 @@ unzip go.zip -d my-function
 cd my-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. 関数コードの修正
 `functions.go`ファイルを、目的のロジックに合わせて修正します。
 
@@ -185,6 +200,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. ZIPファイルへ圧縮
 修正したコードを、再度ZIPファイルへ圧縮します。
 
@@ -202,11 +218,14 @@ zip my-function.zip functions.go go.mod
 zip -r my-function.zip . -x "*.git*" "go.sum" "test.go"
 ```
 
-### Cloud Functionsコンソールでのアップロード
+<a id="upload-from-cloud-functions-console"></a>
+### Cloud Functionsコンソールでのアップロード { #upload-from-cloud-functions-console }
 > 関数を作成または修正する際に、ユーザーのローカル環境にあるファイルをアップロードする場合に使用します。(コンソール利用ガイド参照)
 
-### アップロード時の注意事項
+<a id="cautions-for-upload"></a>
+### アップロード時の注意事項 { #cautions-for-upload }
 
+<a id="cautions-for-upload-zip-file-structure"></a>
 #### ZIPファイルの構造
 - ZIPファイルのルートに、直接`.go`ファイルと`go.mod`を配置する必要があります。
 - 不要なフォルダ構造は避けることを推奨します。
@@ -227,10 +246,12 @@ my-function.zip
     └── go.mod
 ```
 
+<a id="cautions-for-upload-file-size-limit"></a>
 #### ファイルサイズの制限
 - ZIPファイルのサイズは100MiB以下に制限されます。
 - `go.sum`ファイルは含めないでください。
 
+<a id="cautions-for-upload-files-to-exclude"></a>
 #### 除外するファイル
 ```bash
 # .gitignoreと同様に、以下のファイルは除外
@@ -243,9 +264,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
-## HTTPメソッド別の処理
+<a id="process-by-http-method"></a>
+## HTTPメソッド別の処理 { #process-by-http-method }
 
-### GETリクエストの処理
+<a id="process-get-request"></a>
+### GETリクエストの処理 { #process-get-request }
 ```go
 package main
 
@@ -283,7 +306,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
-### POSTリクエストの処理
+<a id="process-post-request"></a>
+### POSTリクエストの処理 { #process-post-request }
 ```go
 package main
 
@@ -354,9 +378,11 @@ func getOrDefault(value, defaultValue string) string {
 }
 ```
 
-## パッケージ管理
+<a id="manage-packages"></a>
+## パッケージ管理 { #manage-packages }
 
-### go.modの作成
+<a id="write-gomod"></a>
+### go.modの作成 { #write-gomod }
 依存関係の管理には、`go.mod`ファイルを作成します。
 
 ```go
@@ -370,7 +396,8 @@ require (
 )
 ```
 
-### 外部API呼び出しの例
+<a id="example-of-external-api-call"></a>
+### 外部API呼び出しの例 { #example-of-external-api-call }
 ```go
 package main
 
@@ -423,7 +450,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
-### データ処理の例
+<a id="data-processing-example"></a>
+### データ処理の例 { #data-processing-example }
 ```go
 package main
 
@@ -516,7 +544,8 @@ func normalizeName(name string) string {
 }
 ```
 
-## 環境変数の使用
+<a id="use-environment-variables"></a>
+## 環境変数の使用 { #use-environment-variables }
 関数に登録した環境変数は、`os.Getenv`でアクセスできます。環境変数は、関数の作成及び修正のコード作成段階で登録します。詳細については、コンソール使用ガイドをご参照ください。
 
 ```go
@@ -565,15 +594,18 @@ func Handler(w http.ResponseWriter, r *http.Request) {
     - `GODEBUG`
     - Goは一般ユーザーの変数と衝突しないよう、プレフィックスによるブロックはありません。
 
-## エントリーポイントの設定
+<a id="configure-entry-point"></a>
+## エントリーポイントの設定 { #configure-entry-point }
 
-### 単一関数
+<a id="single-function"></a>
+### 単一関数 { #single-function }
 関数名をエントリーポイントとして使用します。
 
 関数名: `Handler`
 Entry Point: `Handler`
 
-### 複数関数
+<a id="multiple-functions"></a>
+### 複数関数 { #multiple-functions }
 1つのファイルで複数の関数を定義できます。
 
 ```go
@@ -613,9 +645,11 @@ func UpdateUser(w http.ResponseWriter, r *http.Request) {
 - `CreateUser`
 - `UpdateUser`
 
-## 注意事項
+<a id="caution"></a>
+## 注意事項 { #caution }
 
-### Goのバージョン
+<a id="go-version"></a>
+### Goのバージョン { #go-version }
 | バージョン | サポート終了日 | 利用終了日 |
 |-----|-----------|-----------|
 | 1.25 | - | - |
@@ -623,6 +657,7 @@ func UpdateUser(w http.ResponseWriter, r *http.Request) {
 | 1.23 | 2026-02-21 | 2026-08-21 |
 | 1.22 | 2026-01-28 | 2026-07-28 |
 
+<a id="go-version-support-policy"></a>
 #### Goバージョンサポートポリシー
 Cloud Functionsは、Goの公式リリース方針に従います。Goは年2回(1月、7月)新しいメジャーバージョンをリリースしており、各バージョンは最新の2つのメジャーバージョンまでサポートされます。
 

--- a/ja/code-template-java-guide.md
+++ b/ja/code-template-java-guide.md
@@ -1,17 +1,23 @@
-## Compute > Cloud Functions > コードテンプレートガイド > Java
+<!-- pre-align:aligned sig=fe65e841fbc2 -->
+
+<a id="compute-cloud-functions-code-template-guide-java"></a>
+## Compute > Cloud Functions > コードテンプレートガイド > Java { #compute-cloud-functions-code-template-guide-java }
 
 このドキュメントでは、NHN CloudのCloud FunctionsサービスでJavaを使用して関数を開発する方法を詳しく説明します。
 
-## テンプレート情報
+<a id="template-information"></a>
+## テンプレート情報 { #template-information }
 | 項目       | 値                |
 |-----------------|--------------------|
 | **サポートバージョン** | 17, 21             |
 | **ファイル名**    | HelloWorld.java    |
 | **Entry Point** | example.HelloWorld |
 
-## 基本テンプレート
+<a id="basic-template"></a>
+## 基本テンプレート { #basic-template }
 
-### Hello Worldの例
+<a id="hello-world-example"></a>
+### Hello Worldの例 { #hello-world-example }
 最も基本的な関数の形式です。
 
 ```java
@@ -29,7 +35,8 @@ public class HelloWorld {
 }
 ```
 
-### Contextオブジェクト(RequestEntity)
+<a id="context-object-requestentity"></a>
+### Contextオブジェクト(RequestEntity) { #context-object-requestentity }
 Javaの関数では、Springの`RequestEntity`を通じてHTTPリクエスト情報にアクセスできます。
 
 ```java
@@ -62,14 +69,17 @@ public class HelloWorld {
 }
 ```
 
-## テンプレートファイルのダウンロードと活用
+<a id="download-and-use-template-file"></a>
+## テンプレートファイルのダウンロードと活用 { #download-and-use-template-file }
 
-### テンプレートのダウンロード
+<a id="template-download"></a>
+### テンプレートのダウンロード { #template-download }
 Cloud Functionsが提供するJavaテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [java.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/java/java.zip)
 
-### テンプレートのファイル構造
+<a id="template-file-structure"></a>
+### テンプレートのファイル構造 { #template-file-structure }
 ダウンロードしたテンプレートは、Mavenのプロジェクト構造に従っています。
 
 ```
@@ -82,8 +92,10 @@ java.zip
                 └── HelloWorld.java
 ```
 
-### ローカルでの開発プロセス
+<a id="local-development-process"></a>
+### ローカルでの開発プロセス { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. 解凍
 ```bash
 # 解凍
@@ -93,6 +105,7 @@ unzip java.zip -d my-java-function
 cd my-java-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. 関数コードの修正
 `src/main/java/example/HelloWorld.java`ファイルを、目的のロジックに合わせて修正します。
 
@@ -144,6 +157,7 @@ public class HelloWorld {
 }
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. ZIPファイルへ圧縮
 修正したソースコードを、再度ZIPファイルへ圧縮します。`pom.xml`ファイルと`src`ディレクトリがルートディレクトリに含まれるように圧縮する必要があります。
 
@@ -161,19 +175,23 @@ zip -r my-function.zip pom.xml src
 zip -r my-function.zip . -x "*.git*" "target/*" "*.log"
 ```
 
-### Cloud Functionsコンソールでのアップロード
+<a id="upload-from-cloud-functions-console"></a>
+### Cloud Functionsコンソールでのアップロード { #upload-from-cloud-functions-console }
 - 関数を作成または修正する際に、**ユーザーローカル環境**方式を選択します。
 - **ファイルを選択**をクリックし、作成した`my-function.zip`ファイルをアップロードします。
 
-### アップロード時の注意事項
+<a id="cautions-for-upload"></a>
+### アップロード時の注意事項 { #cautions-for-upload }
 - **アップロードファイル**:ソースコードと`pom.xml`が含まれた**ZIPファイル**をアップロードする必要があります。
 - **ZIPファイルの構造**: ZIPファイルのルートに`pom.xml`と`src`ディレクトリを配置する必要があります。
 - **除外するファイル**: `target`ディレクトリや`.git`ディレクトリなど、不要なファイルは含めないでください。
 - **ファイルサイズ**: ZIPファイルのサイズは100MiB以下に制限されます。
 
-## HTTPメソッド別の処理
+<a id="process-by-http-method"></a>
+## HTTPメソッド別の処理 { #process-by-http-method }
 
-### GETリクエストの処理
+<a id="process-get-request"></a>
+### GETリクエストの処理 { #process-get-request }
 ```java
 package example;
 
@@ -209,7 +227,8 @@ public class GetHandler {
 }
 ```
 
-### POSTリクエストの処理
+<a id="process-post-request"></a>
+### POSTリクエストの処理 { #process-post-request }
 ```java
 package example;
 
@@ -250,7 +269,8 @@ public class PostHandler {
 }
 ```
 
-## パッケージ管理(`pom.xml`)
+<a id="manage-package-pomxml"></a>
+## パッケージ管理(`pom.xml`) { #manage-package-pomxml }
 
 依存関係の管理には、`pom.xml`ファイルを修正します。`dependencies`セクションに必要なライブラリを追加すると、関数のアップロード時にCloud Functionsが自動で依存関係をダウンロードし、ビルドに含めます。
 
@@ -273,7 +293,8 @@ public class PostHandler {
 </dependencies>
 ```
 
-### 外部ライブラリの活用例
+<a id="example-of-using-external-libraries"></a>
+### 外部ライブラリの活用例 { #example-of-using-external-libraries }
 ```java
 package example;
 
@@ -307,7 +328,8 @@ public class StringUtilsHandler {
 }
 ```
 
-## 環境変数の使用
+<a id="use-environment-variables"></a>
+## 環境変数の使用 { #use-environment-variables }
 関数に登録した環境変数は、`System.getProperty`でアクセスできます。環境変数は、関数の作成及び修正のコード作成段階で登録します。詳細については、コンソール使用ガイドをご参照ください。
 
 !!! tip "ポイント"
@@ -358,9 +380,11 @@ public class HelloWorld {
 
     - `JAVA_TOOL_OPTIONS`, `_JAVA_OPTIONS`, `JDK_JAVA_OPTIONS`, `CLASSPATH`
 
-## エントリーポイントの設定
+<a id="entry-point-configuration"></a>
+## エントリーポイントの設定 { #entry-point-configuration }
 
-### 単一クラス
+<a id="single-class"></a>
+### 単一クラス { #single-class }
 `パッケージ名。クラス名`をエントリーポイントとして使用します。
 
 - パッケージ名: `example`
@@ -368,6 +392,7 @@ public class HelloWorld {
 - Entry Point: `example.HelloWorld`
 - **重要**:関数として機能するメソッドは、`public ResponseEntity<?> call(RequestEntity<?> req)`というシグネチャを持つ必要があります。
 
-### 注意事項
+<a id="caution"></a>
+### 注意事項 { #caution }
 - **プロジェクト構造**: `src/main/java`のディレクトリ構造を維持する必要があります。
 - **メモリと実行時間**:関数は限られたリソース内で動作する必要があるため、重い処理は避け、コードを最適化してください。

--- a/ja/code-template-node-guide.md
+++ b/ja/code-template-node-guide.md
@@ -1,16 +1,22 @@
-## Compute > Cloud Functions > コードテンプレートガイド > Node.js
+<!-- pre-align:aligned sig=9f2d38073162 -->
+
+<a id="compute-cloud-functions-code-template-guide-nodejs"></a>
+## Compute > Cloud Functions > コードテンプレートガイド > Node.js { #compute-cloud-functions-code-template-guide-nodejs }
 
 このドキュメントでは、NHN CloudのCloud FunctionsサービスでNode.jsを使用して関数を開発する方法を詳しく説明します。
 
-## テンプレート情報
+<a id="template-information"></a>
+## テンプレート情報 { #template-information }
 | 項目       | 値                |
 |-----------------|-----------------|
 | **サポートバージョン** | 20.16.0, 22.5.0   |
 | **ファイル名**    | hello.js           |
 | **Entry Point** | hello            |
 
-## 基本テンプレート
-### Hello Worldの例
+<a id="basic-template"></a>
+## 基本テンプレート { #basic-template }
+<a id="hello-world-example"></a>
+### Hello Worldの例 { #hello-world-example }
 最も基本的な関数の形式です。
 
 ```javascript
@@ -22,7 +28,8 @@ module.exports = async (context) => {
 }
 ```
 
-### Contextオブジェクト
+<a id="context-object"></a>
+### Contextオブジェクト { #context-object }
 関数に渡される`context`オブジェクトには、以下の情報が含まれます。
 
 ```javascript
@@ -42,14 +49,17 @@ module.exports = async (context) => {
 }
 ```
 
-## テンプレートファイルのダウンロードと活用
+<a id="download-and-use-template-file"></a>
+## テンプレートファイルのダウンロードと活用 { #download-and-use-template-file }
 
-### テンプレートのダウンロード
+<a id="template-download"></a>
+### テンプレートのダウンロード { #template-download }
 Cloud Functionsが提供するNode.jsテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [nodejs.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/nodejs/nodejs.zip)
 
-### テンプレートのファイル構造
+<a id="template-file-structure"></a>
+### テンプレートのファイル構造 { #template-file-structure }
 ダウンロードしたテンプレートファイルの構造は次のとおりです。
 
 ```
@@ -58,6 +68,7 @@ nodejs.zip
 └── package.json      # 依存関係管理ファイル
 ```
 
+<a id="template-file-structure-hellojs"></a>
 #### hello.js
 基本的なHello World関数が含まれています。
 ```javascript
@@ -69,13 +80,16 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="template-file-structure-packagejson"></a>
 #### package.json
 ```json
 {}
 ```
 
-### ローカルでの開発プロセス
+<a id="local-development-process"></a>
+### ローカルでの開発プロセス { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. 解凍
 ```bash
 # 解凍
@@ -85,6 +99,7 @@ unzip nodejs.zip -d my-function
 cd my-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. 関数コードの修正
 `hello.js`ファイルを、目的のロジックに合わせて修正します。
 
@@ -127,6 +142,7 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. ZIPファイルへ圧縮
 修正したコードを、再度ZIPファイルへ圧縮します。
 
@@ -144,11 +160,14 @@ zip my-function.zip hello.js package.json
 zip -r my-function.zip . -x "*.git*" "node_modules/*" "test.js"
 ```
 
-### Cloud Functionsコンソールでのアップロード
+<a id="upload-from-cloud-functions-console"></a>
+### Cloud Functionsコンソールでのアップロード { #upload-from-cloud-functions-console }
 > 関数を作成または修正する際に、ユーザーのローカル環境にあるファイルをアップロードする場合に使用します。(コンソール利用ガイド参照)
 
-### アップロード時の注意事項
+<a id="cautions-for-upload"></a>
+### アップロード時の注意事項 { #cautions-for-upload }
 
+<a id="cautions-for-upload-zip-file-structure"></a>
 #### ZIPファイルの構造
 - ZIPファイルのルートに、直接`.js`ファイルと`package.json`を配置する必要があります。
 - 不要なフォルダ構造は避けることを推奨します。
@@ -169,10 +188,12 @@ my-function.zip
     └── package.json
 ```
 
+<a id="cautions-for-upload-file-size-limit"></a>
 #### ファイルサイズの制限
 - ZIPファイルのサイズは100MiB以下に制限されます。
 - `node_modules`フォルダは含めないでください。(依存関係は`package.json`で管理)
 
+<a id="cautions-for-upload-files-to-exclude"></a>
 #### 除外するファイル
 ```bash
 # .gitignoreと同様に、以下のファイルは除外
@@ -185,9 +206,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
-## HTTPメソッド別の処理
+<a id="process-by-http-method"></a>
+## HTTPメソッド別の処理 { #process-by-http-method }
 
-### GETリクエストの処理
+<a id="process-get-request"></a>
+### GETリクエストの処理 { #process-get-request }
 ```javascript
 module.exports = async (context) => {
     if (context.request.method !== 'GET') {
@@ -213,7 +236,8 @@ module.exports = async (context) => {
 }
 ```
 
-### POSTリクエストの処理
+<a id="process-post-request"></a>
+### POSTリクエストの処理 { #process-post-request }
 ```javascript
 module.exports = async (context) => {
     if (context.request.method !== 'POST') {
@@ -258,9 +282,11 @@ module.exports = async (context) => {
 }
 ```
 
-## パッケージ管理
+<a id="manage-packages"></a>
+## パッケージ管理 { #manage-packages }
 
-### package.jsonの作成
+<a id="write-packagejson"></a>
+### package.jsonの作成 { #write-packagejson }
 依存関係の管理には、`package.json`ファイルを作成します。
 
 ```json
@@ -278,7 +304,8 @@ module.exports = async (context) => {
 }
 ```
 
-### 外部API呼び出しの例
+<a id="example-of-external-api-call"></a>
+### 外部API呼び出しの例 { #example-of-external-api-call }
 ```javascript
 const axios = require('axios');
 
@@ -328,7 +355,8 @@ module.exports = async (context) => {
 }
 ```
 
-### データ処理の例
+<a id="data-processing-example"></a>
+### データ処理の例 { #data-processing-example }
 ```javascript
 const _ = require('lodash');
 const moment = require('moment');
@@ -382,7 +410,8 @@ module.exports = async (context) => {
 }
 ```
 
-## 環境変数の使用
+<a id="use-environment-variables"></a>
+## 環境変数の使用 { #use-environment-variables }
 関数に登録した環境変数は、`process.env`でアクセスできます。環境変数は、関数の作成及び修正のコード作成段階で登録します。詳細については、コンソール使用ガイドをご参照ください。
 
 ```javascript
@@ -424,15 +453,18 @@ module.exports = async (context) => {
     - `NODE_PATH`, `NODE_OPTIONS`, `NODE_EXTRA_CA_CERTS`
     - プレフィックス `NODE_`
 
-## エントリーポイントの設定
+<a id="configure-entry-point"></a>
+## エントリーポイントの設定 { #configure-entry-point }
 
-### 単一関数
+<a id="single-function"></a>
+### 単一関数 { #single-function }
 ファイル名をエントリーポイントとして使用します。
 
 ファイル名: `hello.js`
 Entry Point: `hello`
 
-### 複数関数
+<a id="multiple-functions"></a>
+### 複数関数 { #multiple-functions }
 1つのファイルで複数の関数をエクスポートできます。
 
 ```javascript
@@ -467,7 +499,8 @@ module.exports.updateUser = async (context) => {
 - `users.createUser`
 - `users.updateUser`
 
-### エントリーポイントの制限事項
+<a id="entry-point-restriction"></a>
+### エントリーポイントの制限事項 { #entry-point-restriction }
 - **サブディレクトリの指定不可**:ルートディレクトリのサブディレクトリにあるファイルは、エントリーポイントとして指定できません。
 
 **正しいエントリーポイント:**
@@ -485,9 +518,11 @@ modules/auth.js → modules.auth ❌
 
 全ての関数ファイルは、ZIPファイルのルートレベルに配置する必要があります。
 
-## 注意事項
+<a id="caution"></a>
+## 注意事項 { #caution }
 
-### CommonJS vs ES Modules
+<a id="commonjs-vs-es-modules"></a>
+### CommonJS vs ES Modules { #commonjs-vs-es-modules }
 現在、Cloud FunctionsはCommonJS方式のみをサポートしています。
 
 **使用可能(CommonJS):**
@@ -506,7 +541,8 @@ export default async (context) => { // ❌サポートしていません
 };
 ```
 
-### メモリ及び実行時間に関する考慮事項
+<a id="considerations-for-memory-and-execution-time"></a>
+### メモリ及び実行時間に関する考慮事項 { #considerations-for-memory-and-execution-time }
 - 関数は、限られたメモリと実行時間内で動作する必要があります。
 - 大容量データを処理する際は、ストリーム処理を検討してください。
 - 長時間実行されるタスクは、適切に分割してください。

--- a/ja/code-template-python-guide.md
+++ b/ja/code-template-python-guide.md
@@ -1,17 +1,23 @@
-## Compute > Cloud Functions > コードテンプレートガイド > Python
+<!-- pre-align:aligned sig=253528824169 -->
+
+<a id="compute-cloud-functions-code-template-guide-python"></a>
+## Compute > Cloud Functions > コードテンプレートガイド > Python { #compute-cloud-functions-code-template-guide-python }
 
 このドキュメントでは、NHN CloudのCloud FunctionsサービスでPythonを使用して関数を開発する方法を詳しく説明します。
 
-## テンプレート情報
+<a id="template-information"></a>
+## テンプレート情報 { #template-information }
 | 項目             | 値               |
 |-----------------|------------------|
 | **サポートバージョン**       | 3.11, 3.12, 3.13 |
 | **ファイル名**         | user.py          |
 | **Entry Point** | user.main        |
 
-## 基本テンプレート
+<a id="basic-template"></a>
+## 基本テンプレート { #basic-template }
 
-### Hello Worldの例
+<a id="hello-world-example"></a>
+### Hello Worldの例 { #hello-world-example }
 最も基本的な関数の形式です。
 
 ```python
@@ -29,7 +35,8 @@ def main():
     return yaml.dump(yaml.safe_load(document))
 ```
 
-### Contextオブジェクト
+<a id="context-object"></a>
+### Contextオブジェクト { #context-object }
 Pythonの関数では、Flaskのrequestオブジェクトを通じてHTTPリクエスト情報にアクセスできます。
 
 ```python
@@ -57,14 +64,17 @@ def main():
     }
 ```
 
-## テンプレートファイルのダウンロードと活用
+<a id="download-and-use-template-file"></a>
+## テンプレートファイルのダウンロードと活用 { #download-and-use-template-file }
 
-### テンプレートのダウンロード
+<a id="template-download"></a>
+### テンプレートのダウンロード { #template-download }
 Cloud Functionsが提供するPythonテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [python.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/python/python.zip)
 
-### テンプレートのファイル構造
+<a id="template-file-structure"></a>
+### テンプレートのファイル構造 { #template-file-structure }
 ダウンロードしたテンプレートファイルの構造は以下の通りです:
 
 ```
@@ -73,6 +83,7 @@ python.zip
 └── requirements.txt # 依存関係管理ファイル
 ```
 
+<a id="template-file-structure-userpy"></a>
 #### user.py
 基本的なYAML処理関数が含まれています。
 ```python
@@ -90,13 +101,16 @@ def main():
     return yaml.dump(yaml.safe_load(document))
 ```
 
+<a id="template-file-structure-requirementstxt"></a>
 #### requirements.txt
 ```txt
 pyyaml
 ```
 
-### ローカルでの開発プロセス
+<a id="local-development-process"></a>
+### ローカルでの開発プロセス { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. 解凍
 ```bash
 # 解凍
@@ -106,6 +120,7 @@ unzip python.zip -d my-function
 cd my-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. 関数コードの修正
 `user.py`ファイルを、目的のロジックに合わせて修正します。
 
@@ -147,6 +162,7 @@ def main():
         }, ensure_ascii=False)
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. ZIPファイルへ圧縮
 修正したコードを、再度ZIPファイルへ圧縮します。
 
@@ -164,11 +180,14 @@ zip my-function.zip user.py requirements.txt
 zip -r my-function.zip . -x "*.git*" "__pycache__/*" "*.pyc" "test.py"
 ```
 
-### Cloud Functionsコンソールでのアップロード
+<a id="upload-from-cloud-functions-console"></a>
+### Cloud Functionsコンソールでのアップロード { #upload-from-cloud-functions-console }
 > 関数を作成または修正する際に、ユーザーのローカル環境にあるファイルをアップロードする場合に使用します。(コンソール利用ガイド参照)
 
-### アップロード時の注意事項
+<a id="cautions-for-upload"></a>
+### アップロード時の注意事項 { #cautions-for-upload }
 
+<a id="cautions-for-upload-zip-file-structure"></a>
 #### ZIPファイルの構造
 - ZIPファイルのルートに、直接`.py`ファイルと`requirements.txt`を配置する必要があります。
 - 不要なフォルダ構造は避けることを推奨します。
@@ -189,10 +208,12 @@ my-function.zip
     └── requirements.txt
 ```
 
+<a id="cautions-for-upload-file-size-limit"></a>
 #### ファイルサイズの制限
 - ZIPファイルのサイズは100MiB以下に制限されます。
 - `__pycache__`フォルダは含めないでください。
 
+<a id="cautions-for-upload-files-to-exclude"></a>
 #### 除外するファイル
 ```bash
 # .gitignoreと同様に、以下のファイルは除外
@@ -206,9 +227,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
-## HTTPメソッド別の処理
+<a id="process-by-http-method"></a>
+## HTTPメソッド別の処理 { #process-by-http-method }
 
-### GETリクエストの処理
+<a id="process-get-request"></a>
+### GETリクエストの処理 { #process-get-request }
 ```python
 from flask import request
 import json
@@ -231,7 +254,8 @@ def main():
     return json.dumps(result, ensure_ascii=False)
 ```
 
-### POSTリクエストの処理
+<a id="process-post-request"></a>
+### POSTリクエストの処理 { #process-post-request }
 ```python
 from flask import request
 import json
@@ -274,9 +298,11 @@ def main():
         }, ensure_ascii=False), 400
 ```
 
-## パッケージ管理
+<a id="manage-packages"></a>
+## パッケージ管理 { #manage-packages }
 
-### requirements.txtの作成
+<a id="write-requirementstxt"></a>
+### requirements.txtの作成 { #write-requirementstxt }
 依存関係の管理には、`requirements.txt`ファイルを作成します。
 
 ```txt
@@ -285,7 +311,8 @@ requests>=2.28.0
 python-dateutil>=2.8.0
 ```
 
-### 外部API呼び出しの例
+<a id="example-of-external-api-call"></a>
+### 外部API呼び出しの例 { #example-of-external-api-call }
 ```python
 from flask import request
 import json
@@ -327,7 +354,8 @@ def main():
         }, ensure_ascii=False), 500
 ```
 
-### データ処理の例
+<a id="data-processing-example"></a>
+### データ処理の例 { #data-processing-example }
 ```python
 from flask import request
 import json
@@ -381,7 +409,8 @@ def normalize_name(name):
     return name.strip().title()
 ```
 
-## 環境変数の使用
+<a id="use-environment-variables"></a>
+## 環境変数の使用 { #use-environment-variables }
 関数に登録した環境変数は、`os.environ`(または`os.getenv`)でアクセスできます。環境変数は、関数の作成及び修正のコード作成段階で登録します。詳細については、コンソール使用ガイドをご参照ください。
 
 ```python
@@ -418,16 +447,19 @@ def main():
     - `PYTHONPATH`, `PYTHONSTARTUP`, `PYTHONHOME`, `PYTHONEXECUTABLE`
     - プレフィックス `PYTHON`
 
-## エントリーポイントの設定
+<a id="configure-entry-point"></a>
+## エントリーポイントの設定 { #configure-entry-point }
 
-### 単一関数
+<a id="single-function"></a>
+### 単一関数 { #single-function }
 `ファイル名.関数名`をエントリーポイントとして使用します。
 
 ファイル名: `user.py`
 関数名: `main`
 Entry Point: `user.main`
 
-### 複数関数
+<a id="multiple-functions"></a>
+### 複数関数 { #multiple-functions }
 1つのファイルで複数の関数を定義できます。
 
 ```python
@@ -453,9 +485,11 @@ def update_user():
 - `handlers.create_user`
 - `handlers.update_user`
 
-## 注意事項
+<a id="caution"></a>
+## 注意事項 { #caution }
 
-### サポートしていないパッケージ
+<a id="unsupported-packages"></a>
+### サポートしていないパッケージ { #unsupported-packages }
 現在、以下の特徴を持つ複雑なパッケージはサポートしていません。
 
 **サポートしていないパッケージの例:**
@@ -469,7 +503,8 @@ def update_user():
 - `python-dateutil` (日付・時刻処理)
 - `pillow` (画像処理 - 基本機能)
 
-### メモリ及び実行時間に関する考慮事項
+<a id="considerations-for-memory-and-execution-time"></a>
+### メモリ及び実行時間に関する考慮事項 { #considerations-for-memory-and-execution-time }
 - 関数は、限られたメモリと実行時間内で動作する必要があります。
 - 大容量データを処理する際は、ジェネレータやストリーム処理を検討してください。
 - 長時間実行されるタスクは、適切に分割してください。

--- a/ja/code-template-ruby-guide.md
+++ b/ja/code-template-ruby-guide.md
@@ -1,17 +1,23 @@
-## Compute > Cloud Functions > コードテンプレートガイド > Ruby
+<!-- pre-align:aligned sig=015e63f62c78 -->
+
+<a id="compute-cloud-functions-code-template-guide-ruby"></a>
+## Compute > Cloud Functions > コードテンプレートガイド > Ruby { #compute-cloud-functions-code-template-guide-ruby }
 
 このドキュメントでは、NHN CloudのCloud FunctionsサービスでRubyを使用して関数を開発する方法を詳しく説明します。
 
-## テンプレート情報
+<a id="template-information"></a>
+## テンプレート情報 { #template-information }
 | 項目             | 値       |
 |-----------------|----------|
 | **サポートバージョン**       | 3.4.5    |
 | **ファイル名**         | parse.rb |
 | **Entry Point** | handler  |
 
-## 基本テンプレート
+<a id="basic-template"></a>
+## 基本テンプレート { #basic-template }
 
-### Hello Worldの例
+<a id="hello-world-example"></a>
+### Hello Worldの例 { #hello-world-example }
 最も基本的な関数の形式です。
 
 ```ruby
@@ -30,7 +36,8 @@ def handler(context)
 end
 ```
 
-### Contextオブジェクト
+<a id="context-object"></a>
+### Contextオブジェクト { #context-object }
 関数に渡される`context`オブジェクトを通じて、ロガーやリクエスト情報にアクセスできます。
 
 ```ruby
@@ -64,14 +71,17 @@ def handler(context)
 end
 ```
 
-## テンプレートファイルのダウンロードと活用
+<a id="download-and-use-template-file"></a>
+## テンプレートファイルのダウンロードと活用 { #download-and-use-template-file }
 
-### テンプレートのダウンロード
+<a id="template-download"></a>
+### テンプレートのダウンロード { #template-download }
 Cloud Functionsが提供するRubyテンプレートをダウンロードし、ローカル環境で開発できます。
 
 **テンプレートのダウンロードリンク**: [ruby.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/ruby/ruby.zip)
 
-### テンプレートのファイル構造
+<a id="template-file-structure"></a>
+### テンプレートのファイル構造 { #template-file-structure }
 ダウンロードしたテンプレートファイルの構造は次のとおりです。
 
 ```
@@ -80,8 +90,10 @@ ruby.zip
 └── Gemfile
 ```
 
-### ローカルでの開発プロセス
+<a id="local-development-process"></a>
+### ローカルでの開発プロセス { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. 解凍
 ```bash
 # 解凍
@@ -91,6 +103,7 @@ unzip ruby.zip -d my-function
 cd my-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. 関数コードの修正
 `parse.rb`ファイルを、目的のロジックに合わせて修正します。
 
@@ -135,6 +148,7 @@ def handler(context)
 end
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. ZIPファイルへ圧縮
 修正したソースコードを、再度ZIPファイルへ圧縮します。`parse.rb`と`Gemfile`がルートディレクトリに含まれるように圧縮する必要があります。
 
@@ -143,19 +157,23 @@ zip my-function.zip parse.rb Gemfile Gemfile.lock
 ```
 **参考**: `Gemfile.lock`ファイルはデプロイ段階で自動的に生成されますが、依存関係の正確なバージョンを事前に確認または固定したい場合は、ローカルで`bundle install`を実行して直接生成した後、一緒に圧縮できます。`Gemfile.lock`ファイルが含まれている場合、そのファイルに明記されたバージョンを使用してビルドされます。
 
-### Cloud Functionsコンソールでのアップロード
+<a id="upload-from-cloud-functions-console"></a>
+### Cloud Functionsコンソールでのアップロード { #upload-from-cloud-functions-console }
 - 関数を作成または修正する際に、**ユーザーローカル環境**方式を選択します。
 - **ファイルを選択**をクリックし、作成した`my-function.zip`ファイルをアップロードします。
 
-### アップロード時の注意事項
+<a id="cautions-for-upload"></a>
+### アップロード時の注意事項 { #cautions-for-upload }
 - **アップロードファイル**: `*.rb`、`Gemfile`が含まれた**ZIPファイル**をアップロードする必要があります。
   - `Gemfile.lock`ファイルは任意です。含まれている場合はそのファイルに明記されたバージョンでビルドされ、ない場合はデプロイ段階で自動的に生成されます。
 - **ZIPファイルの構造**: ZIPファイルのルートに各ファイルを配置する必要があります。
 - **ファイルサイズ**: ZIPファイルのサイズは100MiB以下に制限されます。
 
-## HTTPメソッド別の処理
+<a id="process-post-request"></a>
+## HTTPメソッド別の処理 { #process-post-request }
 
-### GETリクエストの処理
+<a id="process-get-request"></a>
+### GETリクエストの処理 { #process-get-request }
 ```ruby
 # frozen_string_literal: true
 
@@ -179,7 +197,8 @@ def handler(context)
 end
 ```
 
-### POSTリクエストの処理
+<a id="process-post-request-2"></a>
+### POSTリクエストの処理 { #process-post-request-2 }
 ```ruby
 # frozen_string_literal: true
 
@@ -214,7 +233,8 @@ def handler(context)
 end
 ```
 
-## パッケージ管理(`Gemfile`)
+<a id="manage-package-gemfile"></a>
+## パッケージ管理(`Gemfile`) { #manage-package-gemfile }
 
 依存関係(Gem)の管理には`Gemfile`を使用します。必要なGemを追加し、`bundle install`を実行して`Gemfile.lock`を生成します。
 
@@ -228,7 +248,8 @@ gem "nokogiri", "~> 1.18" # XML/HTMLパーサー
 gem "httparty", "~> 0.23" # HTTPクライアント
 ```
 
-### 外部API呼び出しの例
+<a id="example-of-external-api-call"></a>
+### 外部API呼び出しの例 { #example-of-external-api-call }
 ```ruby
 # frozen_string_literal: true
 
@@ -268,7 +289,8 @@ def handler(context)
 end
 ```
 
-## 環境変数の使用
+<a id="use-environment-variables"></a>
+## 環境変数の使用 { #use-environment-variables }
 関数に登録した環境変数は、`ENV`でアクセスできます。環境変数は、関数の作成及び修正のコード作成段階で登録します。詳細については、コンソール使用ガイドをご参照ください。
 
 ```ruby
@@ -309,7 +331,8 @@ end
     - `RUBYOPT`, `RUBYLIB`, `GEM_HOME`, `GEM_PATH`
     - プレフィックス `RUBY`
 
-## エントリーポイントの設定
+<a id="configure-entry-point"></a>
+## エントリーポイントの設定 { #configure-entry-point }
 
 エントリーポイントには関数名を使用します。
 
@@ -317,6 +340,7 @@ end
 - 関数名: `handler`
 - Entry Point: `handler`
 
-### 注意事項
+<a id="caution"></a>
+### 注意事項 { #caution }
 - **Bundlerのバージョン**: `Gemfile.lock`を作成する際には、Bundler 2.6.2以上のバージョンの使用を推奨します。
 - **ActiveSupportなど一部のGemの互換性**: `ActiveSupport`のようにC拡張(C extension)に依存したり、内部構造が複雑だったりする一部のGemは、現在のCloud Functions環境と互換性の問題が発生する可能性があります。`activesupport` Gemは内部で`zeitwerk` Gemに依存しており、このGemがファイルシステムを探索する方法が実行環境と競合し、正常に動作しない場合があります。そのため、できるだけ標準ライブラリや外部依存の少ないGemを使用することを推奨します。

--- a/ja/console-guide.md
+++ b/ja/console-guide.md
@@ -1,15 +1,21 @@
-## Compute > Cloud Functions > コンソール使用ガイド
+<!-- pre-align:aligned sig=1dc54302160b -->
+
+<a id="compute-cloud-functions-console-user-guide"></a>
+## Compute > Cloud Functions > コンソール使用ガイド { #compute-cloud-functions-console-user-guide }
 この文書では、NHN Cloud Functionsコンソールで関数を作成し、管理する方法について説明します。
 
-## 関数管理
+<a id="manage-functions"></a>
+## 関数管理 { #manage-functions }
 関数を作成、修正、削除、コピーできます。
 
-### 関数作成
+<a id="create-functions"></a>
+### 関数作成 { #create-functions }
 関数設定を行いコードを作成してビルドした後、**作成**ボタンをクリックすると、最後にビルドしたパッケージで関数が作成されます。
 
 ![console-guide-07](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-01.png)
 ![console-guide-08](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-02.png)
 
+<a id="create-functions-function-settings"></a>
 #### 関数設定
 <table class="it">
     <tr>
@@ -87,6 +93,7 @@
 <br>
 
 
+<a id="create-functions-code-writing"></a>
 #### コード作成
 
 ![console-guide-16](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn-origin/prod_cloud_functions/2026-07-14/console-guide-jp-16.png)
@@ -159,6 +166,7 @@
 > 「本ランタイムは2026年4月30日にサポートが終了しており、2026年10月31日に使用中止となる予定です。使用中止後は既存の関数の修正が不可能となるため、安定的な運用のために最新のランタイムを使用することを推奨します。」<br>
 > 使用中止となったランタイムはリストから除外され、新しい関数の作成時に選択できません。ランタイムの状態に関する詳細については、概要の「ランタイムサポート状態」をご参照ください。
 
+<a id="create-functions-environment-variable"></a>
 #### 環境変数
 関数が外部サービスの連携に必要な認証情報(APIキー、DB接続情報など)を、コードにハードコーディングせずに環境変数として分離して管理できます。
 
@@ -194,17 +202,21 @@
 > - 言語/ランタイム: `PYTHONPATH`(Python)、`NODE_OPTIONS`(Node.js)、`JAVA_TOOL_OPTIONS`・`CLASSPATH`(Java)<br>
 > - プレフィックス `LD_`、`DYLD_`、`KUBERNETES_`、`FISSION_`で始まるキーは全てブロックされます。
 
-### 関数修正
+<a id="modify-functions"></a>
+### 関数修正 { #modify-functions }
 既存の関数の設定とコードを修正するために、**修正**ボタンを クリックして 関数を修正します。
 
+<a id="modify-functions-non-modifiable-item"></a>
 #### 修正不可項目
 - 名前、ランタイム環境
     - 該当項目を除く全ての項目を修正できます。
     
+<a id="modify-functions-source-code"></a>
 #### ソースコード
 - コードエディタを使用する場合既存コードが読み込まれます。
 - ユーザーローカル環境のZIPファイルをアップロードして関数を生成した場合、コードエディタに変更するとZIPファイルを表示せず、基本テンプレートコードが読み込まれます。
 
+<a id="modify-functions-modify-function-restrictions-for-discontinued-runtimes"></a>
 #### 使用中止ランタイムにおける関数修正の制限
 - 使用中止となったランタイムを使用する関数は修正できません。
 - 関数一覧で使用中止ランタイムを使用する関数を1件選択すると、**修正**ボタンが無効になり、関数の修正画面に進むことができません。
@@ -212,30 +224,36 @@
     - 「使用中止されたランタイムで関数を修正することはできません。最新のランタイムで関数を新しく作成してください。」
 - サポート終了(使用中止前)のランタイムを使用する関数は修正可能であり、関数の作成時と同様に案内のコールアウトが表示されます。
 
-### 関数削除
+<a id="delete-a-function"></a>
+### 関数削除 { #delete-a-function }
 ![console-guide-14](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-06.png)
 既存の関数を選択して削除します。一度に複数の関数を削除可能です。
 
-### 関数コピー
+<a id="copy-a-function"></a>
+### 関数コピー { #copy-a-function }
 ![console-guide-13](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-07.png)
 既存の関数と同一の関数をコピーします。名前は重複不可のため、コピー前に新しい名前を指定できます。
 - トリガーはコピーされません。(HTTPトリガーはデフォルトで提供)
 - バージョンは現在適用されているバージョンのみコピーされます。
 - 元の関数に登録された環境変数はそのままコピーされます。
 
-## 関数情報
-### 関数リスト
+<a id="about-functions"></a>
+## 関数情報 { #about-functions }
+<a id="list-of-functions"></a>
+### 関数リスト { #list-of-functions }
 ![console-guide-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-08.png)
 - ユーザーが作成した関数リストを確認できます。
 - ビルドの状態は 現在のバージョンのビルド状態を表示します。
 - ランタイム情報の右側に、ランタイムのサポート状態(サポート終了/使用中止)のバッジが表示されます。
 
-### 関数基本情報
+<a id="basic-information-of-functions"></a>
+### 関数基本情報 { #basic-information-of-functions }
 ![console-guide-19](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn-origin/prod_cloud_functions/2026-07-14/console-guide-jp-19.png)
 - 関数の基本情報を確認できます。
 - ログ管理項目で **Log & Crash Search** ボタンをクリックし、Log & Crash Searchサービスへ移動してログを確認できます。
 
-### 関数の環境変数
+<a id="function-environment-variables"></a>
+### 関数の環境変数 { #function-environment-variables }
 関数の詳細情報の環境変数タブで、該当する関数に登録された環境変数の一覧を確認できます。
 
 ![console-guide-20](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn-origin/prod_cloud_functions/2026-07-14/console-guide-jp-20.png)
@@ -260,17 +278,20 @@
 
 - 環境変数の登録/修正/削除は、関数の作成及び修正のコード作成段階で行うことができます。詳細については、関数の作成 > 環境変数をご参照ください。
 
-### 関数バージョン管理
+<a id="function-versioning"></a>
+### 関数バージョン管理 { #function-versioning }
 ![console-guide-15](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2026-01-27/console-guide-jp-15.png)
 - 関数のバージョンを管理できます。
 - 作成された全てのバージョンの履歴を確認し、以前のバージョンにロールバックできます。
 
+<a id="function-versioning-versioning-overview"></a>
 #### バージョン管理の概要
 関数作成/修正画面で **ビルド** ボタンをクリックし、コードをビルドするとパッケージが作成されます。
 - 関数の作成/修正時に最後にビルドしたパッケージが関数バージョンとして連携されます。
 - 各バージョンは独立して管理され、テストしたバージョンをそのまま関数に適用できます。
 - 関数作成時、少なくとも1回以上ビルドを実行する必要があります。
 
+<a id="function-versioning-version-information"></a>
 #### バージョン情報
 <table class="it">
     <tr>
@@ -300,6 +321,7 @@
     </tr>
 </table>
 
+<a id="function-versioning-deploy-versions"></a>
 #### バージョン配布
 - バージョンリストから配布するバージョンを選択し、**バージョン配布**ボタンをクリックすると、該当バージョンで関数が更新されます。
 - 現在適用されているバージョンは選択できません。
@@ -308,6 +330,7 @@
 
 > **[参考]**
 > <br>バージョン配布時に確認ポップアップが表示され、成功するとバージョンリストが自動的に更新されます。
+<a id="function-versioning-delete-versions"></a>
 #### バージョン削除
 - バージョンリストから削除するバージョンを選択し、**バージョン削除**ボタンをクリックすると、該当バージョンが削除されます。
 - 現在適用されているバージョンは削除できません。
@@ -316,13 +339,15 @@
 
 > **[参考]**
 > <br>バージョン削除時に確認ポップアップが表示され、削除されたバージョンは復元できません。
+<a id="function-versioning-constraints"></a>
 #### 制約事項
 - 関数作成/修正画面でビルドしたパッケージは、関数の作成/修正をキャンセルすると関数バージョンとして連携されません。
 - 関数削除時、該当関数と連携された全てのバージョンも一緒に削除されます。
 - 関数コピー時、元の関数の現在適用されているバージョンのみコピーされ、全てのバージョン履歴はコピーされません。
 - 関数作成時には複数のランタイムでビルドできますが、関数修正時には作成時に選択したランタイムでのみビルドできます。
 
-### 関数トリガー管理
+<a id="manage-function-triggers"></a>
+### 関数トリガー管理 { #manage-function-triggers }
 - 関数を実行できるトリガーを管理できます。
 - HTTPトリガーは関数の作成時にデフォルトで提供されます。
     - 有効化/無効化により、使用するかどうかを設定できます。
@@ -333,16 +358,19 @@
     - 例: `https://{userdomain}/{関数名}`
     - Method : GET, POST
 
+<a id="manage-function-triggers-createedit-triggers"></a>
 #### トリガー作成/修正
 - Timer
     - Value: Cron文字列で周期を入力します。
 - API Gateway
     - API Gatewayサービスを利用してHTTPエンドポイントを追加できます。
         
+<a id="manage-function-triggers-delete-triggers"></a>
 #### トリガー削除
 - 複数のトリガーを選択して削除できます。デフォルトのトリガーであるHTTPトリガーは削除できません。
 
-### 関数モニタリング
+<a id="monitor-functions"></a>
+### 関数モニタリング { #monitor-functions }
 ![console-guide-06](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/console-guide-jp-11.png)
 - 関数の使用量を確認できます。
 - 関数呼び出し回数、呼び出し拒否数、エラー発生回数、成功率、関数実行時間指標を提供します。

--- a/ja/overview.md
+++ b/ja/overview.md
@@ -1,7 +1,11 @@
-## Compute > Cloud Functions > 概要
+<!-- pre-align:aligned sig=1cb57d0b02b5 -->
+
+<a id="compute-cloud-functions-overview"></a>
+## Compute > Cloud Functions > 概要 { #compute-cloud-functions-overview }
 ユーザーは関数単位でコードを作成でき、特定のイベントが発生した際に定義された関数が自動で実行され、必要な処理を行います。サーバー管理やインフラ設定を行うことなく、アプリケーションロジックに専念することができます。
 
-### 特徴
+<a id="features"></a>
+### 特徴 { #features }
 - コスト効率性
     - 使用した分だけ課金するため、コストを削減できます。
     - 必要な時にのみリソースを割り当てるため、管理コストを削減できます。
@@ -13,15 +17,18 @@
     - 様々な言語とランタイムをサポートします。
     - イベントベースのアーキテクチャにより、多様な活用が可能です。
 
-### 主な機能
+<a id="main-features"></a>
+### 主な機能 { #main-features }
 - 様々な言語(環境)を提供します。
 - **コードエディタ**を使用して、簡単な関数単位コードを作成できます。
 - 関数を実行できるHTTPSエンドポイントを標準で提供します。
 - 関数を一定間隔で繰り返し実行できます。
 
-### 2つのモードを提供
+<a id="two-modes-available"></a>
+### 2つのモードを提供 { #two-modes-available }
 - Pool Manager
 - New Deployment
+<a id="two-modes-available-pool-manager"></a>
 #### Pool Manager
 - 関数が実行される際にのみインスタンスが作成され、リソースを使用します。
 - 一定期間関数が実行されない場合、インスタンスは消滅し、リソース使用量は0になります。
@@ -29,6 +36,7 @@
 
 ![overview-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_1_ja.png)
 
+<a id="two-modes-available-new-deployment"></a>
 #### New Deployment
 - 関数を作成すると、すぐにインスタンスが作成され、一定量のリソースを継続して使用します。
 - 高速な応答のためにインスタンス作成を維持します。
@@ -36,7 +44,8 @@
 
 ![overview-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_2_ja.png)
 
-### サポート言語
+<a id="supported-languages"></a>
+### サポート言語 { #supported-languages }
 
 | 言語     | バージョン                | サポート終了日   | 利用終了日   |
 |--------|-------------------|------------|------------|
@@ -57,6 +66,7 @@
 | .NET   | 8                 | 2026-11-10 | 2027-11-10 |
 |        | 7(利用停止)         | 2024-05-14 | 2025-05-14 |
 
+<a id="supported-languages-runtime-support-status"></a>
 #### ランタイムのサポート状態
 各ランタイムはEOL(end of life)ポリシーに従い、以下の3つの状態に分類されます。
 
@@ -71,7 +81,8 @@
 
 ランタイムの状態は関数一覧と詳細情報、関数の作成/修正画面で確認できます。詳細な動作については、コンソール使用ガイドをご参照ください。
 
-### Trigger
+<a id="trigger"></a>
+### Trigger { #trigger }
 - HTTP Trigger
     - 基本提供(GET、POSTサポート)
 - Timer Trigger

--- a/ja/release-notes.md
+++ b/ja/release-notes.md
@@ -1,7 +1,12 @@
-## Compute > Cloud Functions > リリースノート
+<!-- pre-align:aligned sig=a0129d78150c -->
 
-### 2026. 07. 14.
+<a id="compute-cloud-functions-release-notes"></a>
+## Compute > Cloud Functions > リリースノート { #compute-cloud-functions-release-notes }
 
+<a id="july-14-2026"></a>
+### 2026. 07. 14. { #july-14-2026 }
+
+<a id="july-14-2026-added-features"></a>
 #### 機能の追加
 - 環境変数機能の追加
   - 関数に環境変数を設定し、コードと設定を分離できます。
@@ -10,24 +15,31 @@
   - 関数一覧と詳細情報に、ランタイムのサポート終了/使用中止状態を表示します。
   - 関数の作成/修正時にサポート終了のランタイムを案内し、使用中止のランタイムの選択及び修正を制限します。
 
-### 2026. 04. 14.
+<a id="april-14-2026"></a>
+### 2026. 04. 14. { #april-14-2026 }
 
+<a id="april-14-2026-added-features"></a>
 #### 機能追加
 - Public API v1.0追加
   - APIでCloud Functionsを利用できます。
   
-### 2026. 01. 27.
+<a id="january-27-2026"></a>
+### 2026. 01. 27. { #january-27-2026 }
 
+<a id="january-27-2026-added-features"></a>
 #### 機能追加
 - 関数バージョン管理機能の追加
   - ビルドしたパッケージをバージョンとして管理し、以前のバージョンにロールバックできます。
     
-### 2025. 11. 25.
+<a id="november-25-2025"></a>
+### 2025. 11. 25. { #november-25-2025 }
 
+<a id="november-25-2025-added-features"></a>
 #### 機能追加
 - API Gatewayトリガーの追加
   - 同一プロジェクトのAPI Gatewayサービスを活用してAPI Gatewayトリガーを作成できます。
 
+<a id="november-25-2025-feature-updates"></a>
 #### 機能改善
 - ランタイム環境の最新バージョンの追加及び一部バージョンの使用中止
   - Go 1.24、1.25の追加
@@ -36,7 +48,9 @@
   - Ruby 2.6.1の使用中止、Ruby 3.4.5の追加
   - .NET 7の使用中止、.NET 8の追加
     
-### 2025. 07. 29.
+<a id="july-29-2025"></a>
+### 2025. 07. 29. { #july-29-2025 }
 
+<a id="july-29-2025-launch-cloud-functions-service"></a>
 #### Cloud Functionsサービスリリース
 - ユーザーは関数単位でコードを作成でき、特定のイベントが発生した際に定義された関数が自動で実行され、必要な処理を行います。サーバー管理やインフラ設定を行うことなく、アプリケーションロジックに専念することができます。

--- a/ja/trigger-guide.md
+++ b/ja/trigger-guide.md
@@ -1,12 +1,17 @@
-## Compute > Cloud Functions > トリガーガイド
+<!-- pre-align:aligned sig=1dfb7cf11d02 -->
+
+<a id="compute-cloud-functions-trigger-guide"></a>
+## Compute > Cloud Functions > トリガーガイド { #compute-cloud-functions-trigger-guide }
 
 このドキュメントでは、Cloud Functionsで提供するトリガーの種類と設定方法について説明します。
 
-## トリガーの概要
+<a id="trigger-overview"></a>
+## トリガーの概要 { #trigger-overview }
 
 トリガーは関数を実行させるイベントソースです。Cloud Functionsは様々な種類のトリガーを提供しており、複数の方法で関数を呼び出すことができます。
 
-### サポートするトリガーの種類
+<a id="supported-triggers"></a>
+### サポートするトリガーの種類 { #supported-triggers }
 
 | トリガーの種類      | 説明                      | デフォルト提供 |
 |-------------|------------------------|-------|
@@ -14,30 +19,36 @@
 | Timer       | 指定された時間または周期に従って関数を実行 | X      |
 | API Gateway | API Gatewayを通じて関数を実行  | X      |
 
-## HTTPトリガー
+<a id="http-trigger"></a>
+## HTTPトリガー { #http-trigger }
 
 HTTPトリガーは関数の作成時にデフォルトで提供され、HTTPリクエストを通じて関数を実行できます。
 
-### 特徴
+<a id="features"></a>
+### 特徴 { #features }
 
 - 関数の作成時に自動的に生成されます。
 - 削除することはできず、有効化/無効化のみ可能です。
 - GET, POSTメソッドをサポートします。
 
-### HTTPトリガーURL形式
+<a id="url-format-of-http-trigger"></a>
+### HTTPトリガーURL形式 { #url-format-of-http-trigger }
 
 ```
 https://{userdomain}/{関数名}
 ```
 
-### 使用例
+<a id="examples"></a>
+### 使用例 { #examples }
 
+<a id="examples-request-get"></a>
 #### GETリクエスト
 
 ```bash
 curl -X GET "https://{userdomain}/{関数名}?param1=value1&param2=value2"
 ```
 
+<a id="examples-request-post"></a>
 #### POSTリクエスト
 
 ```bash
@@ -46,7 +57,8 @@ curl -X POST "https://{userdomain}/{関数名}" \
   -d '{"key": "value"}'
 ```
 
-### HTTPトリガーの有効化/無効化
+<a id="enabledisable-http-trigger"></a>
+### HTTPトリガーの有効化/無効化 { #enabledisable-http-trigger }
 
 1. Cloud Functionsコンソールで関数を選択します。
 2. **トリガー**タブに移動します。
@@ -55,11 +67,13 @@ curl -X POST "https://{userdomain}/{関数名}" \
 > **[参考]**
 > <br>無効化されたHTTPトリガーにリクエストを送信しても、関数は実行されません。
 
-## Timerトリガー
+<a id="timer-trigger"></a>
+## Timerトリガー { #timer-trigger }
 
 Timerトリガーは、指定された時間または周期に従って自動的に関数を実行します。Cron式を使用して実行周期を設定できます。
 
-### Timerトリガーの作成
+<a id="create-timer-trigger"></a>
+### Timerトリガーの作成 { #create-timer-trigger }
 
 ![trigger-guide-05](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-01.png)
 
@@ -70,7 +84,8 @@ Timerトリガーは、指定された時間または周期に従って自動的
 5. **Value**にCron式を入力します。
 6. **作成**をクリックします。
 
-### Cron式の形式
+<a id="cron-expression-format"></a>
+### Cron式の形式 { #cron-expression-format }
 
 Cron式は次のような形式に従います。
 
@@ -85,6 +100,7 @@ Cron式は次のような形式に従います。
 └─────────── 秒 (0-59)
 ```
 
+<a id="cron-expression-format-cron-expression-field"></a>
 #### Cron式のフィールド
 
 | フィールド              | 必須  | 許容値             | 許容される記号  |
@@ -96,6 +112,7 @@ Cron式は次のような形式に従います。
 | 月(Month)         | Yes | 1-12 または JAN-DEC | * / , -    |
 | 曜日(Day of week) | Yes | 0-6 または SUN-SAT  | * / , - ? |
 
+<a id="cron-expression-format-special-characters-details"></a>
 #### 記号の説明
 
 `*`
@@ -118,7 +135,8 @@ Cron式は次のような形式に従います。
 
 日(Day of month)または曜日(Day of week)フィールドを空けておくために、`*`の代わりに使用できます。
 
-### Cron式の例
+<a id="example-of-cron-expression"></a>
+### Cron式の例 { #example-of-cron-expression }
 
 | Cron式              | 説明                             |
 |------------------------|---------------------------------|
@@ -132,7 +150,8 @@ Cron式は次のような形式に従います。
 | `30 0 12 * * *`        | 毎日午後12時0分30秒に実行             |
 | `0 0 0 1 JAN *`        | 毎年1月1日の午前0時に実行                  |
 
-### Timerトリガーの修正
+<a id="modify-timer-trigger"></a>
+### Timerトリガーの修正 { #modify-timer-trigger }
 
 ![trigger-guide-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-02.png)
 
@@ -146,16 +165,19 @@ Cron式は次のような形式に従います。
 > **[参考]**
 > <br>月(Month)と曜日(Day of week)フィールドの値は、大文字と小文字を区別しません。"SUN"、"Sun"、"sun"は全て同じものとして認識されます。
 
-## API Gatewayトリガー
+<a id="api-gateway-trigger"></a>
+## API Gatewayトリガー { #api-gateway-trigger }
 
 API Gatewayトリガーは、同一プロジェクトのAPI Gatewayサービスを活用して関数を実行できます。API Gatewayを通じて、よりきめ細かいAPI管理と制御が可能になります。
 
-### 事前要件
+<a id="prerequisites"></a>
+### 事前要件 { #prerequisites }
 
 - 同一プロジェクトでAPI Gatewayサービスが有効になっている必要があります。
   - 有効になっていない場合、トリガー作成時に有効化できます。
 
-### API Gatewayトリガーの作成
+<a id="create-api-gateway-trigger"></a>
+### API Gatewayトリガーの作成 { #create-api-gateway-trigger }
 
 ![trigger-guide-04](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-04.png)
 
@@ -167,20 +189,24 @@ API Gatewayトリガーは、同一プロジェクトのAPI Gatewayサービス�
    * 重複するパスは使用できません。
 6. **作成**をクリックします。
 
-### API GatewayトリガーURL形式
+<a id="api-gateway-trigger-url-format"></a>
+### API GatewayトリガーURL形式 { #api-gateway-trigger-url-format }
 
 ```
 https://{stageurl}/{パス}
 ```
 
-### 使用例
+<a id="api-gateway-trigger-examples"></a>
+### 使用例 { #api-gateway-trigger-examples }
 
+<a id="api-gateway-trigger-examples-request-get"></a>
 #### GETリクエスト
 
 ```bash
 curl -X GET "https://{stageurl}/{パス}?param1=value1&param2=value2"
 ```
 
+<a id="api-gateway-trigger-examples-request-post"></a>
 #### POSTリクエスト
 
 ```bash
@@ -189,7 +215,8 @@ curl -X POST "https://{stageurl}/{パス}" \
   -d '{"key": "value"}'
 ```
 
-### API Gatewayトリガーの特徴
+<a id="features-of-api-gateway-trigger"></a>
+### API Gatewayトリガーの特徴 { #features-of-api-gateway-trigger }
 
 - API Gatewayの様々な機能を活用できます。
   - 認証及び権限管理
@@ -200,7 +227,8 @@ curl -X POST "https://{stageurl}/{パス}" \
 - 自動的に生成された1つのサービスでのみ関数連携が可能です。
 - HTTPトリガーと同様にGET,POSTメソッドをサポートします。
 
-### API Gatewayトリガーの修正
+<a id="modify-api-gateway-trigger"></a>
+### API Gatewayトリガーの修正 { #modify-api-gateway-trigger }
 
 ![trigger-guide-05](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-05.png)
 
@@ -216,15 +244,18 @@ curl -X POST "https://{stageurl}/{パス}" \
 > <br>これにより、そのリソースに適用されたプラグインが全て削除されます。
 > <br>プラグインが適用されたリソースパスを変更する場合は、修正の代わりに新しいトリガーを追加することを推奨します。
 
-### API Gatewayと併用する
+<a id="use-with-api-gateway"></a>
+### API Gatewayと併用する { #use-with-api-gateway }
 
 API Gatewayトリガーを作成すると、API Gatewayコンソールで追加設定を行えます。
 
 詳細は[API Gatewayガイド](https://docs.nhncloud.com/ko/Application%20Service/API%20Gateway/ko/overview/)を参照してください。
 
-## トリガーの削除
+<a id="delete-trigger"></a>
+## トリガーの削除 { #delete-trigger }
 
-### トリガーの削除方法
+<a id="how-to-delete-trigger"></a>
+### トリガーの削除方法 { #how-to-delete-trigger }
 
 ![trigger-guide-03](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-03.png)
 
@@ -234,15 +265,18 @@ API Gatewayトリガーを作成すると、API Gatewayコンソールで追加�
 4. **トリガー削除**をクリックします。
 5. **トリガー削除**モーダルウィンドウで**削除**をクリックします。
 
-### 注意事項
+<a id="cautions"></a>
+### 注意事項 { #cautions }
 
 - HTTPトリガーは削除できません。HTTPトリガーは基本トリガーとして提供され、有効化/無効化のみ可能です。
 - トリガーを削除すると、そのイベントを通じて関数を実行できなくなります。
 - 削除されたトリガーは復元できません。
 
-## トリガーの制限事項
+<a id="restrictions"></a>
+## トリガーの制限事項 { #restrictions }
 
-### API Gatewayトリガーの制限事項
+<a id="restrictions-for-api-gateway-trigger"></a>
+### API Gatewayトリガーの制限事項 { #restrictions-for-api-gateway-trigger }
 
 - 同一プロジェクト内のAPI Gatewayのみ接続できます。
 - 1つのAPI Gatewayリソースには、1つの関数のみ接続できます。

--- a/ko/api-guide-v1-0.md
+++ b/ko/api-guide-v1-0.md
@@ -1,10 +1,15 @@
-## Cloud Functions API v1.0 가이드
+<!-- pre-align:aligned sig=fb47c311eeaa -->
+
+<a id="cloud-functions-api-v10-guide"></a>
+## Cloud Functions API v1.0 가이드 { #cloud-functions-api-v10-guide }
 
 **Compute > Cloud Functions > API 가이드 > API v1.0 가이드**
 
-## Cloud Functions API v1.0 공통 정보
+<a id="cloud-functions-api-v10-common-information"></a>
+## Cloud Functions API v1.0 공통 정보 { #cloud-functions-api-v10-common-information }
 
-### API 엔드포인트
+<a id="api-endpoint"></a>
+### API 엔드포인트 { #api-endpoint }
 
 Cloud Functions API를 호출하기 위한 리전별 엔드포인트는 다음과 같습니다.
 
@@ -12,13 +17,15 @@ Cloud Functions API를 호출하기 위한 리전별 엔드포인트는 다음�
 | --- |-----------------------------------------------------|
 | 한국(판교) 리전 | https://kr1-cloud-functions.api.nhncloudservice.com |
 
-### 인증 및 권한
+<a id="authentication-and-authorization"></a>
+### 인증 및 권한 { #authentication-and-authorization }
 
 Cloud Functions는 API 호출 시 인증/인가를 위해 User Access Key 토큰을 사용합니다.
 User Access Key 토큰은 User Access Key를 기반으로 발급되는 Bearer 타입의 일시적 액세스 토큰입니다.
 User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Access Key 토큰](/nhncloud/ko/public-api/user-access-key-token)을 참고하세요.
 
-### 응답 공통 정보
+<a id="response-common-information"></a>
+### 응답 공통 정보 { #response-common-information }
 
 모든 API 응답은 다음과 같은 공통 형식을 따릅니다.
 
@@ -64,7 +71,8 @@ User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Acc
 | header.resultMessage | String | 결과 메시지 |
 | data | Object | 응답 데이터(API별 상이) |
 
-### 런타임 EOL 상태 공통 필드
+<a id="runtime-eol-status-common-fields"></a>
+### 런타임 EOL 상태 공통 필드 { #runtime-eol-status-common-fields }
 
 함수 및 환경 목록 조회 응답에는 런타임의 EOL(end of life) 상태 정보가 포함됩니다.
 
@@ -79,28 +87,33 @@ User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Acc
 
 ---
 
-## 환경 목록 조회
+<a id="list-environments"></a>
+## 환경 목록 조회 { #list-environments }
 
 사용 가능한 런타임 환경 목록을 조회합니다.
 
-### 요청
+<a id="request"></a>
+### 요청 { #request }
 
 ```
 GET /v1.0/env/list
 ```
 
-### 요청 파라미터
+<a id="request-parameter"></a>
+### 요청 파라미터 { #request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
 | X-NHN-appkey | Header | String | Y | 앱키 |
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 
-### 요청 본문
+<a id="request-body"></a>
+### 요청 본문 { #request-body }
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-### 응답
+<a id="response"></a>
+### 응답 { #response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -150,17 +163,20 @@ GET /v1.0/env/list
 
 ---
 
-## 함수 목록 조회
+<a id="list-functions"></a>
+## 함수 목록 조회 { #list-functions }
 
 함수 목록을 조회합니다.
 
-### 요청
+<a id="list-functions-request"></a>
+### 요청 { #list-functions-request }
 
 ```
 GET /v1.0/functions
 ```
 
-### 요청 파라미터
+<a id="list-functions-request-parameter"></a>
+### 요청 파라미터 { #list-functions-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -169,11 +185,13 @@ GET /v1.0/functions
 | page | Query | Integer | N | 현재 페이지(기본값: 0) |
 | pageSize | Query | Integer | N | 한 페이지에 노출될 개수 |
 
-### 요청 본문
+<a id="list-functions-request-body"></a>
+### 요청 본문 { #list-functions-request-body }
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-### 응답
+<a id="list-functions-response"></a>
+### 응답 { #list-functions-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -228,17 +246,20 @@ GET /v1.0/functions
 
 ---
 
-## 함수 상세 조회
+<a id="get-function"></a>
+## 함수 상세 조회 { #get-function }
 
 함수의 상세 정보와 빌드 로그를 함께 조회합니다.
 
-### 요청
+<a id="get-function-request"></a>
+### 요청 { #get-function-request }
 
 ```
 GET /v1.0/functions/{functionName}
 ```
 
-### 요청 파라미터
+<a id="get-function-request-parameter"></a>
+### 요청 파라미터 { #get-function-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -246,11 +267,13 @@ GET /v1.0/functions/{functionName}
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 함수 이름 |
 
-### 요청 본문
+<a id="get-function-request-body"></a>
+### 요청 본문 { #get-function-request-body }
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-### 응답
+<a id="get-function-response"></a>
+### 응답 { #get-function-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -319,7 +342,8 @@ GET /v1.0/functions/{functionName}
 
 ---
 
-## 함수 생성
+<a id="create-function"></a>
+## 함수 생성 { #create-function }
 
 새 함수를 생성합니다. multipart/form-data로 소스 파일을 업로드합니다.
 `runtime`은 `{environment}-{version}` 형식으로 입력해야 합니다(예: NodeJS-22.5.0). 사용 가능한 런타임은 환경 목록 조회 API로 확인할 수 있습니다.
@@ -328,20 +352,23 @@ GET /v1.0/functions/{functionName}
 
 환경 변수는 `envVars` 필드에 JSON 문자열로 전달합니다. 함수당 최대 100개, 키는 `^[A-Za-z_][A-Za-z0-9_]*$`(최대 128자, 중복 불가), 값은 최대 4,096자이며, 보안상 예약된 키는 등록할 수 없습니다. 잘못된 JSON이면 실패 응답을 반환합니다.
 
-### 요청
+<a id="create-function-request"></a>
+### 요청 { #create-function-request }
 
 ```
 POST /v1.0/functions
 ```
 
-### 요청 파라미터
+<a id="create-function-request-parameter"></a>
+### 요청 파라미터 { #create-function-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
 | X-NHN-appkey | Header | String | Y | 앱키 |
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 
-### 요청 본문
+<a id="create-function-request-body"></a>
+### 요청 본문 { #create-function-request-body }
 
 Content-Type: multipart/form-data
 
@@ -361,7 +388,8 @@ Content-Type: multipart/form-data
 | envVars | String | N          | 환경 변수(JSON 문자열, 예: `{"DB_HOST":"10.0.0.1"}`). 미지정 시 환경 변수 없음. 잘못된 JSON이면 실패 응답 |
 | sourceFile | Binary | Y          | 소스 코드 파일(ZIP)                                                                                     |
 
-### 응답
+<a id="create-function-response"></a>
+### 응답 { #create-function-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -381,7 +409,8 @@ Content-Type: multipart/form-data
 
 ---
 
-## 함수 수정
+<a id="modify-function"></a>
+## 함수 수정 { #modify-function }
 
 함수를 수정합니다. multipart/form-data로 소스 파일을 업로드할 수 있습니다.
 
@@ -391,13 +420,15 @@ Content-Type: multipart/form-data
 
 사용 중단(`DISCONTINUED`)된 런타임을 사용하는 함수는 수정할 수 없습니다. 요청 시 실패 응답(`header.isSuccessful`이 `false`)과 함께 "사용 중단된 런타임으로 함수를 수정할 수 없습니다. 최신 런타임으로 함수를 새로 생성해주세요." 메시지가 반환됩니다.
 
-### 요청
+<a id="modify-function-request"></a>
+### 요청 { #modify-function-request }
 
 ```
 PUT /v1.0/functions/{functionName}
 ```
 
-### 요청 파라미터
+<a id="modify-function-request-parameter"></a>
+### 요청 파라미터 { #modify-function-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -405,7 +436,8 @@ PUT /v1.0/functions/{functionName}
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 수정할 함수 이름 |
 
-### 요청 본문
+<a id="modify-function-request-body"></a>
+### 요청 본문 { #modify-function-request-body }
 
 Content-Type: multipart/form-data
 
@@ -424,7 +456,8 @@ Content-Type: multipart/form-data
 | envVars | String | N          | 환경 변수(JSON 문자열). 미지정 시 기존 유지, `"{}"`이면 전체 삭제, 값이 있으면 전체 교체. 잘못된 JSON이면 실패 응답 |
 | sourceFile | Binary | N          | 소스 코드 파일(ZIP)                                                                                     |
 
-### 응답
+<a id="modify-function-response"></a>
+### 응답 { #modify-function-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -444,24 +477,28 @@ Content-Type: multipart/form-data
 
 ---
 
-## 함수 삭제
+<a id="delete-functions"></a>
+## 함수 삭제 { #delete-functions }
 
 함수를 일괄 삭제합니다.
 
-### 요청
+<a id="delete-functions-request"></a>
+### 요청 { #delete-functions-request }
 
 ```
 DELETE /v1.0/functions
 ```
 
-### 요청 파라미터
+<a id="delete-functions-request-parameter"></a>
+### 요청 파라미터 { #delete-functions-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
 | X-NHN-appkey | Header | String | Y | 앱키 |
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 
-### 요청 본문
+<a id="delete-functions-request-body"></a>
+### 요청 본문 { #delete-functions-request-body }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -478,7 +515,8 @@ DELETE /v1.0/functions
 | --- | --- | --- | --- |
 | names | Array | Y | 삭제할 함수 이름 목록 |
 
-### 응답
+<a id="delete-functions-response"></a>
+### 응답 { #delete-functions-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -498,17 +536,20 @@ DELETE /v1.0/functions
 
 ---
 
-## 함수 실행(GET)
+<a id="execute-function-get"></a>
+## 함수 실행(GET) { #execute-function-get }
 
 GET 방식으로 함수를 실행합니다.
 
-### 요청
+<a id="execute-function-get-request"></a>
+### 요청 { #execute-function-get-request }
 
 ```
 GET /v1.0/functions/{functionName}/invoke
 ```
 
-### 요청 파라미터
+<a id="execute-function-get-request-parameter"></a>
+### 요청 파라미터 { #execute-function-get-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -516,11 +557,13 @@ GET /v1.0/functions/{functionName}/invoke
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 실행할 함수 이름 |
 
-### 요청 본문
+<a id="execute-function-get-request-body"></a>
+### 요청 본문 { #execute-function-get-request-body }
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-### 응답
+<a id="execute-function-get-response"></a>
+### 응답 { #execute-function-get-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -544,17 +587,20 @@ GET /v1.0/functions/{functionName}/invoke
 
 ---
 
-## 함수 실행(POST)
+<a id="execute-function-post"></a>
+## 함수 실행(POST) { #execute-function-post }
 
 POST 방식으로 함수를 실행합니다. body를 전달할 수 있습니다.
 
-### 요청
+<a id="execute-function-post-request"></a>
+### 요청 { #execute-function-post-request }
 
 ```
 POST /v1.0/functions/{functionName}/invoke
 ```
 
-### 요청 파라미터
+<a id="execute-function-post-request-parameter"></a>
+### 요청 파라미터 { #execute-function-post-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -562,7 +608,8 @@ POST /v1.0/functions/{functionName}/invoke
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 실행할 함수 이름 |
 
-### 요청 본문
+<a id="execute-function-post-request-body"></a>
+### 요청 본문 { #execute-function-post-request-body }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -579,7 +626,8 @@ POST /v1.0/functions/{functionName}/invoke
 | --- |------| --- | --- |
 | body | JSON | N | 함수에 전달할 body |
 
-### 응답
+<a id="execute-function-post-response"></a>
+### 응답 { #execute-function-post-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -603,17 +651,20 @@ POST /v1.0/functions/{functionName}/invoke
 
 ---
 
-## 버전 목록 조회
+<a id="list-versions"></a>
+## 버전 목록 조회 { #list-versions }
 
 함수의 버전(패키지) 목록을 조회합니다.
 
-### 요청
+<a id="list-versions-request"></a>
+### 요청 { #list-versions-request }
 
 ```
 GET /v1.0/functions/{functionName}/versions
 ```
 
-### 요청 파라미터
+<a id="list-versions-request-parameter"></a>
+### 요청 파라미터 { #list-versions-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -621,11 +672,13 @@ GET /v1.0/functions/{functionName}/versions
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 함수 이름 |
 
-### 요청 본문
+<a id="list-versions-request-body"></a>
+### 요청 본문 { #list-versions-request-body }
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-### 응답
+<a id="list-versions-response"></a>
+### 응답 { #list-versions-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -672,17 +725,20 @@ GET /v1.0/functions/{functionName}/versions
 
 ---
 
-## 버전 전환
+<a id="switch-version"></a>
+## 버전 전환 { #switch-version }
 
 함수의 현재 활성 버전을 변경합니다.
 
-### 요청
+<a id="switch-version-request"></a>
+### 요청 { #switch-version-request }
 
 ```
 PUT /v1.0/functions/{functionName}/versions
 ```
 
-### 요청 파라미터
+<a id="switch-version-request-parameter"></a>
+### 요청 파라미터 { #switch-version-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -690,7 +746,8 @@ PUT /v1.0/functions/{functionName}/versions
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 함수 이름 |
 
-### 요청 본문
+<a id="switch-version-request-body"></a>
+### 요청 본문 { #switch-version-request-body }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -707,7 +764,8 @@ PUT /v1.0/functions/{functionName}/versions
 | --- | --- | --- | --- |
 | versionId | Integer | Y | 전환할 버전 ID |
 
-### 응답
+<a id="switch-version-response"></a>
+### 응답 { #switch-version-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -727,19 +785,22 @@ PUT /v1.0/functions/{functionName}/versions
 
 ---
 
-## 버전 삭제
+<a id="delete-versions"></a>
+## 버전 삭제 { #delete-versions }
 
 함수의 버전을 일괄 삭제합니다.
 
 현재 활성 버전은 삭제할 수 없습니다.
 
-### 요청
+<a id="delete-versions-request"></a>
+### 요청 { #delete-versions-request }
 
 ```
 DELETE /v1.0/functions/{functionName}/versions
 ```
 
-### 요청 파라미터
+<a id="delete-versions-request-parameter"></a>
+### 요청 파라미터 { #delete-versions-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -747,7 +808,8 @@ DELETE /v1.0/functions/{functionName}/versions
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 함수 이름 |
 
-### 요청 본문
+<a id="delete-versions-request-body"></a>
+### 요청 본문 { #delete-versions-request-body }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -764,7 +826,8 @@ DELETE /v1.0/functions/{functionName}/versions
 | --- | --- | --- | --- |
 | versionIds | Array | Y | 삭제할 버전 ID 목록 |
 
-### 응답
+<a id="delete-versions-response"></a>
+### 응답 { #delete-versions-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -784,17 +847,20 @@ DELETE /v1.0/functions/{functionName}/versions
 
 ---
 
-## 트리거 목록 조회
+<a id="list-triggers"></a>
+## 트리거 목록 조회 { #list-triggers }
 
 함수의 트리거 목록을 조회합니다.
 
-### 요청
+<a id="list-triggers-request"></a>
+### 요청 { #list-triggers-request }
 
 ```
 GET /v1.0/triggers/{functionName}
 ```
 
-### 요청 파라미터
+<a id="list-triggers-request-parameter"></a>
+### 요청 파라미터 { #list-triggers-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -802,11 +868,13 @@ GET /v1.0/triggers/{functionName}
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 함수 이름 |
 
-### 요청 본문
+<a id="list-triggers-request-body"></a>
+### 요청 본문 { #list-triggers-request-body }
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-### 응답
+<a id="list-triggers-response"></a>
+### 응답 { #list-triggers-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -847,17 +915,20 @@ GET /v1.0/triggers/{functionName}
 
 ---
 
-## 타임 트리거 생성
+<a id="create-time-trigger"></a>
+## 타임 트리거 생성 { #create-time-trigger }
 
 함수에 타임 트리거를 생성합니다.
 
-### 요청
+<a id="create-time-trigger-request"></a>
+### 요청 { #create-time-trigger-request }
 
 ```
 POST /v1.0/triggers/{functionName}/time
 ```
 
-### 요청 파라미터
+<a id="create-time-trigger-request-parameter"></a>
+### 요청 파라미터 { #create-time-trigger-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -865,7 +936,8 @@ POST /v1.0/triggers/{functionName}/time
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 함수 이름 |
 
-### 요청 본문
+<a id="create-time-trigger-request-body"></a>
+### 요청 본문 { #create-time-trigger-request-body }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -882,7 +954,8 @@ POST /v1.0/triggers/{functionName}/time
 | --- | --- | --- | --- |
 | cron | String | Y | cron 표현식 |
 
-### 응답
+<a id="create-time-trigger-response"></a>
+### 응답 { #create-time-trigger-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -902,17 +975,20 @@ POST /v1.0/triggers/{functionName}/time
 
 ---
 
-## 타임 트리거 수정
+<a id="modify-time-trigger"></a>
+## 타임 트리거 수정 { #modify-time-trigger }
 
 타임 트리거의 cron 표현식을 수정합니다.
 
-### 요청
+<a id="modify-time-trigger-request"></a>
+### 요청 { #modify-time-trigger-request }
 
 ```
 PUT /v1.0/triggers/{functionName}/time
 ```
 
-### 요청 파라미터
+<a id="modify-time-trigger-request-parameter"></a>
+### 요청 파라미터 { #modify-time-trigger-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -920,7 +996,8 @@ PUT /v1.0/triggers/{functionName}/time
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 함수 이름 |
 
-### 요청 본문
+<a id="modify-time-trigger-request-body"></a>
+### 요청 본문 { #modify-time-trigger-request-body }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -939,7 +1016,8 @@ PUT /v1.0/triggers/{functionName}/time
 | name | String | Y | 트리거 이름 |
 | cron | String | Y | cron 표현식 |
 
-### 응답
+<a id="modify-time-trigger-response"></a>
+### 응답 { #modify-time-trigger-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -959,17 +1037,20 @@ PUT /v1.0/triggers/{functionName}/time
 
 ---
 
-## 타임 트리거 삭제
+<a id="delete-time-triggers"></a>
+## 타임 트리거 삭제 { #delete-time-triggers }
 
 타임 트리거를 일괄 삭제합니다.
 
-### 요청
+<a id="delete-time-triggers-request"></a>
+### 요청 { #delete-time-triggers-request }
 
 ```
 DELETE /v1.0/triggers/{functionName}/time
 ```
 
-### 요청 파라미터
+<a id="delete-time-triggers-request-parameter"></a>
+### 요청 파라미터 { #delete-time-triggers-request-parameter }
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 | --- | --- | --- | --- | --- |
@@ -977,7 +1058,8 @@ DELETE /v1.0/triggers/{functionName}/time
 | X-NHN-authorization | Header | String | Y | 사용자 토큰(Bearer {token}) |
 | functionName | URL | String | Y | 함수 이름 |
 
-### 요청 본문
+<a id="delete-time-triggers-request-body"></a>
+### 요청 본문 { #delete-time-triggers-request-body }
 
 <details>
   <summary><strong>예시 코드</strong></summary>
@@ -994,7 +1076,8 @@ DELETE /v1.0/triggers/{functionName}/time
 | --- | --- | --- | --- |
 | names | Array | Y | 삭제할 트리거 이름 목록 |
 
-### 응답
+<a id="delete-time-triggers-response"></a>
+### 응답 { #delete-time-triggers-response }
 
 <details>
   <summary><strong>예시 코드</strong></summary>

--- a/ko/code-template-dotnet-guide.md
+++ b/ko/code-template-dotnet-guide.md
@@ -1,17 +1,23 @@
-## Compute > Cloud Functions > 코드 템플릿 가이드 > .NET
+<!-- pre-align:aligned sig=12935a7ff892 -->
+
+<a id="compute-cloud-functions-code-template-guide-net"></a>
+## Compute > Cloud Functions > 코드 템플릿 가이드 > .NET { #compute-cloud-functions-code-template-guide-net }
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 .NET을 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
 
-## 템플릿 정보
+<a id="template-information"></a>
+## 템플릿 정보 { #template-information }
 | 항목              | 값       |
 |-----------------|---------|
 | 지원 버전       | 8       |
 | 파일명         | func.cs |
 | Entry Point | func    |
 
-## 기본 템플릿
+<a id="basic-template"></a>
+## 기본 템플릿 { #basic-template }
 
-### Hello World 예시
+<a id="hello-world-example"></a>
+### Hello World 예시 { #hello-world-example }
 가장 기본적인 함수 형태입니다. `Nhn.DotNetCore.Api` 네임스페이스의 `NhnContext`를 사용하여 로거 및 요청 정보에 접근합니다.
 
 ```csharp
@@ -50,7 +56,8 @@ public class NhnFunction
 }
 ```
 
-### Context 객체
+<a id="context-object"></a>
+### Context 객체 { #context-object }
 `NhnContext` 객체로 로거, 요청(Request), 응답(Response) 객체에 접근할 수 있습니다.
 
 ```csharp
@@ -95,14 +102,17 @@ public class NhnFunction
 }
 ```
 
-## 템플릿 파일 다운로드 및 활용
+<a id="download-and-use-template-file"></a>
+## 템플릿 파일 다운로드 및 활용 { #download-and-use-template-file }
 
-### 템플릿 다운로드
+<a id="template-download"></a>
+### 템플릿 다운로드 { #template-download }
 Cloud Functions에서 제공하는 .NET 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 템플릿 다운로드 링크: [dotnet.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/dotnet/dotnet.zip)
 
-### 템플릿 파일 구조
+<a id="template-file-structure"></a>
+### 템플릿 파일 구조 { #template-file-structure }
 다운로드한 템플릿 파일의 구조는 다음과 같습니다.
 
 ```
@@ -112,8 +122,10 @@ dotnet.zip
 └── nuget.txt     # 의존성 관리 파일
 ```
 
-### 로컬 개발 과정
+<a id="local-development-process"></a>
+### 로컬 개발 과정 { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. 압축 해제
 ```bash
 # 압축 해제
@@ -123,6 +135,7 @@ unzip dotnet.zip -d my-function
 cd my-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. 함수 코드 수정
 `func.cs` 파일을 원하는 로직으로 수정합니다.
 
@@ -178,6 +191,7 @@ public class NhnFunction
 }
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. ZIP 파일로 압축
 수정된 소스 코드를 다시 ZIP 파일로 압축합니다. `func.cs`와 `nuget.txt`가 최상위에 포함되도록 압축해야 합니다.
 
@@ -185,13 +199,16 @@ public class NhnFunction
 zip my-function.zip func.cs nuget.txt
 ```
 
-### Cloud Functions 콘솔에서 업로드
+<a id="upload-from-cloud-functions-console"></a>
+### Cloud Functions 콘솔에서 업로드 { #upload-from-cloud-functions-console }
 - 함수 생성 또는 수정 시, **사용자 로컬 환경** 방식을 선택합니다.
 - **파일 선택**을 클릭하여 생성한 `my-function.zip` 파일을 업로드합니다.
 
-## HTTP 메서드별 처리
+<a id="process-by-http-method"></a>
+## HTTP 메서드별 처리 { #process-by-http-method }
 
-### GET 요청 처리
+<a id="process-get-request"></a>
+### GET 요청 처리 { #process-get-request }
 ```csharp
 using System;
 using Nhn.DotNetCore.Api;
@@ -220,7 +237,8 @@ public class NhnFunction
 }
 ```
 
-### POST 요청 처리
+<a id="process-post-request"></a>
+### POST 요청 처리 { #process-post-request }
 ```csharp
 using System;
 using System.IO;
@@ -272,7 +290,8 @@ public class NhnFunction
 }
 ```
 
-## 패키지 관리(`nuget.txt`)
+<a id="manage-package-nugettxt"></a>
+## 패키지 관리(`nuget.txt`) { #manage-package-nugettxt }
 
 의존성(NuGet 패키지)을 관리하려면 `nuget.txt` 파일을 사용합니다. 필요한 패키지를 한 줄에 하나씩 작성합니다.
 
@@ -281,7 +300,8 @@ public class NhnFunction
 Microsoft.Extensions.Configuration:8.0.0
 ```
 
-### 설정 관리 예시
+<a id="example-of-configuration-management"></a>
+### 설정 관리 예시 { #example-of-configuration-management }
 ```csharp
 using System;
 using System.Collections.Generic;
@@ -362,7 +382,8 @@ public class NhnFunction
 }
 ```
 
-## 환경 변수 사용
+<a id="use-environment-variables"></a>
+## 환경 변수 사용 { #use-environment-variables }
 함수에 등록한 환경 변수는 `Environment.GetEnvironmentVariable`로 접근할 수 있습니다. 환경 변수는 함수 생성 및 수정의 코드 작성 단계에서 등록합니다. 자세한 내용은 콘솔 사용 가이드를 참고하세요.
 
 ```csharp
@@ -412,7 +433,8 @@ public class NhnFunction
     - `DOTNET_STARTUP_HOOKS`, `DOTNET_ADDITIONAL_DEPS`, `ASPNETCORE_HOSTINGSTARTUPASSEMBLIES`
     - 접두사 `CORECLR_`, `COMPLUS_`, `DOTNET_`, `ASPNETCORE_`
 
-## Entry Point 설정
+<a id="configure-entry-point"></a>
+## Entry Point 설정 { #configure-entry-point }
 
 Entry Point는 파일명입니다(확장자 제외).
 
@@ -423,6 +445,7 @@ Entry Point는 파일명입니다(확장자 제외).
     클래스 이름은 `NhnFunction`이어야 하며, 함수 역할을 하는 메서드는 `public string Execute(NhnContext context)` 시그니처를 가져야 합니다.
     
 
-### 주의사항
+<a id="caution"></a>
+### 주의사항 { #caution }
 - 패키지 버전: `nuget.txt`에서 패키지 버전을 명시할 수 있습니다(예: `Newtonsoft.Json:9.0.1`).
 - 타입 충돌: 의존성 추가 시 타입 충돌이 발생할 수 있으므로, 가능하면 .NET 기본 라이브러리를 사용하거나 호환되는 버전의 패키지를 사용하는 것을 권장합니다.

--- a/ko/code-template-go-guide.md
+++ b/ko/code-template-go-guide.md
@@ -1,17 +1,23 @@
-## Compute > Cloud Functions > 코드 템플릿 가이드 > Go
+<!-- pre-align:aligned sig=03a04e4bdda0 -->
+
+<a id="compute-cloud-functions-code-template-guide-go"></a>
+## Compute > Cloud Functions > 코드 템플릿 가이드 > Go { #compute-cloud-functions-code-template-guide-go }
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 Go를 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
 
-## 템플릿 정보
+<a id="template-information"></a>
+## 템플릿 정보 { #template-information }
 | 항목              | 값                                        |
 |-----------------|------------------------------------------|
 | 지원 버전       | 1.22, 1.23, 1.24, 1.25 |
 | 파일명         | functions.go                             |
 | Entry Point | Handler                                  |
 
-## 기본 템플릿
+<a id="basic-template"></a>
+## 기본 템플릿 { #basic-template }
 
-### Hello World 예시
+<a id="hello-world-example"></a>
+### Hello World 예시 { #hello-world-example }
 가장 기본적인 함수 형태입니다.
 
 ```go
@@ -38,7 +44,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
-### Context 객체
+<a id="context-object"></a>
+### Context 객체 { #context-object }
 Go 함수에서는 `http.ResponseWriter`와 `*http.Request`로 HTTP 요청과 응답을 처리합니다.
 
 ```go
@@ -74,14 +81,17 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
-## 템플릿 파일 다운로드 및 활용
+<a id="download-and-use-template-file"></a>
+## 템플릿 파일 다운로드 및 활용 { #download-and-use-template-file }
 
-### 템플릿 다운로드
+<a id="template-download"></a>
+### 템플릿 다운로드 { #template-download }
 Cloud Functions에서 제공하는 Go 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 템플릿 다운로드 링크: [go.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/go/go.zip)
 
-### 템플릿 파일 구조
+<a id="template-file-structure"></a>
+### 템플릿 파일 구조 { #template-file-structure }
 다운로드한 템플릿 파일의 구조는 다음과 같습니다.
 
 ```
@@ -90,6 +100,7 @@ go.zip
 └── go.mod          # 의존성 관리 파일
 ```
 
+<a id="template-file-structure-functionsgo"></a>
 #### functions.go
 기본 fake 데이터 생성 함수가 포함되어 있습니다.
 ```go
@@ -116,6 +127,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+<a id="template-file-structure-gomod"></a>
 #### go.mod
 ```go
 module example.com/ncf
@@ -125,8 +137,10 @@ go 1.22
 require github.com/brianvoe/gofakeit/v6 v6.28.0
 ```
 
-### 로컬 개발 과정
+<a id="local-development-process"></a>
+### 로컬 개발 과정 { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. 압축 해제
 ```bash
 # 압축 해제
@@ -136,6 +150,7 @@ unzip go.zip -d my-function
 cd my-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. 함수 코드 수정
 `functions.go` 파일을 원하는 로직으로 수정합니다.
 
@@ -185,6 +200,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. ZIP 파일로 압축
 수정된 코드를 다시 ZIP 파일로 압축합니다.
 
@@ -202,11 +218,14 @@ zip my-function.zip functions.go go.mod
 zip -r my-function.zip . -x "*.git*" "go.sum" "test.go"
 ```
 
-### Cloud Functions 콘솔에서 업로드
+<a id="upload-from-cloud-functions-console"></a>
+### Cloud Functions 콘솔에서 업로드 { #upload-from-cloud-functions-console }
 함수를 생성하거나 수정할 때 사용자 로컬 환경의 파일을 업로드하는 경우에 사용합니다. 자세한 내용은 콘솔 사용 가이드를 참고하세요.
 
-### 업로드 시 주의사항
+<a id="cautions-for-upload"></a>
+### 업로드 시 주의사항 { #cautions-for-upload }
 
+<a id="cautions-for-upload-zip-file-structure"></a>
 #### ZIP 파일 구조
 - ZIP 파일의 루트에 직접 `.go` 파일과 `go.mod`가 위치해야 합니다.
 - 불필요한 폴더 구조는 피할 것을 권장합니다.
@@ -227,10 +246,12 @@ my-function.zip
     └── go.mod
 ```
 
+<a id="cautions-for-upload-file-size-limit"></a>
 #### 파일 크기 제한
 - ZIP 파일 크기는 100MiB 이하로 제한됩니다.
 - `go.sum` 파일은 포함하지 마세요.
 
+<a id="cautions-for-upload-files-to-exclude"></a>
 #### 제외할 파일들
 ```bash
 # .gitignore와 유사하게 다음 파일들은 제외
@@ -243,9 +264,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
-## HTTP 메서드별 처리
+<a id="process-by-http-method"></a>
+## HTTP 메서드별 처리 { #process-by-http-method }
 
-### GET 요청 처리
+<a id="process-get-request"></a>
+### GET 요청 처리 { #process-get-request }
 ```go
 package main
 
@@ -283,7 +306,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
-### POST 요청 처리
+<a id="process-post-request"></a>
+### POST 요청 처리 { #process-post-request }
 ```go
 package main
 
@@ -354,9 +378,11 @@ func getOrDefault(value, defaultValue string) string {
 }
 ```
 
-## 패키지 관리
+<a id="manage-packages"></a>
+## 패키지 관리 { #manage-packages }
 
-### go.mod 작성
+<a id="write-gomod"></a>
+### go.mod 작성 { #write-gomod }
 의존성 관리를 위해 `go.mod` 파일을 작성합니다.
 
 ```go
@@ -370,7 +396,8 @@ require (
 )
 ```
 
-### 외부 API 호출 예시
+<a id="example-of-external-api-call"></a>
+### 외부 API 호출 예시 { #example-of-external-api-call }
 ```go
 package main
 
@@ -423,7 +450,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
-### 데이터 처리 예시
+<a id="data-processing-example"></a>
+### 데이터 처리 예시 { #data-processing-example }
 ```go
 package main
 
@@ -516,7 +544,8 @@ func normalizeName(name string) string {
 }
 ```
 
-## 환경 변수 사용
+<a id="use-environment-variables"></a>
+## 환경 변수 사용 { #use-environment-variables }
 함수에 등록한 환경 변수는 `os.Getenv`로 접근할 수 있습니다. 환경 변수는 함수 생성 및 수정의 코드 작성 단계에서 등록합니다. 자세한 내용은 콘솔 사용 가이드를 참고하세요.
 
 ```go
@@ -565,15 +594,18 @@ func Handler(w http.ResponseWriter, r *http.Request) {
     - `GODEBUG`
     - Go는 일반 사용자 변수와 충돌하지 않도록 접두사 차단이 없습니다.
 
-## Entry Point 설정
+<a id="configure-entry-point"></a>
+## Entry Point 설정 { #configure-entry-point }
 
-### 단일 함수
+<a id="single-function"></a>
+### 단일 함수 { #single-function }
 함수명을 Entry Point로 사용합니다.
 
 함수명: `Handler`
 Entry Point: `Handler`
 
-### 다중 함수
+<a id="multiple-functions"></a>
+### 다중 함수 { #multiple-functions }
 하나의 파일에서 여러 함수를 정의할 수 있습니다.
 
 ```go
@@ -613,9 +645,11 @@ Entry Point 설정:
 - `CreateUser`
 - `UpdateUser`
 
-## 주의사항
+<a id="caution"></a>
+## 주의사항 { #caution }
 
-### Go 버전
+<a id="go-version"></a>
+### Go 버전 { #go-version }
 | 버전 | 지원 중단일 | 사용 중단일 |
 |-----|-----------|-----------|
 | 1.25 | - | - |
@@ -623,6 +657,7 @@ Entry Point 설정:
 | 1.23 | 2026-02-21 | 2026-08-21 |
 | 1.22 | 2026-01-28 | 2026-07-28 |
 
+<a id="go-version-support-policy"></a>
 #### Go 버전 지원 정책
 Cloud Functions는 Go의 공식 릴리스 정책을 따릅니다. Go는 연 2회(1월, 7월) 새로운 메이저 버전을 릴리스하며, 각 버전은 최신 2개 메이저 버전까지만 지원됩니다.
 

--- a/ko/code-template-java-guide.md
+++ b/ko/code-template-java-guide.md
@@ -1,17 +1,23 @@
-## Compute > Cloud Functions > 코드 템플릿 가이드 > Java
+<!-- pre-align:aligned sig=fe65e841fbc2 -->
+
+<a id="compute-cloud-functions-code-template-guide-java"></a>
+## Compute > Cloud Functions > 코드 템플릿 가이드 > Java { #compute-cloud-functions-code-template-guide-java }
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 Java를 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
 
-## 템플릿 정보
+<a id="template-information"></a>
+## 템플릿 정보 { #template-information }
 | 항목              | 값                  |
 |-----------------|--------------------|
 | 지원 버전       | 17, 21             |
 | 파일명         | HelloWorld.java    |
 | Entry Point | example.HelloWorld |
 
-## 기본 템플릿
+<a id="basic-template"></a>
+## 기본 템플릿 { #basic-template }
 
-### Hello World 예시
+<a id="hello-world-example"></a>
+### Hello World 예시 { #hello-world-example }
 가장 기본적인 함수 형태입니다.
 
 ```java
@@ -29,7 +35,8 @@ public class HelloWorld {
 }
 ```
 
-### Context 객체(RequestEntity)
+<a id="context-object-requestentity"></a>
+### Context 객체(RequestEntity) { #context-object-requestentity }
 Java 함수에서는 Spring의 `RequestEntity`로 HTTP 요청 정보에 접근할 수 있습니다.
 
 ```java
@@ -62,14 +69,17 @@ public class HelloWorld {
 }
 ```
 
-## 템플릿 파일 다운로드 및 활용
+<a id="download-and-use-template-file"></a>
+## 템플릿 파일 다운로드 및 활용 { #download-and-use-template-file }
 
-### 템플릿 다운로드
+<a id="template-download"></a>
+### 템플릿 다운로드 { #template-download }
 Cloud Functions에서 제공하는 Java 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 템플릿 다운로드 링크: [java.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/java/java.zip)
 
-### 템플릿 파일 구조
+<a id="template-file-structure"></a>
+### 템플릿 파일 구조 { #template-file-structure }
 다운로드한 템플릿은 Maven 프로젝트 구조를 따릅니다.
 
 ```
@@ -82,8 +92,10 @@ java.zip
                 └── HelloWorld.java
 ```
 
-### 로컬 개발 과정
+<a id="local-development-process"></a>
+### 로컬 개발 과정 { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. 압축 해제
 ```bash
 # 압축 해제
@@ -93,6 +105,7 @@ unzip java.zip -d my-java-function
 cd my-java-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. 함수 코드 수정
 `src/main/java/example/HelloWorld.java` 파일을 원하는 로직으로 수정합니다.
 
@@ -144,6 +157,7 @@ public class HelloWorld {
 }
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. ZIP 파일로 압축
 수정된 소스 코드를 다시 ZIP 파일로 압축합니다. `pom.xml` 파일과 `src` 디렉터리가 최상위에 포함되도록 압축해야 합니다.
 
@@ -161,19 +175,23 @@ zip -r my-function.zip pom.xml src
 zip -r my-function.zip . -x "*.git*" "target/*" "*.log"
 ```
 
-### Cloud Functions 콘솔에서 업로드
+<a id="upload-from-cloud-functions-console"></a>
+### Cloud Functions 콘솔에서 업로드 { #upload-from-cloud-functions-console }
 - 함수 생성 또는 수정 시, **사용자 로컬 환경** 방식을 선택합니다.
 - **파일 선택**을 클릭하여 생성한 `my-function.zip` 파일을 업로드합니다.
 
-### 업로드 시 주의사항
+<a id="cautions-for-upload"></a>
+### 업로드 시 주의사항 { #cautions-for-upload }
 - 업로드 파일: 소스 코드와 `pom.xml`이 포함된 ZIP 파일을 업로드해야 합니다.
 - ZIP 파일 구조: ZIP 파일의 루트에 `pom.xml`과 `src` 디렉터리가 위치해야 합니다.
 - 제외할 파일: `target` 디렉터리, `.git` 디렉터리 등 불필요한 파일은 포함하지 마세요.
 - 파일 크기: ZIP 파일 크기는 100MiB 이하로 제한됩니다.
 
-## HTTP 메서드별 처리
+<a id="process-by-http-method"></a>
+## HTTP 메서드별 처리 { #process-by-http-method }
 
-### GET 요청 처리
+<a id="process-get-request"></a>
+### GET 요청 처리 { #process-get-request }
 ```java
 package example;
 
@@ -209,7 +227,8 @@ public class GetHandler {
 }
 ```
 
-### POST 요청 처리
+<a id="process-post-request"></a>
+### POST 요청 처리 { #process-post-request }
 ```java
 package example;
 
@@ -250,7 +269,8 @@ public class PostHandler {
 }
 ```
 
-## 패키지 관리(`pom.xml`)
+<a id="manage-package-pomxml"></a>
+## 패키지 관리(`pom.xml`) { #manage-package-pomxml }
 
 의존성 관리를 위해 `pom.xml` 파일을 수정합니다. `dependencies` 섹션에 필요한 라이브러리를 추가하면, 함수 업로드 시 Cloud Functions가 자동으로 의존성을 다운로드하여 빌드에 포함합니다.
 
@@ -273,7 +293,8 @@ public class PostHandler {
 </dependencies>
 ```
 
-### 외부 라이브러리 활용 예시
+<a id="example-of-using-external-libraries"></a>
+### 외부 라이브러리 활용 예시 { #example-of-using-external-libraries }
 ```java
 package example;
 
@@ -307,7 +328,8 @@ public class StringUtilsHandler {
 }
 ```
 
-## 환경 변수 사용
+<a id="use-environment-variables"></a>
+## 환경 변수 사용 { #use-environment-variables }
 함수에 등록한 환경 변수는 `System.getProperty`로 접근할 수 있습니다. 환경 변수는 함수 생성 및 수정의 코드 작성 단계에서 등록합니다. 자세한 내용은 콘솔 사용 가이드를 참고하세요.
 
 !!! tip "참고"
@@ -358,9 +380,11 @@ public class HelloWorld {
 
     - `JAVA_TOOL_OPTIONS`, `_JAVA_OPTIONS`, `JDK_JAVA_OPTIONS`, `CLASSPATH`
 
-## Entry Point 설정
+<a id="entry-point-configuration"></a>
+## Entry Point 설정 { #entry-point-configuration }
 
-### 단일 클래스
+<a id="single-class"></a>
+### 단일 클래스 { #single-class }
 `패키지명.클래스명`을 Entry Point로 사용합니다.
 
 - 패키지명: `example`
@@ -370,6 +394,7 @@ public class HelloWorld {
 !!! danger "중요"
     함수 역할을 하는 메서드는 `public ResponseEntity<?> call(RequestEntity<?> req)` 시그니처를 가져야 합니다.
 
-### 주의사항
+<a id="caution"></a>
+### 주의사항 { #caution }
 - 프로젝트 구조: `src/main/java` 디렉터리 구조를 유지해야 합니다.
 - 메모리 및 실행 시간: 함수는 제한된 리소스 내에서 동작해야 하므로, 무거운 작업은 피하고 코드를 최적화하세요.

--- a/ko/code-template-node-guide.md
+++ b/ko/code-template-node-guide.md
@@ -1,16 +1,22 @@
-## Compute > Cloud Functions > 코드 템플릿 가이드 > Node.js
+<!-- pre-align:aligned sig=9f2d38073162 -->
+
+<a id="compute-cloud-functions-code-template-guide-nodejs"></a>
+## Compute > Cloud Functions > 코드 템플릿 가이드 > Node.js { #compute-cloud-functions-code-template-guide-nodejs }
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 Node.js를 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
 
-## 템플릿 정보
+<a id="template-information"></a>
+## 템플릿 정보 { #template-information }
 | 항목              | 값               |
 |-----------------|-----------------|
 | 지원 버전       | 20.16.0, 22.5.0 |
 | 파일명         | hello.js        |
 | Entry Point | hello           |
 
-## 기본 템플릿
-### Hello World 예시
+<a id="basic-template"></a>
+## 기본 템플릿 { #basic-template }
+<a id="hello-world-example"></a>
+### Hello World 예시 { #hello-world-example }
 가장 기본적인 함수 형태입니다.
 
 ```javascript
@@ -22,7 +28,8 @@ module.exports = async (context) => {
 }
 ```
 
-### Context 객체
+<a id="context-object"></a>
+### Context 객체 { #context-object }
 함수에 전달되는 `context` 객체는 다음과 같은 정보를 포함합니다.
 
 ```javascript
@@ -42,14 +49,17 @@ module.exports = async (context) => {
 }
 ```
 
-## 템플릿 파일 다운로드 및 활용
+<a id="download-and-use-template-file"></a>
+## 템플릿 파일 다운로드 및 활용 { #download-and-use-template-file }
 
-### 템플릿 다운로드
+<a id="template-download"></a>
+### 템플릿 다운로드 { #template-download }
 Cloud Functions에서 제공하는 Node.js 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 템플릿 다운로드 링크: [nodejs.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/nodejs/nodejs.zip)
 
-### 템플릿 파일 구조
+<a id="template-file-structure"></a>
+### 템플릿 파일 구조 { #template-file-structure }
 다운로드한 템플릿 파일의 구조는 다음과 같습니다.
 
 ```
@@ -58,6 +68,7 @@ nodejs.zip
 └── package.json      # 의존성 관리 파일
 ```
 
+<a id="template-file-structure-hellojs"></a>
 #### hello.js
 기본 Hello World 함수가 포함되어 있습니다.
 ```javascript
@@ -69,13 +80,16 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="template-file-structure-packagejson"></a>
 #### package.json
 ```json
 {}
 ```
 
-### 로컬 개발 과정
+<a id="local-development-process"></a>
+### 로컬 개발 과정 { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. 압축 해제
 ```bash
 # 압축 해제
@@ -85,6 +99,7 @@ unzip nodejs.zip -d my-function
 cd my-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. 함수 코드 수정
 `hello.js` 파일을 원하는 로직으로 수정합니다.
 
@@ -127,6 +142,7 @@ module.exports = async (context) => {
 }
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. ZIP 파일로 압축
 수정된 코드를 다시 ZIP 파일로 압축합니다.
 
@@ -144,11 +160,14 @@ zip my-function.zip hello.js package.json
 zip -r my-function.zip . -x "*.git*" "node_modules/*" "test.js"
 ```
 
-### Cloud Functions 콘솔에서 업로드
+<a id="upload-from-cloud-functions-console"></a>
+### Cloud Functions 콘솔에서 업로드 { #upload-from-cloud-functions-console }
 함수를 생성하거나 수정할 때 사용자 로컬 환경의 파일을 업로드하는 경우에 사용합니다. 자세한 내용은 콘솔 사용 가이드를 참고하세요.
 
-### 업로드 시 주의사항
+<a id="cautions-for-upload"></a>
+### 업로드 시 주의사항 { #cautions-for-upload }
 
+<a id="cautions-for-upload-zip-file-structure"></a>
 #### ZIP 파일 구조
 - ZIP 파일의 루트에 직접 `.js` 파일과 `package.json`이 위치해야 합니다.
 - 불필요한 폴더 구조는 피할 것을 권장합니다.
@@ -169,10 +188,12 @@ my-function.zip
     └── package.json
 ```
 
+<a id="cautions-for-upload-file-size-limit"></a>
 #### 파일 크기 제한
 - ZIP 파일 크기는 100MiB 이하로 제한됩니다.
 - `node_modules` 폴더는 포함하지 마세요. (의존성은 `package.json`으로 관리)
 
+<a id="cautions-for-upload-files-to-exclude"></a>
 #### 제외할 파일들
 ```bash
 # .gitignore와 유사하게 다음 파일들은 제외
@@ -185,9 +206,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
-## HTTP 메서드별 처리
+<a id="process-by-http-method"></a>
+## HTTP 메서드별 처리 { #process-by-http-method }
 
-### GET 요청 처리
+<a id="process-get-request"></a>
+### GET 요청 처리 { #process-get-request }
 ```javascript
 module.exports = async (context) => {
     if (context.request.method !== 'GET') {
@@ -213,7 +236,8 @@ module.exports = async (context) => {
 }
 ```
 
-### POST 요청 처리
+<a id="process-post-request"></a>
+### POST 요청 처리 { #process-post-request }
 ```javascript
 module.exports = async (context) => {
     if (context.request.method !== 'POST') {
@@ -258,9 +282,11 @@ module.exports = async (context) => {
 }
 ```
 
-## 패키지 관리
+<a id="manage-packages"></a>
+## 패키지 관리 { #manage-packages }
 
-### package.json 작성
+<a id="write-packagejson"></a>
+### package.json 작성 { #write-packagejson }
 의존성 관리를 위해 `package.json` 파일을 작성합니다.
 
 ```json
@@ -278,7 +304,8 @@ module.exports = async (context) => {
 }
 ```
 
-### 외부 API 호출 예시
+<a id="example-of-external-api-call"></a>
+### 외부 API 호출 예시 { #example-of-external-api-call }
 ```javascript
 const axios = require('axios');
 
@@ -328,7 +355,8 @@ module.exports = async (context) => {
 }
 ```
 
-### 데이터 처리 예시
+<a id="data-processing-example"></a>
+### 데이터 처리 예시 { #data-processing-example }
 ```javascript
 const _ = require('lodash');
 const moment = require('moment');
@@ -382,7 +410,8 @@ module.exports = async (context) => {
 }
 ```
 
-## 환경 변수 사용
+<a id="use-environment-variables"></a>
+## 환경 변수 사용 { #use-environment-variables }
 함수에 등록한 환경 변수는 `process.env`로 접근할 수 있습니다. 환경 변수는 함수 생성 및 수정의 코드 작성 단계에서 등록합니다. 자세한 내용은 콘솔 사용 가이드를 참고하세요.
 
 ```javascript
@@ -424,15 +453,18 @@ module.exports = async (context) => {
     - `NODE_PATH`, `NODE_OPTIONS`, `NODE_EXTRA_CA_CERTS`
     - 접두사 `NODE_`
 
-## Entry Point 설정
+<a id="configure-entry-point"></a>
+## Entry Point 설정 { #configure-entry-point }
 
-### 단일 함수
+<a id="single-function"></a>
+### 단일 함수 { #single-function }
 파일명을 Entry Point로 사용합니다.
 
 파일명: `hello.js`
 Entry Point: `hello`
 
-### 다중 함수
+<a id="multiple-functions"></a>
+### 다중 함수 { #multiple-functions }
 하나의 파일에서 여러 함수를 내보낼 수 있습니다.
 
 ```javascript
@@ -467,7 +499,8 @@ Entry Point 설정:
 - `users.createUser`
 - `users.updateUser`
 
-### Entry Point 제한 사항
+<a id="entry-point-restriction"></a>
+### Entry Point 제한 사항 { #entry-point-restriction }
 - 하위 디렉터리 지정 불가: 루트 디렉터리의 하위 디렉터리에 있는 파일은 Entry Point로 지정할 수 없습니다.
 
 올바른 Entry Point:
@@ -485,9 +518,11 @@ modules/auth.js → modules.auth ❌
 
 모든 함수 파일은 ZIP 파일의 루트 레벨에 위치해야 합니다.
 
-## 주의사항
+<a id="caution"></a>
+## 주의사항 { #caution }
 
-### CommonJS vs ES Modules
+<a id="commonjs-vs-es-modules"></a>
+### CommonJS vs ES Modules { #commonjs-vs-es-modules }
 현재 Cloud Functions는 CommonJS 방식만 지원합니다.
 
 사용 가능(CommonJS):
@@ -506,7 +541,8 @@ export default async (context) => {  // ❌ 지원하지 않음
 };
 ```
 
-### 메모리 및 실행 시간 고려사항
+<a id="considerations-for-memory-and-execution-time"></a>
+### 메모리 및 실행 시간 고려사항 { #considerations-for-memory-and-execution-time }
 - 함수는 제한된 메모리와 실행 시간 내에서 동작해야 합니다.
 - 대용량 데이터 처리 시 스트림 처리를 고려하세요.
 - 장시간 실행되는 작업은 적절히 분할하세요.

--- a/ko/code-template-python-guide.md
+++ b/ko/code-template-python-guide.md
@@ -1,17 +1,23 @@
-## Compute > Cloud Functions > 코드 템플릿 가이드 > Python
+<!-- pre-align:aligned sig=253528824169 -->
+
+<a id="compute-cloud-functions-code-template-guide-python"></a>
+## Compute > Cloud Functions > 코드 템플릿 가이드 > Python { #compute-cloud-functions-code-template-guide-python }
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 Python을 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
 
-## 템플릿 정보
+<a id="template-information"></a>
+## 템플릿 정보 { #template-information }
 | 항목              | 값                |
 |-----------------|------------------|
 | 지원 버전       | 3.11, 3.12, 3.13 |
 | 파일명         | user.py          |
 | Entry Point | user.main        |
 
-## 기본 템플릿
+<a id="basic-template"></a>
+## 기본 템플릿 { #basic-template }
 
-### Hello World 예시
+<a id="hello-world-example"></a>
+### Hello World 예시 { #hello-world-example }
 가장 기본적인 함수 형태입니다.
 
 ```python
@@ -29,7 +35,8 @@ def main():
     return yaml.dump(yaml.safe_load(document))
 ```
 
-### Context 객체
+<a id="context-object"></a>
+### Context 객체 { #context-object }
 Python 함수에서는 Flask의 request 객체로 HTTP 요청 정보에 접근할 수 있습니다.
 
 ```python
@@ -57,14 +64,17 @@ def main():
     }
 ```
 
-## 템플릿 파일 다운로드 및 활용
+<a id="download-and-use-template-file"></a>
+## 템플릿 파일 다운로드 및 활용 { #download-and-use-template-file }
 
-### 템플릿 다운로드
+<a id="template-download"></a>
+### 템플릿 다운로드 { #template-download }
 Cloud Functions에서 제공하는 Python 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 템플릿 다운로드 링크: [python.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/python/python.zip)
 
-### 템플릿 파일 구조
+<a id="template-file-structure"></a>
+### 템플릿 파일 구조 { #template-file-structure }
 다운로드한 템플릿 파일의 구조는 다음과 같습니다.
 
 ```
@@ -73,6 +83,7 @@ python.zip
 └── requirements.txt # 의존성 관리 파일
 ```
 
+<a id="template-file-structure-userpy"></a>
 #### user.py
 기본 YAML 처리 함수가 포함되어 있습니다.
 ```python
@@ -90,13 +101,16 @@ def main():
     return yaml.dump(yaml.safe_load(document))
 ```
 
+<a id="template-file-structure-requirementstxt"></a>
 #### requirements.txt
 ```txt
 pyyaml
 ```
 
-### 로컬 개발 과정
+<a id="local-development-process"></a>
+### 로컬 개발 과정 { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. 압축 해제
 ```bash
 # 압축 해제
@@ -106,6 +120,7 @@ unzip python.zip -d my-function
 cd my-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. 함수 코드 수정
 `user.py` 파일을 원하는 로직으로 수정합니다.
 
@@ -147,6 +162,7 @@ def main():
         }, ensure_ascii=False)
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. ZIP 파일로 압축
 수정된 코드를 다시 ZIP 파일로 압축합니다.
 
@@ -164,11 +180,14 @@ zip my-function.zip user.py requirements.txt
 zip -r my-function.zip . -x "*.git*" "__pycache__/*" "*.pyc" "test.py"
 ```
 
-### Cloud Functions 콘솔에서 업로드
+<a id="upload-from-cloud-functions-console"></a>
+### Cloud Functions 콘솔에서 업로드 { #upload-from-cloud-functions-console }
 함수를 생성하거나 수정할 때 사용자 로컬 환경의 파일을 업로드하는 경우에 사용합니다. 자세한 내용은 콘솔 사용 가이드를 참고하세요.
 
-### 업로드 시 주의사항
+<a id="cautions-for-upload"></a>
+### 업로드 시 주의사항 { #cautions-for-upload }
 
+<a id="cautions-for-upload-zip-file-structure"></a>
 #### ZIP 파일 구조
 - ZIP 파일의 루트에 직접 `.py` 파일과 `requirements.txt`가 위치해야 합니다.
 - 불필요한 폴더 구조는 피할 것을 권장합니다.
@@ -189,10 +208,12 @@ my-function.zip
     └── requirements.txt
 ```
 
+<a id="cautions-for-upload-file-size-limit"></a>
 #### 파일 크기 제한
 - ZIP 파일 크기는 100MiB 이하로 제한됩니다.
 - `__pycache__` 폴더는 포함하지 마세요.
 
+<a id="cautions-for-upload-files-to-exclude"></a>
 #### 제외할 파일들
 ```bash
 # .gitignore와 유사하게 다음 파일들은 제외
@@ -206,9 +227,11 @@ zip -r my-function.zip . -x \
   "*.zip"
 ```
 
-## HTTP 메서드별 처리
+<a id="process-by-http-method"></a>
+## HTTP 메서드별 처리 { #process-by-http-method }
 
-### GET 요청 처리
+<a id="process-get-request"></a>
+### GET 요청 처리 { #process-get-request }
 ```python
 from flask import request
 import json
@@ -231,7 +254,8 @@ def main():
     return json.dumps(result, ensure_ascii=False)
 ```
 
-### POST 요청 처리
+<a id="process-post-request"></a>
+### POST 요청 처리 { #process-post-request }
 ```python
 from flask import request
 import json
@@ -274,9 +298,11 @@ def main():
         }, ensure_ascii=False), 400
 ```
 
-## 패키지 관리
+<a id="manage-packages"></a>
+## 패키지 관리 { #manage-packages }
 
-### requirements.txt 작성
+<a id="write-requirementstxt"></a>
+### requirements.txt 작성 { #write-requirementstxt }
 의존성 관리를 위해 `requirements.txt` 파일을 작성합니다.
 
 ```txt
@@ -285,7 +311,8 @@ requests>=2.28.0
 python-dateutil>=2.8.0
 ```
 
-### 외부 API 호출 예시
+<a id="example-of-external-api-call"></a>
+### 외부 API 호출 예시 { #example-of-external-api-call }
 ```python
 from flask import request
 import json
@@ -327,7 +354,8 @@ def main():
         }, ensure_ascii=False), 500
 ```
 
-### 데이터 처리 예시
+<a id="data-processing-example"></a>
+### 데이터 처리 예시 { #data-processing-example }
 ```python
 from flask import request
 import json
@@ -381,7 +409,8 @@ def normalize_name(name):
     return name.strip().title()
 ```
 
-## 환경 변수 사용
+<a id="use-environment-variables"></a>
+## 환경 변수 사용 { #use-environment-variables }
 함수에 등록한 환경 변수는 `os.environ`(또는 `os.getenv`)으로 접근할 수 있습니다. 환경 변수는 함수 생성 및 수정의 코드 작성 단계에서 등록합니다. 자세한 내용은 콘솔 사용 가이드를 참고하세요.
 
 ```python
@@ -418,16 +447,19 @@ def main():
     - `PYTHONPATH`, `PYTHONSTARTUP`, `PYTHONHOME`, `PYTHONEXECUTABLE`
     - 접두사 `PYTHON`
 
-## Entry Point 설정
+<a id="configure-entry-point"></a>
+## Entry Point 설정 { #configure-entry-point }
 
-### 단일 함수
+<a id="single-function"></a>
+### 단일 함수 { #single-function }
 `파일명.함수명`을 Entry Point로 사용합니다.
 
 파일명: `user.py`
 함수명: `main`
 Entry Point: `user.main`
 
-### 다중 함수
+<a id="multiple-functions"></a>
+### 다중 함수 { #multiple-functions }
 하나의 파일에서 여러 함수를 정의할 수 있습니다.
 
 ```python
@@ -453,9 +485,11 @@ Entry Point 설정:
 - `handlers.create_user`
 - `handlers.update_user`
 
-## 주의사항
+<a id="caution"></a>
+## 주의사항 { #caution }
 
-### 지원하지 않는 패키지
+<a id="unsupported-packages"></a>
+### 지원하지 않는 패키지 { #unsupported-packages }
 현재 아래 특징이 있는 복잡한 패키지는 지원하지 않습니다.
 
 지원하지 않는 패키지 예시:
@@ -469,7 +503,8 @@ Entry Point 설정:
 - `python-dateutil` (날짜/시간 처리)
 - `pillow` (이미지 처리 - 기본 기능)
 
-### 메모리 및 실행 시간 고려사항
+<a id="considerations-for-memory-and-execution-time"></a>
+### 메모리 및 실행 시간 고려사항 { #considerations-for-memory-and-execution-time }
 - 함수는 제한된 메모리와 실행 시간 내에서 동작해야 합니다.
 - 대용량 데이터 처리 시 제너레이터나 스트림 처리를 고려하세요.
 - 장시간 실행되는 작업은 적절히 분할하세요.

--- a/ko/code-template-ruby-guide.md
+++ b/ko/code-template-ruby-guide.md
@@ -1,17 +1,23 @@
-## Compute > Cloud Functions > 코드 템플릿 가이드 > Ruby
+<!-- pre-align:aligned sig=015e63f62c78 -->
+
+<a id="compute-cloud-functions-code-template-guide-ruby"></a>
+## Compute > Cloud Functions > 코드 템플릿 가이드 > Ruby { #compute-cloud-functions-code-template-guide-ruby }
 
 이 문서는 NHN Cloud의 Cloud Functions 서비스에서 Ruby를 사용하여 함수를 개발하는 방법을 상세히 설명합니다.
 
-## 템플릿 정보
+<a id="template-information"></a>
+## 템플릿 정보 { #template-information }
 | 항목              | 값        |
 |-----------------|----------|
 | 지원 버전       | 3.4.5    |
 | 파일명         | parse.rb |
 | Entry Point | handler  |
 
-## 기본 템플릿
+<a id="basic-template"></a>
+## 기본 템플릿 { #basic-template }
 
-### Hello World 예시
+<a id="hello-world-example"></a>
+### Hello World 예시 { #hello-world-example }
 가장 기본적인 함수 형태입니다.
 
 ```ruby
@@ -30,7 +36,8 @@ def handler(context)
 end
 ```
 
-### Context 객체
+<a id="context-object"></a>
+### Context 객체 { #context-object }
 함수에 전달되는 `context` 객체로 로거와 요청 정보에 접근할 수 있습니다.
 
 ```ruby
@@ -64,14 +71,17 @@ def handler(context)
 end
 ```
 
-## 템플릿 파일 다운로드 및 활용
+<a id="download-and-use-template-file"></a>
+## 템플릿 파일 다운로드 및 활용 { #download-and-use-template-file }
 
-### 템플릿 다운로드
+<a id="template-download"></a>
+### 템플릿 다운로드 { #template-download }
 Cloud Functions에서 제공하는 Ruby 템플릿을 다운로드하여 로컬 환경에서 개발할 수 있습니다.
 
 템플릿 다운로드 링크: [ruby.zip](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/templates/ruby/ruby.zip)
 
-### 템플릿 파일 구조
+<a id="template-file-structure"></a>
+### 템플릿 파일 구조 { #template-file-structure }
 다운로드한 템플릿 파일의 구조는 다음과 같습니다.
 
 ```
@@ -80,8 +90,10 @@ ruby.zip
 └── Gemfile
 ```
 
-### 로컬 개발 과정
+<a id="local-development-process"></a>
+### 로컬 개발 과정 { #local-development-process }
 
+<a id="local-development-process-unzip"></a>
 #### 1. 압축 해제
 ```bash
 # 압축 해제
@@ -91,6 +103,7 @@ unzip ruby.zip -d my-function
 cd my-function
 ```
 
+<a id="local-development-process-modify-function-codes"></a>
 #### 2. 함수 코드 수정
 `parse.rb` 파일을 원하는 로직으로 수정합니다.
 
@@ -135,6 +148,7 @@ def handler(context)
 end
 ```
 
+<a id="local-development-process-compress-into-a-zip-file"></a>
 #### 3. ZIP 파일로 압축
 수정된 소스 코드를 다시 ZIP 파일로 압축합니다. `parse.rb`와 `Gemfile`이 최상위에 포함되도록 압축해야 합니다.
 
@@ -144,19 +158,23 @@ zip my-function.zip parse.rb Gemfile Gemfile.lock
 !!! tip "참고"
     `Gemfile.lock` 파일은 배포 단계에서 자동으로 생성되지만, 의존성의 정확한 버전을 미리 확인하거나 고정하고 싶은 경우 로컬에서 `bundle install`을 실행하여 직접 생성한 후 함께 압축할 수 있습니다. `Gemfile.lock` 파일이 포함된 경우 해당 파일에 명시된 버전을 사용하여 빌드됩니다.
 
-### Cloud Functions 콘솔에서 업로드
+<a id="upload-from-cloud-functions-console"></a>
+### Cloud Functions 콘솔에서 업로드 { #upload-from-cloud-functions-console }
 - 함수 생성 또는 수정 시, **사용자 로컬 환경** 방식을 선택합니다.
 - **파일 선택**을 클릭하여 생성한 `my-function.zip` 파일을 업로드합니다.
 
-### 업로드 시 주의사항
+<a id="cautions-for-upload"></a>
+### 업로드 시 주의사항 { #cautions-for-upload }
 - 업로드 파일: `*.rb`, `Gemfile`이 포함된 ZIP 파일을 업로드해야 합니다.
   - `Gemfile.lock` 파일은 선택 사항입니다. 포함된 경우 해당 파일에 명시된 버전으로 빌드되며, 없을 경우 배포 단계에서 자동으로 생성됩니다.
 - ZIP 파일 구조: ZIP 파일의 루트에 파일들이 위치해야 합니다.
 - 파일 크기: ZIP 파일 크기는 100MiB 이하로 제한됩니다.
 
-## HTTP 메서드별 처리
+<a id="process-post-request"></a>
+## HTTP 메서드별 처리 { #process-post-request }
 
-### GET 요청 처리
+<a id="process-get-request"></a>
+### GET 요청 처리 { #process-get-request }
 ```ruby
 # frozen_string_literal: true
 
@@ -180,7 +198,8 @@ def handler(context)
 end
 ```
 
-### POST 요청 처리
+<a id="process-post-request-2"></a>
+### POST 요청 처리 { #process-post-request-2 }
 ```ruby
 # frozen_string_literal: true
 
@@ -215,7 +234,8 @@ def handler(context)
 end
 ```
 
-## 패키지 관리(`Gemfile`)
+<a id="manage-package-gemfile"></a>
+## 패키지 관리(`Gemfile`) { #manage-package-gemfile }
 
 의존성(Gem) 관리를 위해 `Gemfile`을 사용합니다. 필요한 Gem을 추가하고 `bundle install`을 실행하여 `Gemfile.lock`을 생성합니다.
 
@@ -229,7 +249,8 @@ gem "nokogiri", "~> 1.18" # XML/HTML 파서
 gem "httparty", "~> 0.23" # HTTP 클라이언트
 ```
 
-### 외부 API 호출 예시
+<a id="example-of-external-api-call"></a>
+### 외부 API 호출 예시 { #example-of-external-api-call }
 ```ruby
 # frozen_string_literal: true
 
@@ -269,7 +290,8 @@ def handler(context)
 end
 ```
 
-## 환경 변수 사용
+<a id="use-environment-variables"></a>
+## 환경 변수 사용 { #use-environment-variables }
 함수에 등록한 환경 변수는 `ENV`로 접근할 수 있습니다. 환경 변수는 함수 생성 및 수정의 코드 작성 단계에서 등록합니다. 자세한 내용은 콘솔 사용 가이드를 참고하세요.
 
 ```ruby
@@ -310,7 +332,8 @@ end
     - `RUBYOPT`, `RUBYLIB`, `GEM_HOME`, `GEM_PATH`
     - 접두사 `RUBY`
 
-## Entry Point 설정
+<a id="configure-entry-point"></a>
+## Entry Point 설정 { #configure-entry-point }
 
 Entry Point는 함수명을 사용합니다.
 
@@ -318,6 +341,7 @@ Entry Point는 함수명을 사용합니다.
 - 함수명: `handler`
 - Entry Point: `handler`
 
-### 주의사항
+<a id="caution"></a>
+### 주의사항 { #caution }
 - Bundler 버전: `Gemfile.lock` 생성 시 Bundler 2.6.2 이상 버전 사용을 권장합니다.
 - ActiveSupport 등 일부 Gem 호환성: `ActiveSupport`와 같이 C 확장(C extension)에 의존하거나 내부 구조가 복잡한 일부 Gem은 현재 Cloud Functions 환경과 호환성 문제가 발생할 수 있습니다. `activesupport` Gem은 내부적으로 `zeitwerk` Gem에 의존하며, 이 Gem이 파일 시스템을 탐색하는 방식이 실행 환경과 충돌하여 정상적으로 동작하지 않을 수 있습니다. 따라서 가급적 표준 라이브러리나 외부 의존성이 적은 Gem을 사용하는 것을 권장합니다.

--- a/ko/console-guide.md
+++ b/ko/console-guide.md
@@ -1,15 +1,21 @@
-## Compute > Cloud Functions > 콘솔 사용 가이드
+<!-- pre-align:aligned sig=1dc54302160b -->
+
+<a id="compute-cloud-functions-console-user-guide"></a>
+## Compute > Cloud Functions > 콘솔 사용 가이드 { #compute-cloud-functions-console-user-guide }
 이 문서는 Cloud Functions 콘솔에서 함수를 생성하고 관리하는 방법을 설명합니다.
 
-## 함수 관리
+<a id="manage-functions"></a>
+## 함수 관리 { #manage-functions }
 함수를 생성, 수정, 삭제, 복사할 수 있습니다.
 
-### 함수 생성
+<a id="create-functions"></a>
+### 함수 생성 { #create-functions }
 함수 설정을 하고 코드를 작성하여 빌드한 뒤 **생성** 버튼을 클릭하면 마지막 빌드한 패키지로 함수가 생성됩니다.
 
 ![console-guide-07](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-07.png)
 ![console-guide-08](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-08.png)
 
+<a id="create-functions-function-settings"></a>
 #### 함수 설정
 <table class="it">
     <tr>
@@ -87,6 +93,7 @@
 <br>
 
 
+<a id="create-functions-code-writing"></a>
 #### 코드 작성
 
 ![console-guide-16](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn-origin/prod_cloud_functions/2026-07-14/console-guide-16.png)
@@ -159,6 +166,7 @@
 > "본 런타임은 2026년 4월 30일에 지원이 중단되었으며, 2026년 10월 31일에 사용 중단될 예정입니다. 사용 중단 이후에는 기존 함수의 수정이 불가하므로, 안정적인 운영을 위해 최신 런타임 사용을 권장합니다."<br>
 > 사용 중단된 런타임은 목록에서 제외되어 새 함수 생성 시 선택할 수 없습니다. 런타임 상태에 대한 자세한 내용은 개요의 '런타임 지원 상태'를 참고하세요.
 
+<a id="create-functions-environment-variable"></a>
 #### 환경 변수
 함수가 외부 서비스 연동에 필요한 인증 정보(API 키, DB 접속 정보 등)를 코드에 하드코딩하지 않고 환경 변수로 분리하여 관리할 수 있습니다.
 
@@ -194,15 +202,19 @@
 > - 언어/런타임: `PYTHONPATH`(Python), `NODE_OPTIONS`(Node.js), `JAVA_TOOL_OPTIONS`·`CLASSPATH`(Java)<br>
 > - 접두사 `LD_`, `DYLD_`, `KUBERNETES_`, `FISSION_`로 시작하는 키는 모두 차단됩니다.
 
-### 함수 수정
+<a id="modify-functions"></a>
+### 함수 수정 { #modify-functions }
 기존 함수의 함수 설정 및 코드를 수정하려면 **수정** 버튼을 클릭합니다.
+<a id="modify-functions-non-modifiable-item"></a>
 #### 수정 불가 항목
 - 이름, 런타임 환경
     - 해당 항목을 제외한 모든 항목을 수정할 수 있습니다.
+<a id="modify-functions-source-code"></a>
 #### 소스 코드
 - 코드 에디터를 사용하는 경우 기존 코드가 로드됩니다.
 - 사용자 로컬 환경의 ZIP 파일을 업로드하여 함수를 생성했을 경우, 코드 에디터로 변경하면 ZIP 파일을 보여주지 않고 기본 템플릿 코드를 로드합니다.
 
+<a id="modify-functions-modify-function-restrictions-for-discontinued-runtimes"></a>
 #### 사용 중단 런타임 함수 수정 제한
 - 사용 중단된 런타임을 사용하는 함수는 수정할 수 없습니다.
 - 함수 목록에서 사용 중단 런타임을 사용하는 함수를 단건 선택하면 **수정** 버튼이 비활성화되어 함수 수정 화면으로 진입할 수 없습니다.
@@ -210,30 +222,36 @@
     - "사용 중단된 런타임으로 함수를 수정할 수 없습니다. 최신 런타임으로 함수를 새로 생성해주세요."
 - 지원 중단(사용 중단 전) 런타임을 사용하는 함수는 수정할 수 있으며, 함수 생성과 동일하게 안내 콜아웃이 표시됩니다.
 
-### 함수 삭제
+<a id="delete-a-function"></a>
+### 함수 삭제 { #delete-a-function }
 ![console-guide-14](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-14.png)
 기존 함수를 선택하여 삭제합니다. 한 번에 여러 함수 삭제가 가능합니다.
 
-### 함수 복사
+<a id="copy-a-function"></a>
+### 함수 복사 { #copy-a-function }
 ![console-guide-13](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-13.png)
 기존 함수와 동일한 함수를 복사합니다. 이름은 중복이 불가능하여 복사 전에 이름을 새롭게 작성할 수 있습니다.
 - 트리거는 복사되지 않습니다. (HTTP 트리거는 기본 제공)
 - 버전은 현재 적용된 버전만 복사됩니다.
 - 원본 함수에 등록된 환경 변수는 그대로 복사됩니다.
 
-## 함수 정보
-### 함수 목록
+<a id="about-functions"></a>
+## 함수 정보 { #about-functions }
+<a id="list-of-functions"></a>
+### 함수 목록 { #list-of-functions }
 ![console-guide-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-01.png)
 - 사용자가 생성한 함수 목록을 확인할 수 있습니다.
 - 빌드 상태는 현재 버전의 빌드 상태를 표시합니다.
 - 런타임 정보 우측에 런타임의 지원 상태(지원 중단/사용 중단) 배지가 표시됩니다.
 
-### 함수 기본 정보
+<a id="basic-information-of-functions"></a>
+### 함수 기본 정보 { #basic-information-of-functions }
 ![console-guide-19](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn-origin/prod_cloud_functions/2026-07-14/console-guide-19.png)
 - 함수의 기본 정보를 확인할 수 있습니다.
 - 로그 관리 항목에서 **Log & Crash Search** 버튼을 클릭해 Log & Crash Search 서비스로 이동하여 로그를 확인할 수 있습니다.
 
-### 함수 환경 변수
+<a id="function-environment-variables"></a>
+### 함수 환경 변수 { #function-environment-variables }
 함수 상세 정보의 환경 변수 탭에서 해당 함수에 등록된 환경 변수 목록을 확인할 수 있습니다.
 
 ![console-guide-20](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn-origin/prod_cloud_functions/2026-07-14/console-guide-20.png)
@@ -258,17 +276,20 @@
 
 - 환경 변수의 등록/수정/삭제는 함수 생성 및 수정의 코드 작성 단계에서 할 수 있습니다. 자세한 내용은 함수 생성 > 환경 변수를 참고하세요.
 
-### 함수 버전 관리
+<a id="function-versioning"></a>
+### 함수 버전 관리 { #function-versioning }
 ![console-guide-15](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2026-01-27/console-guide-15.png)
 - 함수의 버전을 관리할 수 있습니다.
 - 생성된 모든 버전의 이력을 확인하고, 이전 버전으로 롤백할 수 있습니다.
 
+<a id="function-versioning-versioning-overview"></a>
 #### 버전 관리 개요
 함수 생성/수정 화면에서 **빌드** 버튼을 클릭해 코드를 빌드하면 패키지가 생성됩니다.
 - 함수 생성/수정 시 마지막 빌드한 패키지가 함수 버전으로 연동됩니다.
 - 각 버전은 독립적으로 관리되며, 테스트한 버전을 그대로 함수에 적용할 수 있습니다.
 - 함수 생성 시 최소 1회 이상 빌드를 진행해야 함수 생성이 가능합니다.
 
+<a id="function-versioning-version-information"></a>
 #### 버전 정보
 <table class="it">
     <tr>
@@ -298,6 +319,7 @@
     </tr>
 </table>
 
+<a id="function-versioning-deploy-versions"></a>
 #### 버전 배포
 - 버전 목록에서 배포할 버전을 선택하고 **버전 배포** 버튼을 클릭하면 해당 버전으로 함수가 업데이트됩니다.
 - 현재 적용된 버전은 선택할 수 없습니다.
@@ -307,6 +329,7 @@
 > [참고]
 > <br>버전 배포 시 확인 팝업이 표시되며, 성공 시 버전 목록이 자동으로 갱신됩니다.
 
+<a id="function-versioning-delete-versions"></a>
 #### 버전 삭제
 - 버전 목록에서 삭제할 버전을 선택하고 **버전 삭제** 버튼을 클릭하면 해당 버전이 삭제됩니다.
 - 현재 적용된 버전은 삭제할 수 없습니다.
@@ -316,13 +339,15 @@
 > [참고]
 > <br>버전 삭제 시 확인 팝업이 표시되며, 삭제된 버전은 복구할 수 없습니다.
 
+<a id="function-versioning-constraints"></a>
 #### 제약 사항
 - 함수 생성/수정 화면에서 빌드한 패키지는 함수 생성/수정을 취소하면 함수 버전으로 연동되지 않습니다.
 - 함수 삭제 시 해당 함수와 연동된 모든 버전도 함께 삭제됩니다.
 - 함수 복사 시 원본 함수의 현재 적용된 버전만 복사되며, 모든 버전 이력이 복사되지는 않습니다.
 - 함수 생성 시 여러 런타임으로 빌드할 수 있으나, 함수 수정 시에는 생성 당시 선택한 런타임으로만 빌드할 수 있습니다.
 
-### 함수 트리거 관리
+<a id="manage-function-triggers"></a>
+### 함수 트리거 관리 { #manage-function-triggers }
 - 함수를 실행할 수 있는 트리거를 관리할 수 있습니다.
 - HTTP 트리거는 함수 생성 시 기본으로 제공됩니다.
     - 활성화/비활성화로 사용 여부를 설정할 수 있습니다.
@@ -333,16 +358,19 @@
     - 예: `https://{userdomain}/{함수명}`
     - Method: GET, POST
 
+<a id="manage-function-triggers-createedit-triggers"></a>
 #### 트리거 생성/수정
 - Timer
     - Value: Cron 문자열로 주기를 입력합니다.
 - API Gateway
     - API Gateway 서비스를 이용하여 HTTP Endpoint를 추가할 수 있습니다.
 
+<a id="manage-function-triggers-delete-triggers"></a>
 #### 트리거 삭제
 - 여러 건의 트리거를 선택하여 삭제할 수 있습니다. 기본 트리거인 HTTP 트리거는 삭제할 수 없습니다.
 
-### 함수 모니터링
+<a id="monitor-functions"></a>
+### 함수 모니터링 { #monitor-functions }
 ![console-guide-06](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-07-29/console-guide-06.png)
 - 함수의 사용량을 확인할 수 있습니다.
 - 함수 호출 횟수, 호출 거부 수, 오류 발생 횟수, 성공률, 함수 실행 시간 지표를 제공합니다.

--- a/ko/overview.md
+++ b/ko/overview.md
@@ -1,7 +1,11 @@
-## Compute > Cloud Functions > 개요
+<!-- pre-align:aligned sig=1cb57d0b02b5 -->
+
+<a id="compute-cloud-functions-overview"></a>
+## Compute > Cloud Functions > 개요 { #compute-cloud-functions-overview }
 사용자는 함수 단위로 코드를 작성할 수 있으며, 특정 이벤트 발생 시 정의된 함수가 자동으로 실행되어 필요한 작업을 처리합니다. 서버 관리나 인프라 설정 없이 애플리케이션 로직에만 집중할 수 있습니다.
 
-### 특징
+<a id="features"></a>
+### 특징 { #features }
 - 비용 효율성
     - 사용한 만큼만 과금하여 비용을 절감합니다.
     - 필요할 때만 리소스를 할당하므로 관리 비용을 줄일 수 있습니다.
@@ -13,15 +17,18 @@
     - 다양한 언어 및 런타임을 지원합니다.
     - 이벤트 기반 아키텍처로 다양한 활용이 가능합니다.
 
-### 주요 기능
+<a id="main-features"></a>
+### 주요 기능 { #main-features }
 - 다양한 언어(환경)를 제공합니다.
 - 코드 에디터로 간단한 함수 단위 코드를 작성할 수 있습니다.
 - 함수를 수행할 수 있는 HTTPS Endpoint를 기본 제공합니다.
 - 함수를 일정 주기로 반복 수행할 수 있습니다.
 
-### 두 가지 모드 제공
+<a id="two-modes-available"></a>
+### 두 가지 모드 제공 { #two-modes-available }
 - Pool Manager
 - New Deployment
+<a id="two-modes-available-pool-manager"></a>
 #### Pool Manager
 - 함수가 수행될 때만 인스턴스가 생성되어 리소스를 사용합니다.
 - 일정 기간 함수가 수행되지 않으면 인스턴스는 사라지고 리소스 사용량은 0이 됩니다.
@@ -29,6 +36,7 @@
 
 ![overview-01](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_1_ko.png)
 
+<a id="two-modes-available-new-deployment"></a>
 #### New Deployment
 - 함수를 생성하면 바로 인스턴스가 생성되어 일정량의 리소스를 계속 사용합니다.
 - 빠른 응답을 위해 인스턴스 생성을 유지합니다.
@@ -36,7 +44,8 @@
 
 ![overview-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-08-26/NHN%20Cloud_Guide%20overview_CloudFunctions_2_ko.png)
 
-### 지원 언어
+<a id="supported-languages"></a>
+### 지원 언어 { #supported-languages }
 
 | 언어     | 버전                | 지원 중단일   | 사용 중단일   |
 |--------|-------------------|------------|------------|
@@ -57,6 +66,7 @@
 | .NET   | 8                 | 2026-11-10 | 2027-11-10 |
 |        | 7(사용 중단)         | 2024-05-14 | 2025-05-14 |
 
+<a id="supported-languages-runtime-support-status"></a>
 #### 런타임 지원 상태
 각 런타임은 EOL(end of life) 정책에 따라 다음 세 가지 상태로 구분됩니다.
 
@@ -71,7 +81,8 @@
 
 런타임의 상태는 함수 목록과 상세 정보, 함수 생성/수정 화면에서 확인할 수 있습니다. 자세한 동작은 콘솔 사용 가이드를 참고하세요.
 
-### Trigger
+<a id="trigger"></a>
+### Trigger { #trigger }
 - HTTP Trigger
     - 기본 제공(GET, POST 지원)
 - Timer Trigger

--- a/ko/release-notes.md
+++ b/ko/release-notes.md
@@ -1,7 +1,12 @@
-## Compute > Cloud Functions > 릴리스 노트
+<!-- pre-align:aligned sig=a0129d78150c -->
 
-### 2026. 07. 14.
+<a id="compute-cloud-functions-release-notes"></a>
+## Compute > Cloud Functions > 릴리스 노트 { #compute-cloud-functions-release-notes }
 
+<a id="july-14-2026"></a>
+### 2026. 07. 14. { #july-14-2026 }
+
+<a id="july-14-2026-added-features"></a>
 #### 기능 추가
 - 환경 변수 기능 추가
   - 함수에 환경 변수를 설정하여 코드와 설정을 분리할 수 있습니다.
@@ -10,24 +15,31 @@
   - 함수 목록과 상세 정보에 런타임의 지원 중단/사용 중단 상태를 표시합니다.
   - 함수 생성/수정 시 지원 중단 런타임을 안내하고, 사용 중단 런타임의 선택 및 수정을 제한합니다.
 
-### 2026. 04. 14.
+<a id="april-14-2026"></a>
+### 2026. 04. 14. { #april-14-2026 }
 
+<a id="april-14-2026-added-features"></a>
 #### 기능 추가
 - Public API v1.0 추가
   - API로 Cloud Functions를 이용할 수 있습니다.
 
-### 2026. 01. 27.
+<a id="january-27-2026"></a>
+### 2026. 01. 27. { #january-27-2026 }
 
+<a id="january-27-2026-added-features"></a>
 #### 기능 추가
 - 함수 버전 관리 기능 추가
   - 빌드한 패키지를 버전으로 관리하고 이전 버전으로 롤백할 수 있습니다.
 
-### 2025. 11. 25.
+<a id="november-25-2025"></a>
+### 2025. 11. 25. { #november-25-2025 }
 
+<a id="november-25-2025-added-features"></a>
 #### 기능 추가
 - API Gateway 트리거 추가
   - 동일 프로젝트의 API Gateway 서비스를 활용하여 API Gateway 트리거를 생성할 수 있습니다.
 
+<a id="november-25-2025-feature-updates"></a>
 #### 기능 개선
 - 런타임 환경 최신 버전 추가 및 일부 버전 사용 중단
   - Go 1.24, 1.25 추가
@@ -36,7 +48,9 @@
   - Ruby 2.6.1 사용 중단, Ruby 3.4.5 추가
   - .NET 7 사용 중단, .NET 8 추가
 
-### 2025. 07. 29.
+<a id="july-29-2025"></a>
+### 2025. 07. 29. { #july-29-2025 }
 
+<a id="july-29-2025-launch-cloud-functions-service"></a>
 #### Cloud Functions 서비스 출시
 - 사용자는 함수 단위로 코드를 작성할 수 있으며, 특정 이벤트 발생 시 정의된 함수가 자동으로 실행되어 필요한 작업을 처리합니다. 서버 관리나 인프라 설정 없이 애플리케이션 로직에만 집중할 수 있습니다.

--- a/ko/trigger-guide.md
+++ b/ko/trigger-guide.md
@@ -1,12 +1,17 @@
-## Compute > Cloud Functions > 트리거 가이드
+<!-- pre-align:aligned sig=1dfb7cf11d02 -->
+
+<a id="compute-cloud-functions-trigger-guide"></a>
+## Compute > Cloud Functions > 트리거 가이드 { #compute-cloud-functions-trigger-guide }
 
 이 문서는 Cloud Functions에서 제공하는 트리거 유형과 설정 방법을 설명합니다.
 
-## 트리거 개요
+<a id="trigger-overview"></a>
+## 트리거 개요 { #trigger-overview }
 
 트리거는 함수를 실행시키는 이벤트 소스입니다. Cloud Functions는 다양한 유형의 트리거를 제공하여 여러 방식으로 함수를 호출할 수 있습니다.
 
-### 지원 트리거 유형
+<a id="supported-triggers"></a>
+### 지원 트리거 유형 { #supported-triggers }
 
 | 트리거 유형      | 설명                     | 기본 제공 |
 |-------------|------------------------|-------|
@@ -14,30 +19,36 @@
 | Timer       | 지정된 시간 또는 주기에 따라 함수 실행 | X     |
 | API Gateway | API Gateway를 통해 함수 실행  | X     |
 
-## HTTP 트리거
+<a id="http-trigger"></a>
+## HTTP 트리거 { #http-trigger }
 
 HTTP 트리거는 함수 생성 시 기본으로 제공되며, HTTP 요청을 통해 함수를 실행할 수 있습니다.
 
-### 특징
+<a id="features"></a>
+### 특징 { #features }
 
 - 함수 생성 시 자동으로 생성됩니다.
 - 삭제할 수 없으며, 활성화/비활성화만 가능합니다.
 - GET, POST 메서드를 지원합니다.
 
-### HTTP 트리거 URL 형식
+<a id="url-format-of-http-trigger"></a>
+### HTTP 트리거 URL 형식 { #url-format-of-http-trigger }
 
 ```
 https://{userdomain}/{함수명}
 ```
 
-### 사용 예시
+<a id="examples"></a>
+### 사용 예시 { #examples }
 
+<a id="examples-request-get"></a>
 #### GET 요청
 
 ```bash
 curl -X GET "https://{userdomain}/{함수명}?param1=value1&param2=value2"
 ```
 
+<a id="examples-request-post"></a>
 #### POST 요청
 
 ```bash
@@ -46,7 +57,8 @@ curl -X POST "https://{userdomain}/{함수명}" \
   -d '{"key": "value"}'
 ```
 
-### HTTP 트리거 활성화/비활성화
+<a id="enabledisable-http-trigger"></a>
+### HTTP 트리거 활성화/비활성화 { #enabledisable-http-trigger }
 
 1. Cloud Functions 콘솔에서 함수를 선택합니다.
 2. **트리거** 탭으로 이동합니다.
@@ -55,11 +67,13 @@ curl -X POST "https://{userdomain}/{함수명}" \
 > **[참고]**
 > <br>비활성화된 HTTP 트리거로 요청을 보내면 함수가 실행되지 않습니다.
 
-## Timer 트리거
+<a id="timer-trigger"></a>
+## Timer 트리거 { #timer-trigger }
 
 Timer 트리거는 지정된 시간 또는 주기에 따라 자동으로 함수를 실행합니다. Cron 표현식을 사용하여 실행 주기를 설정할 수 있습니다.
 
-### Timer 트리거 생성
+<a id="create-timer-trigger"></a>
+### Timer 트리거 생성 { #create-timer-trigger }
 
 ![trigger-guide-05](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-01.png)
 
@@ -70,7 +84,8 @@ Timer 트리거는 지정된 시간 또는 주기에 따라 자동으로 함수�
 5. **Value**에 Cron 표현식을 입력합니다.
 6. **생성**을 클릭합니다.
 
-### Cron 표현식 형식
+<a id="cron-expression-format"></a>
+### Cron 표현식 형식 { #cron-expression-format }
 
 Cron 표현식은 다음과 같은 형식을 따릅니다.
 
@@ -85,6 +100,7 @@ Cron 표현식은 다음과 같은 형식을 따릅니다.
 └─────────── 초 (0-59)
 ```
 
+<a id="cron-expression-format-cron-expression-field"></a>
 #### Cron 표현식 필드
 
 | 필드              | 필수  | 허용 값            | 허용 특수 문자  |
@@ -96,6 +112,7 @@ Cron 표현식은 다음과 같은 형식을 따릅니다.
 | 월(Month)        | Yes | 1-12 또는 JAN-DEC | * / , -   |
 | 요일(Day of week) | Yes | 0-6 또는 SUN-SAT  | * / , - ? |
 
+<a id="cron-expression-format-special-characters-details"></a>
 #### 특수 문자 설명
 
 `*`
@@ -118,7 +135,8 @@ Cron 표현식은 다음과 같은 형식을 따릅니다.
 
 일(Day of month) 또는 요일(Day of week) 필드를 비워두기 위해 `*` 대신 사용할 수 있습니다.
 
-### Cron 표현식 예시
+<a id="example-of-cron-expression"></a>
+### Cron 표현식 예시 { #example-of-cron-expression }
 
 | Cron 표현식               | 설명                              |
 |------------------------|---------------------------------|
@@ -132,7 +150,8 @@ Cron 표현식은 다음과 같은 형식을 따릅니다.
 | `30 0 12 * * *`        | 매일 오후 12시 0분 30초에 실행            |
 | `0 0 0 1 JAN *`        | 매년 1월 1일 자정에 실행                 |
 
-### Timer 트리거 수정
+<a id="modify-timer-trigger"></a>
+### Timer 트리거 수정 { #modify-timer-trigger }
 
 ![trigger-guide-02](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-02.png)
 
@@ -146,16 +165,19 @@ Cron 표현식은 다음과 같은 형식을 따릅니다.
 > **[참고]**
 > <br>월(Month)과 요일(Day of week) 필드 값은 대소문자를 구분하지 않습니다. "SUN", "Sun", "sun"은 모두 동일하게 인식됩니다.
 
-## API Gateway 트리거
+<a id="api-gateway-trigger"></a>
+## API Gateway 트리거 { #api-gateway-trigger }
 
 API Gateway 트리거는 동일 프로젝트의 API Gateway 서비스를 활용하여 함수를 실행할 수 있습니다. API Gateway를 통해 더욱 세밀한 API 관리와 제어가 가능합니다.
 
-### 사전 요구사항
+<a id="prerequisites"></a>
+### 사전 요구사항 { #prerequisites }
 
 - 동일 프로젝트에 API Gateway 서비스가 활성화되어 있어야 합니다.
   - 활성화되어 있지 않는 경우 트리거 생성 시 활성화 가능합니다.
 
-### API Gateway 트리거 생성
+<a id="create-api-gateway-trigger"></a>
+### API Gateway 트리거 생성 { #create-api-gateway-trigger }
 
 ![trigger-guide-04](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-04.png)
 
@@ -167,20 +189,24 @@ API Gateway 트리거는 동일 프로젝트의 API Gateway 서비스를 활용�
    * 중복된 경로는 사용 불가능합니다.
 6. **생성**을 클릭합니다.
 
-### API Gateway 트리거 URL 형식
+<a id="api-gateway-trigger-url-format"></a>
+### API Gateway 트리거 URL 형식 { #api-gateway-trigger-url-format }
 
 ```
 https://{stageurl}/{경로}
 ```
 
-### 사용 예시
+<a id="api-gateway-trigger-examples"></a>
+### 사용 예시 { #api-gateway-trigger-examples }
 
+<a id="api-gateway-trigger-examples-request-get"></a>
 #### GET 요청
 
 ```bash
 curl -X GET "https://{stageurl}/{경로}?param1=value1&param2=value2"
 ```
 
+<a id="api-gateway-trigger-examples-request-post"></a>
 #### POST 요청
 
 ```bash
@@ -189,7 +215,8 @@ curl -X POST "https://{stageurl}/{경로}" \
   -d '{"key": "value"}'
 ```
 
-### API Gateway 트리거 특징
+<a id="features-of-api-gateway-trigger"></a>
+### API Gateway 트리거 특징 { #features-of-api-gateway-trigger }
 
 - API Gateway의 다양한 기능을 활용할 수 있습니다.
   - 인증 및 권한 관리
@@ -200,7 +227,8 @@ curl -X POST "https://{stageurl}/{경로}" \
 - 자동으로 생성된 하나의 서비스에서만 함수 연동이 가능합니다.
 - HTTP 트리거와 동일하게 GET, POST 메서드를 지원합니다.
 
-### API Gateway 트리거 수정
+<a id="modify-api-gateway-trigger"></a>
+### API Gateway 트리거 수정 { #modify-api-gateway-trigger }
 
 ![trigger-guide-05](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-05.png)
 
@@ -216,15 +244,18 @@ curl -X POST "https://{stageurl}/{경로}" \
 > <br>이로 인해 해당 리소스에 적용된 플러그인이 전부 제거됩니다.
 > <br>플러그인이 적용된 리소스 경로를 변경하려면 수정 대신 새로운 트리거를 추가하는 것을 권장합니다.
 
-### API Gateway와 함께 사용하기
+<a id="use-with-api-gateway"></a>
+### API Gateway와 함께 사용하기 { #use-with-api-gateway }
 
 API Gateway 트리거를 생성하면 API Gateway 콘솔에서 추가 설정을 할 수 있습니다.
 
 자세한 내용은 [API Gateway 가이드](https://docs.nhncloud.com/ko/Application%20Service/API%20Gateway/ko/overview/)를 참고하세요.
 
-## 트리거 삭제
+<a id="delete-trigger"></a>
+## 트리거 삭제 { #delete-trigger }
 
-### 트리거 삭제 방법
+<a id="how-to-delete-trigger"></a>
+### 트리거 삭제 방법 { #how-to-delete-trigger }
 
 ![trigger-guide-03](https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_2acdfabf4efe4efc8a04c00b348110c9/cdn_origin/prod_cloud_functions/2025-11-25/trigger-guide-03.png)
 
@@ -234,15 +265,18 @@ API Gateway 트리거를 생성하면 API Gateway 콘솔에서 추가 설정을 
 4. **트리거 삭제**를 클릭합니다.
 5. **트리거 삭제** 모달 창에서 **삭제**를 클릭합니다.
 
-### 주의사항
+<a id="cautions"></a>
+### 주의사항 { #cautions }
 
 - HTTP 트리거는 삭제할 수 없습니다. HTTP 트리거는 기본 트리거로 제공되며, 활성화/비활성화만 가능합니다.
 - 트리거를 삭제하면 해당 이벤트를 통해 함수를 실행할 수 없습니다.
 - 삭제된 트리거는 복구할 수 없습니다.
 
-## 트리거 제한사항
+<a id="restrictions"></a>
+## 트리거 제한사항 { #restrictions }
 
-### API Gateway 트리거 제한사항
+<a id="restrictions-for-api-gateway-trigger"></a>
+### API Gateway 트리거 제한사항 { #restrictions-for-api-gateway-trigger }
 
 - 동일 프로젝트 내의 API Gateway만 연결할 수 있습니다.
 - 하나의 API Gateway Resource는 하나의 함수만 연결할 수 있습니다.


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `claude-code (CLI)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `beta` |
| Scope | 11 doc(s) scanned · 33 file(s) changed |
| Self-verify | ✅ all aligned |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/main/63/ |
| Generated | 2026-07-08T23:23:39 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`beta`): [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FCloud-Functions%2Ftree%2Fbeta&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FCloud-Functions%2Fpull%2F60&source=ko&langs=en%2Cja)

## Link check

이 PR 의 링크 상태: [Link Check ↗](http://content-agent.cloud.toastoven.net:7700/link-check?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FCloud-Functions%2Fpull%2F60&ref=beta&langs=en%2Cja)

<!-- LINK_CHECK_SUMMARY -->

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ko/api-guide-v1-0.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/api-guide-v1-0.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/api-guide-v1-0.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-dotnet-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-dotnet-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-dotnet-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-go-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-go-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-go-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-java-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-java-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-java-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-node-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-node-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-node-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-python-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-python-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-python-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/code-template-ruby-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/code-template-ruby-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/code-template-ruby-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/trigger-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/trigger-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/trigger-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Cloud-Functions`